### PR TITLE
fix wp cli encoding

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -72,7 +72,7 @@ class WPExporter:
         logging.info("setting up API on '%s', with %s:xxxxxx", rest_api_url, wp_generator.wp_admin.username)
         self.wp = WordpressJsonWrapper(rest_api_url, wp_generator.wp_admin.username, wp_generator.wp_admin.password)
 
-    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command using method present in WP_Generator instance.
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -72,7 +72,7 @@ class WPExporter:
         logging.info("setting up API on '%s', with %s:xxxxxx", rest_api_url, wp_generator.wp_admin.username)
         self.wp = WordpressJsonWrapper(rest_api_url, wp_generator.wp_admin.username, wp_generator.wp_admin.password)
 
-    def run_wp_cli(self, command, encoding=sys.stdout.encoding, pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command using method present in WP_Generator instance.
 

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -93,7 +93,7 @@ class WPConfig:
                 else:
                     yield WPResult(wp_config.wp_site.path, "KO", "", "", "", "", "")
 
-    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command. The command doesn't have to start with 'wp '. It will be added automatically, and
         it's the same for --path option.

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -93,7 +93,7 @@ class WPConfig:
                 else:
                     yield WPResult(wp_config.wp_site.path, "KO", "", "", "", "", "")
 
-    def run_wp_cli(self, command, encoding=sys.stdout.encoding, pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command. The command doesn't have to start with 'wp '. It will be added automatically, and
         it's the same for --path option.

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -113,7 +113,7 @@ class WPGenerator:
     def __repr__(self):
         return repr(self.wp_site)
 
-    def run_wp_cli(self, command,  encoding=sys.stdout.encoding, pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command using method present in WPConfig instance.
 

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -113,7 +113,7 @@ class WPGenerator:
     def __repr__(self):
         return repr(self.wp_site)
 
-    def run_wp_cli(self, command, encoding='utf-8', pipe_input=None, extra_options=None):
+    def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command using method present in WPConfig instance.
 


### PR DESCRIPTION
**From issue**: xx

Petite explication du pourquoi de cette PR, dans mon environnement local, quand je fais un export many sur le site "hanahanlab", le processus crash et j'ai l'exception :

```
Traceback (most recent call last):
  File "jahia2wp.py", line 650, in <module>
    dispatch(__doc__)
  File "/srv/your-env/venv/lib/python3.5/site-packages/docopt_dispatch.py", line 34, in __call__
    function(**self._kwargify(arguments))
  File "jahia2wp.py", line 400, in export_many
    admin_password=admin_password
  File "jahia2wp.py", line 361, in export
    wp_exporter.import_all_data_to_wordpress()
  File "/srv/your-env/jahia2wp/src/exporter/wp_exporter.py", line 110, in import_all_data_to_wordpress
    self.import_sidebar()
  File "/srv/your-env/jahia2wp/src/exporter/wp_exporter.py", line 450, in import_sidebar
    self.run_wp_cli(cmd)
  File "/srv/your-env/jahia2wp/src/exporter/wp_exporter.py", line 87, in run_wp_cli
    extra_options=extra_options
  File "/srv/your-env/jahia2wp/src/wordpress/generator.py", line 127, in run_wp_cli
    return self.wp_config.run_wp_cli(command, encoding=encoding, pipe_input=pipe_input, extra_options=extra_options)
  File "/srv/your-env/jahia2wp/src/wordpress/config.py", line 123, in run_wp_cli
    return Utils.run_command(cmd, encoding=encoding)
  File "/srv/your-env/jahia2wp/src/utils.py", line 98, in run_command
    command_bytes = command.encode(encoding)
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 822: ordinal not in range(128)
```

Donc, la commande passée à `run_wp_cli` contient un caractère que `encoding` ne connait pas. Or, dans la version actuelle de master, `encoding` vaut `sys.stdout.encoding` qui dans mon container est égal à : `ANSI_X3.4-1968`

Or `sys.getdefaultencoding()` retourne `utf-8` quant à lui. Je pense que c'est mieux de prendre l'encodage qui gère le plus de caractères. De, plus avec ces changements, l'import du site "hanahanlab" fonctionne jusqu'au bout.

Je prends volontier des avis, c'est juste une proposition, à discuter.

**High level changes:**

1. Change default encoding for running wordpress' cli commands to sys.getdefaultencoding()

**Low level changes:**

1. run_wp_cli know has `sys.getdefaultencoding()` as a default encoding.

**Targetted version**: x.x.x
