### PR TITLE
php7.0-gd also needed in mgmt container

### DIFF
--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server \
     tree \
     php7.0 \
+    php7.0-gd \
     php7.0-cli \
     php7.0-curl \
     php7.0-mysql \


### PR DESCRIPTION
**From issue**: #231 

**High level changes:**

None visible

**Low level changes:**

- Add `php7.0-gd` to the `epflidevelop/os-wp-mgmt` image