### PR TITLE
Handle correctly 2 box types in sidebar

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -468,9 +468,13 @@ class WPExporter:
                         content += prepare_html(box.content)
                         content += "[/colored-box]"
 
-                    else: # Box type not supported for now, we skip it
+                    else: # Box type not supported for now,
                         logging.warning("Box type currently not supported for sidebar (%s)", box.type)
-                        continue
+                        widget_type = 'text'
+                        title = prepare_html("TODO: {}".format(box.title))
+                        content = prepare_html(box.content)
+
+
 
                     cmd = 'widget add {} page-widgets {} ' \
                           '--text="{}" --title="{}"'.format(widget_type, widget_pos, content, title)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import sys
-
+from parser.box import Box
 import timeit
 from collections import OrderedDict
 from datetime import timedelta, datetime
@@ -445,8 +445,8 @@ class WPExporter:
         """
         import sidebar via wpcli
         """
-        def clean_sidebar_html(cmd):
-            return cmd.replace(u'\xa0', u' ')
+        def prepare_html(html):
+            return Utils.escape_quotes(html.replace(u'\xa0', u' '))
 
         widget_pos = 1
         widget_pos_to_lang = {}
@@ -455,15 +455,25 @@ class WPExporter:
             for lang in self.site.homepage.contents.keys():
 
                 for box in self.site.homepage.contents[lang].sidebar.boxes:
-                    content = "[colored-box]"
-                    content += "<h3>{}</h3>".format(box.title)
-                    content += Utils.escape_quotes(box.content)
-                    content += "[/colored-box]"
+                    if box.type == Box.TYPE_TEXT:
+                        widget_type = 'text'
+                        title = prepare_html(box.title)
+                        content = prepare_html(box.content)
 
-                    content = clean_sidebar_html(content)
+                    elif box.type == Box.TYPE_COLORED_TEXT:
+                        widget_type = 'text'
+                        title = ""
+                        content = "[colored-box]"
+                        content += "<h3>{}</h3>".format(box.title)
+                        content += prepare_html(box.content)
+                        content += "[/colored-box]"
 
-                    cmd = 'widget add text page-widgets {} ' \
-                          '--text="{}"'.format(widget_pos, content)
+                    else: # Box type not supported for now, we skip it
+                        logging.warning("Box type currently not supported for sidebar (%s)", box.type)
+                        continue
+
+                    cmd = 'widget add {} page-widgets {} ' \
+                          '--text="{}" --title="{}"'.format(widget_type, widget_pos, content, title)
 
                     self.run_wp_cli(cmd)
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -468,13 +468,12 @@ class WPExporter:
                         content += prepare_html(box.content)
                         content += "[/colored-box]"
 
-                    else: # Box type not supported for now,
+                    # Box type not supported for now,
+                    else:
                         logging.warning("Box type currently not supported for sidebar (%s)", box.type)
                         widget_type = 'text'
                         title = prepare_html("TODO: {}".format(box.title))
                         content = prepare_html(box.content)
-
-
 
                     cmd = 'widget add {} page-widgets {} ' \
                           '--text="{}" --title="{}"'.format(widget_type, widget_pos, content, title)

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -12,7 +12,7 @@ class Box:
     TYPE_ACTU = "actu"
     TYPE_MEMENTO = "memento"
     TYPE_FAQ = "faq"
-    TYPE_TOGGLE ="toggle"
+    TYPE_TOGGLE = "toggle"
     TYPE_INCLUDE = "include"
     TYPE_CONTACT = "contact"
     TYPE_XML = "xml"

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -5,23 +5,36 @@ from utils import Utils
 class Box:
     """A Jahia Box. Can be of type text, infoscience, etc."""
 
-    # the known box types
+    # WP box types
+    TYPE_TEXT = "text"
+    TYPE_COLORED_TEXT = "coloredText"
+    TYPE_INFOSCIENCE = "infoscience"
+    TYPE_ACTU = "actu"
+    TYPE_MEMENTO = "memento"
+    TYPE_FAQ = "faq"
+    TYPE_TOGGLE ="toggle"
+    TYPE_INCLUDE = "include"
+    TYPE_CONTACT = "contact"
+    TYPE_XML = "xml"
+
+    # Mapping of known box types from Jahia to WP
     types = {
-        "epfl:textBox": "text",
-        "epfl:coloredTextBox": "coloredText",
-        "epfl:infoscienceBox": "infoscience",
-        "epfl:actuBox": "actu",
-        "epfl:mementoBox": "memento",
-        "epfl:faqContainer": "faq",
-        "epfl:toggleBox": "toggle",
-        "epfl:htmlBox": "include",
-        "epfl:contactBox": "contact",
-        "epfl:xmlBox": "xml"
+        "epfl:textBox": TYPE_TEXT,
+        "epfl:coloredTextBox": TYPE_COLORED_TEXT,
+        "epfl:infoscienceBox": TYPE_INFOSCIENCE,
+        "epfl:actuBox": TYPE_ACTU,
+        "epfl:mementoBox": TYPE_MEMENTO,
+        "epfl:faqContainer": TYPE_FAQ,
+        "epfl:toggleBox": TYPE_TOGGLE,
+        "epfl:htmlBox": TYPE_INCLUDE,
+        "epfl:contactBox": TYPE_CONTACT,
+        "epfl:xmlBox": TYPE_XML
     }
 
     def __init__(self, site, page_content, element, multibox=False):
         self.site = site
         self.page_content = page_content
+        self.type = ""
         self.set_type(element)
         self.title = Utils.get_tag_attribute(element, "boxTitle", "jahia:value")
         self.content = ""
@@ -43,31 +56,31 @@ class Box:
         """set the box attributes"""
 
         # text
-        if "text" == self.type or "coloredText" == self.type:
+        if self.TYPE_TEXT == self.type or self.TYPE_COLORED_TEXT == self.type:
             self.set_box_text(element, multibox)
         # infoscience
-        elif "infoscience" == self.type:
+        elif self.TYPE_INFOSCIENCE == self.type:
             self.set_box_infoscience(element)
         # actu
-        elif "actu" == self.type:
+        elif self.TYPE_ACTU == self.type:
             self.set_box_actu(element)
         # memento
-        elif "memento" == self.type:
+        elif self.TYPE_MEMENTO == self.type:
             self.set_box_memento(element)
         # faq
-        elif "faq" == self.type:
+        elif self.TYPE_FAQ == self.type:
             self.set_box_faq(element)
         # toggle
-        elif "toggle" == self.type:
+        elif self.TYPE_TOGGLE == self.type:
             self.set_box_toggle(element)
         # include
-        elif "include" == self.type:
+        elif self.TYPE_INCLUDE == self.type:
             self.set_box_include(element)
         # contact
-        elif "contact" == self.type:
+        elif self.TYPE_CONTACT == self.type:
             self.set_box_contact(element)
         # xml
-        elif "xml" == self.type:
+        elif self.TYPE_XML == self.type:
             self.set_box_xml(element)
         # unknown
         else:


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Les boîtes de sidebar de type "ColoredTextBox" et "Text" sont gérées correctement. Pour les autres, elles sont pour le moment affichées en tant que "Text" avec un "TODO: " ajouté dans le titre de la boîte.

**Low level changes:**

1. Utilisation de variables pour stocker les ID des box telles que définies pour WordPress dans `box.py`. Ceci a permis de les réutiliser dans la classe `WPExporter` pour faire les ajouts à la Sidebar.

**Targetted version**: x.x.x
