### PR TITLE
No need to rely on fixed container names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
 
 install:
 - make up
-- docker exec mgmt make -C /srv/$WP_ENV/jahia2wp bootstrap-mgmt
+- docker exec $(docker ps -q --filter "label=com.docker.compose.service=mgmt") make -C /srv/$WP_ENV/jahia2wp bootstrap-mgmt
 
 script:
 - ci_env=`bash <(curl -s https://codecov.io/env)`
-- docker exec $ci_env mgmt make -C /srv/$WP_ENV/jahia2wp test-travis
+- docker exec $ci_env  $(docker ps -q --filter "label=com.docker.compose.service=mgmt") make -C /srv/$WP_ENV/jahia2wp test-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ before_install:
 
 install:
 - make up
+# On searching containers by labels, see
+# https://docs.docker.com/engine/reference/commandline/ps/#filtering
+# The labels introduced by docker-compose don't seem to be documented
+# anywhere, but you can list them with "docker inspect". The closest
+# we have to something official would be this pull request's comment:
+# https://github.com/docker/compose/pull/1356#issuecomment-99801372
 - docker exec $(docker ps -q --filter "label=com.docker.compose.service=mgmt") make -C /srv/$WP_ENV/jahia2wp bootstrap-mgmt
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ else
 include .env
 endif
 
+_mgmt_container = $(shell docker ps -q --filter "label=ch.epfl.jahia2wp.mgmt.env=${WP_ENV}")
+
 test: check-env
 # The "test-raw" target is in Makefile.mgmt
-	docker exec mgmt make -C /srv/$$WP_ENV/jahia2wp test-raw
+	docker exec $(_mgmt_container) make -C /srv/$$WP_ENV/jahia2wp test-raw
 
 vars: check-env
 	@echo 'Environment-related vars:'
@@ -48,7 +50,7 @@ exec: check-env
 	  -e WP_ENV=${WP_ENV} \
 	  -e MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} \
 	  -e MYSQL_DB_HOST=${MYSQL_DB_HOST} \
-	  mgmt bash -l
+	  $(_mgmt_container) bash -l
 
 down: check-env
 	@WP_PORT_HTTP=${WP_PORT_HTTP} \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
 
   db:
-    container_name: db
     image: mysql:5.7
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
@@ -12,7 +11,6 @@ services:
 
   phpmyadmin:
       image: phpmyadmin/phpmyadmin
-      container_name: phpmyadmin
       environment:
       - PMA_ARBITRARY=1
       ports:
@@ -21,7 +19,6 @@ services:
       - /sessions
       
   httpd:
-    container_name: httpd
     image: camptocamp/os-wp-httpd
     volumes:
       - ./volumes/srv:/srv
@@ -34,7 +31,8 @@ services:
       - "${WP_PORT_HTTPS}:443"
 
   mgmt:
-    container_name: mgmt
+    labels:
+      ch.epfl.jahia2wp.mgmt.env: ${WP_ENV}
     image: camptocamp/os-wp-mgmt
     env_file:
       - .env


### PR DESCRIPTION
Fixes #32

* Find containers by com.docker.compose.service label in Travis
* Find the "mgmt" container by an ad-hoc label for "make exec"
* Inter-Docker references by host name (e.g. "db") keep working,
  thanks to Docker's magic