### PR TITLE
[WIP] add Content-Disposition header or wordpress refuses to import videos

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -179,7 +179,8 @@ class WPExporter:
         files = files
         try:
             logging.debug("WP media information %s", wp_media_info)
-            wp_media = self.wp.post_media(data=wp_media_info, files=files)
+            headers = {'Content-Disposition': 'attachment;filename={}'.format(media.name)}
+            wp_media = self.wp.post_media(data=wp_media_info, files=files, headers=headers)
             return wp_media
         except Exception as e:
             logging.error("%s - WP export - media failed: %s", self.site.name, e)


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Videos are now correctly imported

**Low level changes:**

1. Add Content-Disposition header when uploading a media via the WordPress API, otherwise it fails for videos.

**Targetted version**: x.x.x
