### PR TITLE
Fix issue with integer in YAML

### DIFF
--- a/src/wordpress/plugins/manager.py
+++ b/src/wordpress/plugins/manager.py
@@ -141,7 +141,7 @@ class WPPluginConfigManager:
 
         Arguments keyword:
         s -- String in which to add slashes"""
-        return re.sub("(\\\\|'|\")", lambda o: "\\" + o.group(1), s)
+        return re.sub("(\\\\|'|\")", lambda o: "\\" + o.group(1), str(s))
 
 
 class WPPluginConfigExtractor(WPPluginConfigManager):


### PR DESCRIPTION
**From issue**: #189 

**Low level changes:**

1. Transformation par défaut en string (`str(..)`) des variables auxquelles on ajoute des `\` pour échapper les quotes.

**Targetted version**: x.x.x
