### PR TITLE
Run codecov correctly in Travis + Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ install:
 - docker exec mgmt make -C /srv/$WP_ENV/jahia2wp bootstrap-mgmt
 
 script:
-- docker exec -e CODECOV_TOKEN=$CODECOV_TOKEN mgmt make -C /srv/$WP_ENV/jahia2wp test-travis
+- ci_env=`bash <(curl -s https://codecov.io/env)`
+- docker exec $ci_env mgmt make -C /srv/$WP_ENV/jahia2wp test-travis

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-travis: check-env
 	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
 	  && flake8 --max-line-length=120 src \
 	  && pytest --cov=./ src \
-	  && codecov -t ${CODECOV_TOKEN}
+	  && codecov
 
 vars: check-env
 	@echo 'Environment-related vars:'


### PR DESCRIPTION
Before: https://travis-ci.org/epfl-idevelop/jahia2wp/builds/284991266?utm_source=github_status&utm_medium=notification (I suspect Travis is currently failing, with or without the PR it is being run on)
After: let's find out in a few minutes down-thread ☺ (or look at the history of [my previous PR](https://github.com/epfl-idevelop/jahia2wp/pull/38)) 

* No more CODECOV_TOKEN since the repo is not private (any longer?)
* Apply instructions from
  https://github.com/codecov/support/wiki/Testing-with-Docker#codecov-inside-docker,
  except the final part to upload the coverage results as this is now
  automatic apparently