### PR TITLE
Correct Breadcrumb with nested wordpress instances

### DIFF
--- a/data/wp/wp-content/themes/epfl-master/functions.php
+++ b/data/wp/wp-content/themes/epfl-master/functions.php
@@ -208,7 +208,7 @@ function get_breadcrumb() {
     //
     // The value is cached during one hour to avoid parsing the url on every page load.
     //
-    // The transient API is used because the basic Cache Object does not persist data if no persistant
+    // The transient API is used because the basic Cache Object does not persist data if no persistent
     // cache plugin is used. The transient API uses the Cache Object if such a plugin is setup, otherwise
     // it stores the value in the database as an option.
     if (false === ($base_breadcrumb = get_transient('base_breadcrumb'))) {

--- a/data/wp/wp-content/themes/epfl-master/functions.php
+++ b/data/wp/wp-content/themes/epfl-master/functions.php
@@ -211,35 +211,35 @@ function get_breadcrumb() {
     // The transient API is used because the basic Cache Object does not persist data if no persistant
     // cache plugin is used. The transient API uses the Cache Object if such a plugin is setup, otherwise
     // it stores the value in the database as an option.
-    if (false === ($base_breadcrum = get_transient('base_breadcrum'))) {
+    if (false === ($base_breadcrumb = get_transient('base_breadcrumb'))) {
 
         $site_url = site_url();
-        $breadcrum_parts = Array();
+        $breadcrumb_parts = Array();
 
         $temp_url = $site_url;
         while ($temp_url != 'http:/' && $temp_url != 'https:/') {
             $name = basename($temp_url);
-            $breadcrum_parts[$temp_url] = $name;
+            $breadcrumb_parts[$temp_url] = $name;
             $temp_url = substr($temp_url, 0, strrpos($temp_url, "/"));
         }
 
-        $breadcrum_parts = array_reverse($breadcrum_parts);
-        $base_breadcrum = '';
+        $breadcrumb_parts = array_reverse($breadcrumb_parts);
+        $base_breadcrumb = '';
 
         $i = 0;
-        foreach($breadcrum_parts as $url => $name){
+        foreach($breadcrumb_parts as $url => $name){
             if ($i == 0) {
-                $base_breadcrum .= '<li class="item-home"><a class="bread-link bread-home" href="' . $url . '" title="' . $name . '">' . $name . '</a></li>';
+                $base_breadcrumb .= '<li class="item-home"><a class="bread-link bread-home" href="' . $url . '" title="' . $name . '">' . $name . '</a></li>';
             } else {
-                $base_breadcrum .= '<li class="item-parent"><a class="bread-parent" href="' . $url . '" title="' . $name . '">' . $name . '</a></li>';
+                $base_breadcrumb .= '<li class="item-parent"><a class="bread-parent" href="' . $url . '" title="' . $name . '">' . $name . '</a></li>';
             }
             $i++;
         }
 
-        set_transient('base_breadcrum', $base_breadcrum, 1 * HOUR_IN_SECONDS);
+        set_transient('base_breadcrumb', $base_breadcrumb, 1 * HOUR_IN_SECONDS);
     }
 
-    echo $base_breadcrum;
+    echo $base_breadcrumb;
 
     if ( is_archive() && !is_tax() && !is_category() && !is_tag() ) {
           

--- a/data/wp/wp-content/themes/epfl-master/functions.php
+++ b/data/wp/wp-content/themes/epfl-master/functions.php
@@ -199,12 +199,12 @@ function get_breadcrumb() {
 
 
     // On a sub-site like https://localhost/site1/site2, on the page https://localhost/site1/site2/page
-    // the default breadcrum looks like "Homepage > page" because the instance of wordpress for site2
+    // the default breadcrumb looks like "Homepage > page" because the instance of wordpress for site2
     // considers https://localhost/site1/site2 to be the Homepage.
     //
-    // So the following code parses the URL and creates a base breadcrum that looks like :
+    // So the following code parses the URL and creates a base breadcrumb that looks like :
     // "localhost > site1 > site2".
-    // Then this base breadcrum is used as a prefix replacing "Homepage" in the original breadcrum.
+    // Then this base breadcrumb is used as a prefix replacing "Homepage" in the original breadcrumb.
     //
     // The value is cached during one hour to avoid parsing the url on every page load.
     //
@@ -217,9 +217,13 @@ function get_breadcrumb() {
         $breadcrumb_parts = Array();
 
         $temp_url = $site_url;
+        // Constructs an array mapping URLs to names. For example, on the site https://localhost/site1 :
+        // ["https://localhost/site1" => "site1", "https://localhost" => "locahost"]
         while ($temp_url != 'http:/' && $temp_url != 'https:/') {
             $name = basename($temp_url);
             $breadcrumb_parts[$temp_url] = $name;
+            // Remove the last part of the URL :
+            // "https://localhost/site1" => "https://localhost"
             $temp_url = substr($temp_url, 0, strrpos($temp_url, "/"));
         }
 


### PR DESCRIPTION
**From issue**: #205 

**High level changes:**

1. The breadcrumb follows the nested sites' hierarchie. For example on "https://localhost/site1/page1" the breadcrumb will be "localhost > site1 > page1"

**Low level changes:**

1. modify the get_breadcrumb() function in the `functions.php` file of the theme to parse the URL and replace the "Homepage" in the original breadcrumb by a breadcrumb representing the site hierarchie.

**Targetted version**: x.x.x
