### PR TITLE
Allow 'assoc' as value for 'theme_faculty' in CSV file

### DIFF
--- a/src/veritas/validators.py
+++ b/src/veritas/validators.py
@@ -79,7 +79,7 @@ def validate_theme(text):
 
 
 def validate_theme_faculty(text):
-    RegexValidator(regex="^(|cdh|cdm|enac|ic|sb|sti|sv)$")(text.lower())
+    RegexValidator(regex="^(|cdh|cdm|enac|ic|sb|sti|sv|assoc)$")(text.lower())
 
 
 def validate_languages(text):


### PR DESCRIPTION
**From issue**: INC0209380

**High level changes:**

1. Il est maintenant possible de mettre la valeur `assoc` pour le champ `theme_faculty` dans le fichier CSV. Ceci permettra de créer des sites pour les associations avec les couleurs correctes.

**Notes:**
- Aline est en train de modifier le thème afin que cette valeur soit prise en compte. 
- La documentation Confluence a été mise à jour (https://confluence.epfl.ch:8443/x/sgdqAw)

**Targetted version**: x.x.x
