### PR TITLE
FIX quote in tagline

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -245,12 +245,12 @@ class WPGenerator:
         command = "--allow-root core install --url={0.url} --title='{0.wp_site_title}'" \
             " --admin_user={1.username} --admin_password='{1.password}'"\
             " --admin_email='{1.email}'"
-        if not self.run_wp_cli(command.format(self.wp_site, self.wp_admin), 'utf-8'):
+        if not self.run_wp_cli(command.format(self.wp_site, self.wp_admin), encoding="utf-8"):
             logging.error("%s - could not setup WP site", repr(self))
             return False
 
         # Set Tagline (blog description)
-        if not self.run_wp_cli("option update blogdescription '{}'".format(self.wp_site.wp_tagline),
+        if not self.run_wp_cli('option update blogdescription "{}"'.format(self.wp_site.wp_tagline),
                                encoding="utf-8"):
             logging.error("%s - could not configure blog description", repr(self))
             return False

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -250,6 +250,8 @@ class WPGenerator:
             return False
 
         # Set Tagline (blog description)
+        # Command is in simple quotes and tagline between double quotes to avoid problems in case of simple quote
+        # in tagline text.
         if not self.run_wp_cli('option update blogdescription "{}"'.format(self.wp_site.wp_tagline),
                                encoding="utf-8"):
             logging.error("%s - could not configure blog description", repr(self))


### PR DESCRIPTION
**From issue**: INC0210400

**Low level changes:**

1. La tagline est maintenant mise entre des doubles quotes `"` au lieu de simple quote, ceci afin d'éviter qu'une simple quote (apostrophe) présente dans la tagline génère une erreur de syntaxe dans la commande. J'ai tenté d'utiliser une regex pour pouvoir échapper les quotes d'une chaîne de caractères mais dès qu'on a une chaîne avec des caractères spéciaux (éà...), il faut transformer la chaîne en "bytes", ce qui la met sous la form `b'...'` mais à ce moment-là, la regex échappe aussi les ' ajoutés lors de la transformation en bytes donc on se retrouve avec `b\'...\'` ... Du coup, j'ai croisé double-quotes et quotes dans la commande qui utiliser la tagline. Je vous laisse regarder dans le code pour voir les changements.
1. Petit changement dans le nommage d'un paramètre (enfin, le passe en mode kwargs)

**Targetted version**: x.x.x
