### PR TITLE
Disable deactivate option in bulk action plugins

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
@@ -42,6 +42,14 @@ function EPFL_remove_menu_pages() {
 	remove_menu_page( 'mo_saml_settings' ); 
 }
 
+/* Hide plugin bulk deactivate action
+ * https://codex.wordpress.org/Plugin_API/Filter_Reference/bulk_actions
+ */
+add_filter('bulk_actions-plugins','my_custom_bulk_actions');
+function my_custom_bulk_actions($actions){
+	    unset( $actions[ 'deactivate-selected' ] );
+	        return $actions;
+}
 
 /* Hide plugin configuration
  * https://codex.wordpress.org/Plugin_API/Action_Reference/admin_menu


### PR DESCRIPTION
**From issue**: #126 

**High level changes:**

1. Disable deactivate option in bulk action plugins


