### PR TITLE
Varnish plugin auto install

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -12,10 +12,12 @@ plugins:
   - name: polylang
     config: !include polylang/v1/config-plugin.yml
   - name: mainwp-child
-    config: !include mainwp-child/v1/config-plugin.yml 
+    config: !include mainwp-child/v1/config-plugin.yml
   - name: tequila
     config: !include tequila/v1/config-plugin.yml
   - name: accred
     config: !include accred/v1/config-plugin.yml
   - name: coming-soon
     config: !include coming-soon/v1/config-plugin.yml
+  - name: varnish-http-purge
+    config: !include varnish-http-purge/v1/config-plugin.yml

--- a/data/plugins/generic/varnish-http-purge/v1/config-plugin.yml
+++ b/data/plugins/generic/varnish-http-purge/v1/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes


### PR DESCRIPTION
**From issue**: #90 

**High level changes:**

1. Ajout du plugin `Varnish HTTP Purge` à la liste des plugins à installer. Celui-ci permet d'automatiquement virer une page du cache lorsque celle-ci est éditée. On peut également manuellement invalider la totalité des pages d'un site dans Varnish.


**Low level changes:**

1. Voir "High level changes"

**Targetted version**: x.x.x
