### PR TITLE
Correct theme name for associations

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -177,6 +177,8 @@ class Site:
 
             self.title[language] = Utils.get_tag_attribute(dom, "siteName", "jahia:value")
             self.theme[language] = Utils.get_tag_attribute(dom, "theme", "jahia:value")
+            if self.theme[language] == 'associations':
+                self.theme[language] = 'assoc'
             self.acronym[language] = Utils.get_tag_attribute(dom, "acronym", "jahia:value")
             self.css_url[language] = "//static.epfl.ch/v0.23.0/styles/%s-built.css" % self.theme[language]
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Use "associations" as a theme name instead of "assoc" to match jahia naming

**Low level changes:**

1. Modify veritas and scss to match associations instead of assoc

**Targetted version**: x.x.x
