### PR TITLE
Extend run_wp_cli()

### DIFF
--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -93,18 +93,35 @@ class WPConfig:
                 else:
                     yield WPResult(wp_config.wp_site.path, "KO", "", "", "", "", "")
 
-    def run_wp_cli(self, command, stdin_options=None, encoding=sys.stdout.encoding):
+    def run_wp_cli(self, command, pipe_input=None, extra_options=None, encoding=sys.stdout.encoding):
         """
         Execute a WP-CLI command. The command doesn't have to start with 'wp '. It will be added automatically, and
         it's the same for --path option.
 
         Argument keywords:
         command -- WP-CLI command to execute
-        stdin_options -- Options to add at the end of the command line. There value is taken from STDIN so it
+        pipe_input -- Elements to give to the command using a pipe (ex: echo "elem" | wp command ...)
+        extra_options -- Options to add at the end of the command line. There value is taken from STDIN so it
                          has to be at the end of the command line (after --path)
         encoding -- encoding to use
         """
-        cmd = "wp {} --path='{}' {}".format(command, self.wp_site.path, "" if stdin_options is None else stdin_options)
+
+        cmd = ""
+
+        if pipe_input:
+            cmd += " sh -c 'echo '\"'\"'"
+            cmd += pipe_input
+            cmd += "'\"'\"' |"
+
+        cmd += "wp {} --path='{}'".format(command, self.wp_site.path)
+
+        if extra_options:
+            cmd += " "
+            cmd += extra_options
+
+        if pipe_input:
+            cmd += "'"
+
         return Utils.run_command(cmd, encoding=encoding)
 
     @property

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -111,17 +111,18 @@ class WPGenerator:
     def __repr__(self):
         return repr(self.wp_site)
 
-    def run_wp_cli(self, command, stdin_options=None, encoding=sys.stdout.encoding):
+    def run_wp_cli(self, command, pipe_input=None, extra_options=None, encoding=sys.stdout.encoding):
         """
         Execute a WP-CLI command using method present in WPConfig instance.
 
         Argument keywords:
         command -- WP-CLI command to execute. The command doesn't have to start with "wp ".
-        stdin_options -- Options to add at the end of the command line. There value is taken from STDIN so it
+        pipe_input -- Elements to give to the command using a pipe (ex: echo "elem" | wp command ...)
+        extra_options -- Options to add at the end of the command line. There value is taken from STDIN so it
                          has to be at the end of the command line (after --path)
         encoding -- encoding to use
         """
-        return self.wp_config.run_wp_cli(command, stdin_options=stdin_options, encoding=encoding)
+        return self.wp_config.run_wp_cli(command, extra_options=extra_options, pipe_input=pipe_input, encoding=encoding)
 
     def run_mysql(self, command):
         """
@@ -240,10 +241,10 @@ class WPGenerator:
         command = "config create --dbname='{0.wp_db_name}' --dbuser='{0.mysql_wp_user}'" \
             " --dbpass='{0.mysql_wp_password}' --dbhost={0.MYSQL_DB_HOST}"
         # Generate options to add PHP code in wp-config.php file to switch to ssl if proxy is in SSL
-        stdin_options = "--extra-php <<PHP \n" \
+        extra_options = "--extra-php <<PHP \n" \
             "if (isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'){\n" \
             "\$_SERVER['HTTPS']='on';} \n"
-        if not self.run_wp_cli(command.format(self), stdin_options=stdin_options):
+        if not self.run_wp_cli(command.format(self), extra_options=extra_options):
             logging.error("%s - could not create config", repr(self))
             return False
 


### PR DESCRIPTION
**From issue**: #xx

**Low level changes:**

1. Ajout d'un paramètre `pipe_input` à la fonction `run_wp_cli` permettant de donner du contenu qui devra être passé à la commande `wp...` via un pipe (`|`)
1. Renommage du paramètre `stdin_options` en `extra_options` pour qu'il ne prête pas à confusion avec le `pipe_input`.


**Targetted version**: x.x.x
