### PR TITLE
Fix if the page does not exist for all languages on the site 

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -369,7 +369,8 @@ class WPExporter:
                     'post_status': 'publish',
                 }
 
-            # if the page doesn't exist for all languages on the site
+            # If the page doesn't exist for all languages on the site we create a blank page in draft status
+            # At the end of export we delete all draft pages
             for lang in self.wp_generator._site_params['langs'].split(","):
                 if lang in info_page:
                     continue
@@ -378,7 +379,7 @@ class WPExporter:
                         'post_name': '',
                         'post_status': 'draft'
                     }
-            
+
             cmd = "pll post create --post_type=page --stdin --porcelain"
             stdin = json.dumps(info_page)
 
@@ -606,7 +607,10 @@ class WPExporter:
                     menu_name = "{}-{}".format(settings.MAIN_MENU, lang)
 
                 if page_content.wp_id:
-                    cmd = 'menu item add-post {} {} --classes=link-home --porcelain'.format(menu_name, page_content.wp_id)
+                    cmd = 'menu item add-post {} {} --classes=link-home --porcelain'.format(
+                        menu_name,
+                        page_content.wp_id
+                    )
                     menu_id = self.run_wp_cli(cmd)
 
                     if not menu_id:
@@ -692,7 +696,6 @@ class WPExporter:
             cmd = "post delete {}".format(page_id)
             self.run_wp_cli(cmd)
         logging.info("All pages in DRAFT status deleted")
-
 
     def delete_pages(self):
         """

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -372,9 +372,7 @@ class WPExporter:
             # If the page doesn't exist for all languages on the site we create a blank page in draft status
             # At the end of export we delete all draft pages
             for lang in self.wp_generator._site_params['langs'].split(","):
-                if lang in info_page:
-                    continue
-                else:
+                if lang not in info_page:
                     info_page[lang] = {
                         'post_name': '',
                         'post_status': 'draft'

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -570,8 +570,8 @@ class WPExporter:
         """
         if page not in self.site.homepage.children \
                 and lang in page.contents \
-                and page.parent.contents[lang].wp_id in self.menu_id_dict\
-                and page.contents[lang].wp_id:
+                and page.parent.contents[lang].wp_id in self.menu_id_dict \
+                and page.contents[lang].wp_id:  # For some unknown reason, wp_id is sometimes None
 
             parent_menu_id = self.menu_id_dict[page.parent.contents[lang].wp_id]
 
@@ -604,6 +604,7 @@ class WPExporter:
                 else:
                     menu_name = "{}-{}".format(settings.MAIN_MENU, lang)
 
+                # For some unknown reason, wp_id is sometimes None
                 if page_content.wp_id:
                     cmd = 'menu item add-post {} {} --classes=link-home --porcelain'.format(
                         menu_name,

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -109,6 +109,7 @@ class WPExporter:
             self.populate_menu()
             self.import_sidebar()
             self.import_breadcrumb()
+            self.delete_draft_pages()
             self.display_report()
 
             # log execution time
@@ -680,6 +681,18 @@ class WPExporter:
                 self.wp.delete_media(media_id=media['id'], params={'force': 'true'})
             medias = self.wp.get_media(params={'per_page': '100'})
         logging.info("All medias deleted")
+
+    def delete_draft_pages(self):
+        """
+        Delete all pages in DRAFT status
+        """
+        cmd = "post list --post_type='page' --post_status=draft --format=csv"
+        pages_id_list = self.run_wp_cli(cmd).split("\n")[1:]
+        for page_id in pages_id_list:
+            cmd = "post delete {}".format(page_id)
+            self.run_wp_cli(cmd)
+        logging.info("All pages in DRAFT status deleted")
+
 
     def delete_pages(self):
         """

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -571,7 +571,7 @@ class WPExporter:
         if page not in self.site.homepage.children \
                 and lang in page.contents \
                 and page.parent.contents[lang].wp_id in self.menu_id_dict \
-                and page.contents[lang].wp_id:  # For some unknown reason, wp_id is sometimes None
+                and page.contents[lang].wp_id:  # FIXME For some unknown reason, wp_id is sometimes None
 
             parent_menu_id = self.menu_id_dict[page.parent.contents[lang].wp_id]
 
@@ -604,7 +604,7 @@ class WPExporter:
                 else:
                     menu_name = "{}-{}".format(settings.MAIN_MENU, lang)
 
-                # For some unknown reason, wp_id is sometimes None
+                # FIXME For some unknown reason, wp_id is sometimes None
                 if page_content.wp_id:
                     cmd = 'menu item add-post {} {} --classes=link-home --porcelain'.format(
                         menu_name,


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Fixer le problème : "si une page n'a pas une version dans les différentes language du site, l'import via wp_cli échoue"

**Low level changes:**

1. on crée une page vide dans le statut Draft pour les versions manquantes
1. à la fin de l'export, on supprime toutes les pages

**Targetted version**: x.x.x
