### PR TITLE
Bash alias path error in install tools how to

### DIFF
--- a/docs/INSTALL_TOOLS.md
+++ b/docs/INSTALL_TOOLS.md
@@ -67,7 +67,7 @@ Install virtualenv and create your first virtual environment:
     $ virtualenv -p /usr/bin/python3 jahia2wp
 
     $ echo "
-    alias vjahia2wp='source ~/virtualenvs/jahia2wp/bin/activate && cd ~/git-repos/jahia2wp && export PYTHONPATH=$PWD/src'
+    alias vjahia2wp='source ~/virtualenvs/jahia2wp/bin/activate && cd ~/jahia2wp && export PYTHONPATH=$PWD/src'
     " >> ~/.bash_aliases
 
     $ source ~/.bash_aliases


### PR DESCRIPTION
If the jahia2wp repo is cloned into ~/jahia2wp as instructed in the main README, the alias should point to it. 
Additionally, it should have been done before this how to...