### PR TITLE
[WIP] Add new social share plugin

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -21,3 +21,5 @@ plugins:
     config: !include coming-soon/v1/config-plugin.yml
   - name: varnish-http-purge
     config: !include varnish-http-purge/v1/config-plugin.yml
+  - name: sassy-social-share
+    config: !include sassy-social-share/v1/config-plugin.yml


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Nouveau plugin ([Sassy Social Share](https://fr.wordpress.org/plugins/sassy-social-share/)) pour remplacer Add-To-Any
1. Aline a été contactée pour modifier le thème et afficher les boutons depuis ce nouveau plugin.


**Targetted version**: x.x.x
