### PR TITLE
MariaBD default character set is latin1 (collation=latin1_swedish_ci)

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -210,7 +210,7 @@ class WPGenerator:
             return False
 
         # create MySQL DB
-        command = "-e \"CREATE DATABASE {0.wp_db_name};\""
+        command = "-e \"CREATE DATABASE {0.wp_db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;\""
         if not self.run_mysql(command.format(self)):
             logging.error("%s - could not create DB", repr(self))
             return False


### PR DESCRIPTION
* Changed the default CHARACTER SET to utf8mb4
* Changed the default COLLATION to utf8mb4_unicode_ci
* See https://stackoverflow.com/a/766996/960623 for details

As the DB_CHARSET in wp-config.php is set to utf8 by default, the DB should be utf8 as well.

See #235.