### PR TITLE
Install php7.0-xml so that "wp export" works

### DIFF
--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     php7.0-curl \
     php7.0-mysql \
     php7.0-zip \
+    php7.0-xml \
     python3 \
     python3-pip \
     python3-virtualenv \


### PR DESCRIPTION
I am currently encountering the same case as https://github.com/wp-cli/wp-cli/issues/3363 : "wp export" gives me a stacktrace. Note that php7.0-xml is already present in the epflidevelop/os-wp-httpd image

**From issue**: #172

**High level changes:**

Transparent to the user

**Low level changes:**

Just one more package in the Dockerfile

**Targeted version**: ASAP
