### PR TITLE
Fix generate command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -136,6 +136,8 @@ Note that python is not in the requirements. You do not necessarily need it on y
 As some commands require `sudo`, you will be asked for your system password. The process will add a line line in your `.bashrc` (again: head to [INSTALL_TOOLS.md](./INSTALL_TOOLS.md) to get more details):
 
     you@host:~$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    # or, would you rather use https instead of SSH
+    # you@host:~$ git clone https://github.com/epfl-idevelop/jahia2wp.git 
     you@host:~$ cd jahia2wp
     you@host:jahia2wp$ make bootstrap-local ( add ENV=your-env if you use a C2C environment name here if you have one)
     ...

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -7,6 +7,8 @@ Usage:
   jahia2wp.py clean                 <wp_env> <wp_url> [--debug | --quiet]
   jahia2wp.py check                 <wp_env> <wp_url> [--debug | --quiet]
   jahia2wp.py generate              <wp_env> <wp_url> [--debug | --quiet]
+    [--wp-title=<WP_TITLE> --admin-password=<ADMIN_PASSWORD>]
+    [--owner=<OWNER_ID> --responsible=<RESPONSIBLE_ID>]
   jahia2wp.py version               <wp_env> <wp_url> [--debug | --quiet]
   jahia2wp.py admins                <wp_env> <wp_url> [--debug | --quiet]
   jahia2wp.py check-one             <wp_env> <wp_url> [--debug | --quiet] [DEPRECATED]


### PR DESCRIPTION
**From issue**: email

**High level changes:**

1. command `generate` accepts same parameters as `generate-one`
1. documentation mention git clone over HTTPS additionnaly to SSH

**Targetted version**: x.x.x