### PR TITLE
Exit if extra yaml needed and missing for 'generate' command

### DIFF
--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -51,10 +51,14 @@ class WPPluginList:
 
         else:
             # If we have missing informations
-            for missing_csv_field in self._yaml_from_csv_missing:
-                logging.error('%s - YAML file CSV reference \'%s\' missing. Can be given with option '
-                              '--extra-config=<YAML>\'. YAML content example: \'%s: <value>\'',
-                              repr(self), missing_csv_field, missing_csv_field)
+            if self._yaml_from_csv_missing:
+
+                for missing_csv_field in self._yaml_from_csv_missing:
+                    logging.error('%s - YAML file CSV reference \'%s\' missing. Can be given with option '
+                                  '--extra-config=<YAML>\'. YAML content example: \'%s: <value>\'',
+                                  repr(self), missing_csv_field, missing_csv_field)
+                raise SystemExit('Please provide YAML file with needed configuration (list above) to fill missing '
+                                 'information for plugin configuration')
 
             # If we have plugins,
             if plugin_list['plugins'] is not None:


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Si à l'utilisation de `generate` il y a besoin de paramètres supplémentaires pour la configuration des plugins (via option `--extra-config=<YAML>`), une erreur par paramètre manquant est affichée et après ça, le programme sort avec une exception. 
Avant, le programme continuait jusqu'à ce que le paramètre soit nécessaire et là ça sortait avec une "trace" de l'exécution.
Maintenant, ça sort directement après que les paramètres manquants aient été identifiés (et avant qu'ils soient utilisés). Cependant, cette identification de paramètre est faite seulement après que le core de WP et le thème aient été installés. Cela signifie qu'en cas d'erreur, il faudra faire un `clean` avant de pouvoir relancer un `generate` avec `--extra-config=<YAML>`. J'ai regardé pour faire le check sur les paramètres de configuration de plugins manquant avant dans le code mais ça implique de dupliquer des parties et de le rendre moins lisible...
En conclusion, c'est un peu plus "propre" qu'avant car on a une "vraie" sortie avec une exception au lieu de crasher sur la tentative d'utilisation d'un paramètre manquant mais il y a toujours une partie du site qui est générée et qu'il faudrait effacer avant de relancer. Selon moi, ceci est acceptable du fait que `generate` est quasi uniquement utilisé que pour nos tests. 


**Targetted version**: x.x.x
