### PR TITLE
Fix breadcrumb import error

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -185,11 +185,10 @@ class WPExporter:
         """
         Import breadcrumb in default language by setting correct option in DB
         """
-        # FIXME: add an attribut default_language to wp_generator.wp_site class
-        default_lang = self.wp_generator._site_params['langs'].split(",")[0]
-
         # If there is a custom breadrcrumb defined for this site
         if self.site.breadcrumb_title and self.site.breadcrumb_url:
+            # FIXME: add an attribut default_language to wp_generator.wp_site class
+            default_lang = self.wp_generator._site_params['langs'].split(",")[0]
             # Generatin breadcrumb to save in parameters
             breadcrumb = "[EPFL|www.epfl.ch]>[{}|{}]".format(self.site.breadcrumb_title[default_lang],
                                                             self.site.breadcrumb_url[default_lang])

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -193,7 +193,7 @@ class WPExporter:
                 default_lang in self.site.breadcrumb_title and default_lang in self.site.breadcrumb_url:
             # Generatin breadcrumb to save in parameters
             breadcrumb = "[EPFL|www.epfl.ch]>[{}|{}]".format(self.site.breadcrumb_title[default_lang],
-                                                            self.site.breadcrumb_url[default_lang])
+                                                             self.site.breadcrumb_url[default_lang])
 
             self.run_wp_cli("option update epfl:custom_breadcrumb '{}'".format(breadcrumb))
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -188,11 +188,13 @@ class WPExporter:
         # FIXME: add an attribut default_language to wp_generator.wp_site class
         default_lang = self.wp_generator._site_params['langs'].split(",")[0]
 
-        # Generatin breadcrumb to save in parameters
-        breadcrumb = "[EPFL|www.epfl.ch]>[{}|{}]".format(self.site.breadcrumb_title[default_lang],
-                                                         self.site.breadcrumb_url[default_lang])
+        # If there is a custom breadrcrumb defined for this site
+        if self.site.breadcrumb_title and self.site.breadcrumb_url:
+            # Generatin breadcrumb to save in parameters
+            breadcrumb = "[EPFL|www.epfl.ch]>[{}|{}]".format(self.site.breadcrumb_title[default_lang],
+                                                            self.site.breadcrumb_url[default_lang])
 
-        self.run_wp_cli("option update epfl:custom_breadcrumb '{}'".format(breadcrumb))
+            self.run_wp_cli("option update epfl:custom_breadcrumb '{}'".format(breadcrumb))
 
     def fix_file_links(self, file, wp_media):
         """Fix the links pointing to the given file"""

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -185,10 +185,12 @@ class WPExporter:
         """
         Import breadcrumb in default language by setting correct option in DB
         """
-        # If there is a custom breadrcrumb defined for this site
-        if self.site.breadcrumb_title and self.site.breadcrumb_url:
-            # FIXME: add an attribut default_language to wp_generator.wp_site class
-            default_lang = self.wp_generator._site_params['langs'].split(",")[0]
+        # FIXME: add an attribut default_language to wp_generator.wp_site class
+        default_lang = self.wp_generator._site_params['langs'].split(",")[0]
+
+        # If there is a custom breadrcrumb defined for this site and the default language
+        if self.site.breadcrumb_title and self.site.breadcrumb_url and \
+                default_lang in self.site.breadcrumb_title and default_lang in self.site.breadcrumb_url:
             # Generatin breadcrumb to save in parameters
             breadcrumb = "[EPFL|www.epfl.ch]>[{}|{}]".format(self.site.breadcrumb_title[default_lang],
                                                             self.site.breadcrumb_url[default_lang])


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Do not try to import a custom breadcrumb in wordpress when there is no custom breadcrumb to import

**Low level changes:**

1. Explicitly check if there is a custom breadcrumb before trying to set the custom_breadcrumb option

**Targetted version**: x.x.x
