### PR TITLE
Add taxonomy sync (Polylang)

### DIFF
--- a/src/wordpress/plugins/polylang.py
+++ b/src/wordpress/plugins/polylang.py
@@ -33,6 +33,10 @@ class WPPolylangConfig(WPPluginConfig):
         logging.info("%s - setting polylang options ...", self.wp_site)
         self.run_wp_cli("pll option update media_support 0")
 
+        # Configure sync option
+        logging.info("%s - configuring option sync ...", self.wp_site)
+        self.run_wp_cli("pll option sync taxonomies")
+
         # create menus
         logging.info("%s - creating polylang menu ...", self.wp_site)
         self.run_wp_cli("pll menu create Main top")


### PR DESCRIPTION
**From issue**: Discussion entre @Escapevelocitycham et @lvenries 

**High level changes:**

1. Quand on assignait une taxonomie (ex: catégorie) à un article, la taxonomie "associée" dans l'autre langue n'était pas ajoutée automatiquement à la traduction de l'article dans l'autre langue en question. Il fallait simplement ajouter une petite option de configuration supplémentaire à Polylang pour que ceci soit fait automatiquement.


**Low level changes:**

1. Modification de la classe de configuration de Polylang pour ajouter l'initialisation de l'option manquante


**Targetted version**: x.x.x
