### PR TITLE
Move set 'permalink' option to generator instead of plugin (polylang)

### DIFF
--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir /var/run/sshd && \
 
 COPY ./bash_profile /var/www/.bash_profile
 COPY ./docker-entrypoint.sh /
+COPY ./config.yml /var/www/.wp-cli/config.yml
 
 RUN sed -ir 's#www-data.*:/usr/sbin/nologin#www-data:x:33:33:www-data:/var/www:/bin/bash#' /etc/passwd
 RUN mkdir -p /var/www/.ssh

--- a/build/mgmt/config.yml
+++ b/build/mgmt/config.yml
@@ -1,0 +1,2 @@
+apache_modules:
+  - mod_rewrite

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -270,6 +270,12 @@ class WPGenerator:
             logging.error("%s - could not setup WP site", repr(self))
             return False
 
+        # Configure permalinks
+        command = "rewrite structure '/%postname%/' --hard"
+        if not self.run_wp_cli(command):
+            logging.error("%s - could not configure permalinks", repr(self))
+            return False
+
         # flag success by returning True
         return True
 

--- a/src/wordpress/plugins/polylang.py
+++ b/src/wordpress/plugins/polylang.py
@@ -32,7 +32,6 @@ class WPPolylangConfig(WPPluginConfig):
         # configure options
         logging.info("%s - setting polylang options ...", self.wp_site)
         self.run_wp_cli("pll option update media_support 0")
-        self.run_wp_cli("option update permalink_structure '/%postname%/'")
 
         # create menus
         logging.info("%s - creating polylang menu ...", self.wp_site)


### PR DESCRIPTION
**From issue**: None

**Low level changes:**

1. Comme mentionné pendant le daily, on peut déplayer la partie qui configure les "permalinks" dans `generator.py` au lieu de `polylang.py`. Comme ça on fait ceci en amont et tous les plugins qui pourraient avoir besoin de ça ont déjà l'option. 
1. Initialisation de "permalinks" de manière plus propre qu'avant dans le sens où maintenant on fait aussi en sorte que le fichier `.htaccess` soit automatiquement généré (ce qui n'était pas le cas avant, c'était fait qu'à moitié en quelque sorte...). Pour faire ça propre, une option de configuration a été ajoutée à WP-CLI via le fichier `config.yml` qui est copié dans le root de WP-CLI par le `Dockerfile` de l'image `build/mgmt`.

**Targetted version**: 0.2.?
