### PR TITLE
Wwp filetype denied

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -138,6 +138,7 @@ class WPExporter:
         Import medias to Wordpress
         """
         logging.info("WP medias import start")
+        self.run_wp_cli('cap add administrator unfiltered_upload')
         for file in self.site.files:
             wp_media = self.import_media(file)
             if wp_media:

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -143,6 +143,8 @@ class WPExporter:
             if wp_media:
                 self.fix_file_links(file, wp_media)
                 self.report['files'] += 1
+        # Remove the capability "unfiltered_upload" to the administrator group.
+        self.run_wp_cli('cap remove administrator unfiltered_upload')
         logging.info("WP medias imported")
 
     def import_media(self, media):

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -242,10 +242,13 @@ class WPGenerator:
         # config WordPress
         command = "config create --dbname='{0.wp_db_name}' --dbuser='{0.mysql_wp_user}'" \
             " --dbpass='{0.mysql_wp_password}' --dbhost={0.MYSQL_DB_HOST}"
-        # Generate options to add PHP code in wp-config.php file to switch to ssl if proxy is in SSL
+        # Generate options to add PHP code in wp-config.php file to switch to ssl if proxy is in SSL.
+        # Also allow the unfiltered_upload capability to be set, this is used just during export, the
+        # capability is explicitly removed after the export.
         extra_options = "--extra-php <<PHP \n" \
             "if (isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'){\n" \
-            "\$_SERVER['HTTPS']='on';} \n"
+            "\$_SERVER['HTTPS']='on';} \n" \
+            "define('ALLOW_UNFILTERED_UPLOADS', true);"
         if not self.run_wp_cli(command.format(self), extra_options=extra_options):
             logging.error("%s - could not create config", repr(self))
             return False

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -297,6 +297,11 @@ class WPGenerator:
         command = "language core install fr_FR"
         self.run_wp_cli(command)
 
+        # remove unfiltered_upload capability. Will be reactivated during
+        # export if needed.
+        command = 'cap remove administrator unfiltered_upload'
+        self.run_wp_cli(command)
+
         # flag success by returning True
         return True
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Files won't be denied during media import anymore.

**Low level changes:**

1. Allow the use of the wordpress capability `unfiltered_upload`, which is then deactivated explicitly and reactivated temporarily during export to avoid filetype denied errors.

**Targetted version**: x.x.x
