### PR TITLE
Organize the Makefile rules to make them more fool-proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,22 +14,8 @@ include .env
 endif
 
 test: check-env
+# The "test-raw" target is in Makefile.mgmt
 	docker exec mgmt make -C /srv/$$WP_ENV/jahia2wp test-raw
-
-test-raw: check-env
-	. /srv/${WP_ENV}/venv/bin/activate \
-	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
-	  && flake8 --max-line-length=120 src \
-	  && pytest --cov=./ src \
-	  && coverage html
-
-test-travis: check-env
-	. /srv/${WP_ENV}/venv/bin/activate \
-	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
-	  && flake8 --max-line-length=120 src \
-	  && pytest --cov=./ src \
-	  && codecov
-	bash -c 'bash <(curl -s https://codecov.io/bash)'
 
 vars: check-env
 	@echo 'Environment-related vars:'
@@ -86,10 +72,3 @@ endif
 	@echo "Done with your local env. You can now" 
 	@if test -z "${WP_ENV}"; then echo "    $ source ~/.bashrc (to update your environment with WP_ENV value)"; fi
 	@echo "    $ make exec        (to connect into your contanier)"
-
-bootstrap-mgmt: check-env
-	cd .. \
-	  && virtualenv -p `which python3` venv
-	. /srv/${WP_ENV}/venv/bin/activate \
-	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
-	  && pip install -r requirements/local.txt

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ down: check-env
 	 docker-compose down
 
 bootstrap-local:
-	cp .env.sample .env
-	cp etc/.bash_history.sample etc/.bash_history
+	[ -f .env ] || cp .env.sample .env
+	[ -f etc/.bash_history ] || cp etc/.bash_history.sample etc/.bash_history
 	sudo chown -R `whoami`:33 .
 	sudo chmod -R g+w .
 ifdef WP_ENV

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test-travis: check-env
 	  && flake8 --max-line-length=120 src \
 	  && pytest --cov=./ src \
 	  && codecov
+	bash -c 'bash <(curl -s https://codecov.io/bash)'
 
 vars: check-env
 	@echo 'Environment-related vars:'

--- a/Makefile.mgmt
+++ b/Makefile.mgmt
@@ -1,0 +1,28 @@
+# These targets are to be run from inside the "mgmt" Docker container
+.PHONY: test-raw test-travis bootstrap-mgmt
+ifndef WP_ENV
+	$(error WP_ENV is undefined)
+endif
+
+test-raw: /srv/${WP_ENV}/venv
+	. /srv/${WP_ENV}/venv/bin/activate \
+	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
+	  && flake8 --max-line-length=120 src \
+	  && pytest --cov=./ src \
+	  && coverage html
+
+test-travis: /srv/${WP_ENV}/venv
+	. /srv/${WP_ENV}/venv/bin/activate \
+	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
+	  && flake8 --max-line-length=120 src \
+	  && pytest --cov=./ src \
+	  && codecov
+	bash -c 'bash <(curl -s https://codecov.io/bash)'
+
+bootstrap-mgmt: /srv/${WP_ENV}/venv
+
+/srv/${WP_ENV}/venv:
+	cd /srv/${WP_ENV} && virtualenv -p `which python3` venv
+	. /srv/${WP_ENV}/venv/bin/activate \
+	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
+	  && pip install -r requirements/local.txt

--- a/Makefile.mgmt
+++ b/Makefile.mgmt
@@ -1,5 +1,5 @@
 # These targets are to be run from inside the "mgmt" Docker container
-.PHONY: test-raw test-travis bootstrap-mgmt
+.PHONY: test-raw test-travis bootstrap-mgmt pip-install
 ifndef WP_ENV
 	$(error WP_ENV is undefined)
 endif
@@ -19,10 +19,12 @@ test-travis: /srv/${WP_ENV}/venv
 	  && codecov
 	bash -c 'bash <(curl -s https://codecov.io/bash)'
 
-bootstrap-mgmt: /srv/${WP_ENV}/venv
-
 /srv/${WP_ENV}/venv:
 	cd /srv/${WP_ENV} && virtualenv -p `which python3` venv
+	$(MAKE) pip-install
+
+bootstrap-mgmt pip-install: /srv/${WP_ENV}/venv
 	. /srv/${WP_ENV}/venv/bin/activate \
 	  && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src \
 	  && pip install -r requirements/local.txt
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - ./data:/srv/${WP_ENV}/jahia2wp/data
       - ./requirements:/srv/${WP_ENV}/jahia2wp/requirements
       - ./src:/srv/${WP_ENV}/jahia2wp/src
-      - ./Makefile:/srv/${WP_ENV}/jahia2wp/Makefile
+      - ./Makefile.mgmt:/srv/${WP_ENV}/jahia2wp/Makefile
       - .env:/srv/${WP_ENV}/jahia2wp/.env
     ports:
       - "2222:22"

--- a/etc/.aliases
+++ b/etc/.aliases
@@ -8,7 +8,7 @@ alias .....="cd ../../../.."
 alias python=python3
 alias pip=pip3
 alias virtualenv="virtualenv --python=`which python3`"
-alias vjahia2wp="source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
+alias vjahia2wp="make -C /srv/${WP_ENV}/jahia2wp bootstrap-mgmt && source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
 
 # Shortcuts
 alias h="history"

--- a/etc/.aliases
+++ b/etc/.aliases
@@ -8,7 +8,7 @@ alias .....="cd ../../../.."
 alias python=python3
 alias pip=pip3
 alias virtualenv="virtualenv --python=`which python3`"
-alias vjahia2wp="make -C /srv/${WP_ENV}/jahia2wp /srv/${WP_ENV}/venv && source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
+alias vjahia2wp="([ -d /srv/${WP_ENV}/venv ] || make -C /srv/${WP_ENV}/jahia2wp bootstrap-mgmt) && source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
 
 # Shortcuts
 alias h="history"

--- a/etc/.aliases
+++ b/etc/.aliases
@@ -8,7 +8,7 @@ alias .....="cd ../../../.."
 alias python=python3
 alias pip=pip3
 alias virtualenv="virtualenv --python=`which python3`"
-alias vjahia2wp="make -C /srv/${WP_ENV}/jahia2wp bootstrap-mgmt && source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
+alias vjahia2wp="make -C /srv/${WP_ENV}/jahia2wp /srv/${WP_ENV}/venv && source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp/src"
 
 # Shortcuts
 alias h="history"


### PR DESCRIPTION
* Make as many targets as possible idempotent (= won't hurt if run twice)
* Split out Makefile.mgmt for targets that only make sense from inside Docker; have that file show up as "the" Makefile from the container (by way of a Docker volume)
* Make the "make bootstrap-mgmt" step implicit for the interactive use case (vjahia2wp)
