### PR TITLE
Fix inventory

### DIFF
--- a/etc/jobs/build-inventory.yaml
+++ b/etc/jobs/build-inventory.yaml
@@ -1,16 +1,19 @@
 apiVersion: batch/v2alpha1
 kind: CronJob
 metadata:
-  name: build-subdomains-inventory
+  name: build-inventory
 spec:
   concurrencyPolicy: Forbid
   # every hour on the tenth minute
-  schedule: '10 */1 * * *'
+  schedule: '10 * * * *'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   suspend: false
   jobTemplate:
      metadata:
        creationTimestamp: null
-     successfulJobsHistoryLimit: 3
+       labels:
+         parent: build-inventory
      spec:
        template:
          metadata:
@@ -21,7 +24,7 @@ spec:
              - bash
              args:
              - -c
-             - source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp && set -o allexport && source .env && set +o allexport && python src/jahia2wp.py inventory ${WP_ENV} /srv/${WP_ENV} > /srv/manager/wp-manager.epfl.ch/htdocs/inventory-${WP_ENV}.csv
+             - source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp && set -o allexport && source .env && set +o allexport && python src/jahia2wp.py inventory /srv/ > /srv/manager/wp-manager.epfl.ch/htdocs/inventory.csv
              env:
              - name: WP_ENV
                value: subdomains

--- a/etc/jobs/build-inventory.yaml
+++ b/etc/jobs/build-inventory.yaml
@@ -24,7 +24,7 @@ spec:
              - bash
              args:
              - -c
-             - source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp && set -o allexport && source .env && set +o allexport && python src/jahia2wp.py inventory /srv/ > /srv/manager/wp-manager.epfl.ch/htdocs/inventory.csv
+             - source /srv/${WP_ENV}/venv/bin/activate && export PYTHONPATH=/srv/${WP_ENV}/jahia2wp/src && cd /srv/${WP_ENV}/jahia2wp && set -o allexport && source .env && set +o allexport && python src/jahia2wp.py inventory /srv/ > /srv/manager/wp-manager.epfl.ch/htdocs/wp-admin/inventory.csv
              env:
              - name: WP_ENV
                value: subdomains

--- a/functional_tests/test_jahia2wp.py
+++ b/functional_tests/test_jahia2wp.py
@@ -82,7 +82,7 @@ class TestCommandLine:
         ]
 
         output = Utils.run_command(
-            'python {0} inventory {1} /srv/{1}/{2}'.format(
+            'python {0} inventory /srv/{1}/{2}'.format(
                 SCRIPT_FILE, OPENSHIFT_ENV, TEST_HOST))
 
         for expected_line in expected_lines:

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -19,7 +19,7 @@ Usage:
   jahia2wp.py backup-many           <csv_file>                      [--debug | --quiet]
     [--backup-type=<BACKUP_TYPE>]
   jahia2wp.py veritas               <csv_file>                      [--debug | --quiet]
-  jahia2wp.py inventory             <wp_env> <path>                 [--debug | --quiet]
+  jahia2wp.py inventory             <path>                          [--debug | --quiet]
   jahia2wp.py extract-plugin-config <wp_env> <wp_url> <output_file> [--debug | --quiet]
   jahia2wp.py list-plugins          <wp_env> <wp_url>               [--debug | --quiet]
     [--config] [--plugin=<PLUGIN_NAME>]
@@ -189,10 +189,10 @@ def backup_many(csv_file, backup_type=None, **kwargs):
 
 
 @dispatch.on('inventory')
-def inventory(wp_env, path, **kwargs):
+def inventory(path, **kwargs):
     logging.info("Building inventory...")
     print(";".join(['path', 'valid', 'url', 'version', 'db_name', 'db_user', 'admins']))
-    for site_details in WPConfig.inventory(wp_env, path):
+    for site_details in WPConfig.inventory(path):
         print(";".join([
             site_details.path,
             site_details.valid,

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -49,12 +49,11 @@ class WPConfig:
         return "config {0} for {1}".format(installed_string, repr(self.wp_site))
 
     @classmethod
-    def inventory(cls, wp_env, path):
+    def inventory(cls, path):
         """
-        Parse path in wp_env and do an inventory of existing websites.
+        Parse path do an inventory of existing websites.
 
         Argument keywords:
-        wp_env -- Name of environment on which script is executed
         path -- Path where to look for installed WordPress websites
         """
         # helper function to filter out directories which are part or WP install
@@ -76,7 +75,7 @@ class WPConfig:
             dir_names[:] = [d for d in dir_names if keep_wp_sites(d)]
             for dir_name in dir_names:
                 logging.debug('checking %s/%s', parent_path, dir_name)
-                wp_site = WPSite.from_path(wp_env, os.path.join(parent_path, dir_name))
+                wp_site = WPSite.from_path(os.path.join(parent_path, dir_name))
                 if wp_site is None:
                     continue
                 wp_config = cls(wp_site)

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -51,7 +51,7 @@ class WPConfig:
     @classmethod
     def inventory(cls, path):
         """
-        Parse path do an inventory of existing websites.
+        Parse path and do an inventory of existing websites.
 
         Argument keywords:
         path -- Path where to look for installed WordPress websites

--- a/src/wordpress/tests/test_wordpress.py
+++ b/src/wordpress/tests/test_wordpress.py
@@ -32,21 +32,15 @@ class TestWPSite:
             openshift_env=settings.OPENSHIFT_ENV,
             wp_site_url="http://www.epfl.ch/") \
             .name == "www"
-        assert WPSite.from_path(settings.OPENSHIFT_ENV, ROOT_PATH + "htdocs/folder") \
-            .name == "folder"
-        assert WPSite.from_path(settings.OPENSHIFT_ENV, ROOT_PATH + "htdocs/folder/sub") \
-            .name == "sub"
 
     def test_failing_url_from_path(self):
         with pytest.raises(ValueError):
-            WPSite.from_path("idontexistandneverwill", ROOT_PATH)
+            WPSite.from_path("/usr/folder")
 
     def test_valid_url_from_path(self):
-        assert WPSite.from_path(settings.OPENSHIFT_ENV, ROOT_PATH) \
-            .url == "http://localhost/"
-        assert WPSite.from_path(settings.OPENSHIFT_ENV, ROOT_PATH + "htdocs/folder") \
+        assert WPSite.from_path(ROOT_PATH + "htdocs/folder") \
             .url == "http://localhost/folder"
-        assert WPSite.from_path(settings.OPENSHIFT_ENV, ROOT_PATH + "htdocs/folder/sub") \
+        assert WPSite.from_path(ROOT_PATH + "htdocs/folder/sub") \
             .url == "http://localhost/folder/sub"
 
 


### PR DESCRIPTION
**From issue**: #130 

**High level changes:**

1. command `inventory` does not need wp_env any more
1. `inventory` can be run in root directory `/srv` to process multiple environments
1. `inventory` does not produce duplicate lines any more

**Low level changes:**

1. only process directories under apache root directories (`htdocs`)
1. `openshift_env` computed from path 

**Targetted version**: 0.4.0 ( 💥 changement dans la commande `inventory` )