### PR TITLE
Set default character set on server to utf8mb4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
     volumes:
       - ./volumes/db:/var/lib/mysql
+      - ./etc/mysql/utf8.cnf:/etc/mysql/conf.d/utf8.cnf:ro
 
   phpmyadmin:
       image: phpmyadmin/phpmyadmin

--- a/etc/mysql/utf8.cnf
+++ b/etc/mysql/utf8.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+
+# https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html
+# says: "The character set named utf8 uses a maximum of three bytes
+# per character and contains only BMP characters."
+# If you want emoji (which your users most probably do), you need to
+# use utf8mb4 instead.
+
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
**From issue**: #235

Fixes #235 

This is the belt that goes with the suspenders of https://github.com/epfl-idevelop/jahia2wp/pull/236 .

* Set default character set and collation to utf8bm4 — Not just utf8, as per
  https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html

**High level changes:**

None visible.

**Low level changes:**

All  DB containers now start up with an additional configuration file in /etc/mysql/conf.d which enacts the changes described above.
