### PR TITLE
Import all files including those with not-ascii characters in their name

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -278,11 +278,14 @@ class WPExporter:
             if not link:
                 continue
 
-            # Encoding in the export file (export_<lang>.xml) and encoding of the filenames in the zip are not the same.
-            # string.encode('ascii', 'replace') replaces all unknown characters by '?'. What happens here is that for
-            # a file named 'vidéo.mp4', the old_url, which is actually the path on the file system, will be 'vid??o.mp4'
-            # once converted to ascii; but, the links that reference the media in the export file will be converted to 'vid?o.mp4'.
-            # So we convert to ascii and remove the '?' character to compare the strings and see if there is a link to replace.
+            # Encoding in the export file (export_<lang>.xml) and encoding of the filenames
+            # in the zip are not the same. string.encode('ascii', 'replace') replaces all
+            # unknown characters by '?'. What happens here is that for a file named 'vidéo.mp4',
+            # the old_url, which is actually the path on the file system, will be 'vid??o.mp4'
+            # once converted to ascii; but, the links that reference the media in the export file
+            # will be converted to 'vid?o.mp4'.
+            # So we convert to ascii and remove the '?' character to compare the strings and see
+            # if there is a link to replace.
             if link.encode('ascii', 'replace').decode('ascii').replace('?', '') == old_url.replace('?', ''):
                 logging.debug("Changing link from %s to %s" % (old_url, new_url))
                 tag[tag_attribute] = new_url

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -278,7 +278,12 @@ class WPExporter:
             if not link:
                 continue
 
-            if link == old_url:
+            # Encoding in the export file (export_<lang>.xml) and encoding of the filenames in the zip are not the same.
+            # string.encode('ascii', 'replace') replaces all unknown characters by '?'. What happens here is that for
+            # a file named 'vidéo.mp4', the old_url, which is actually the path on the file system, will be 'vid??o.mp4'
+            # once converted to ascii; but, the links that reference the media in the export file will be converted to 'vid?o.mp4'.
+            # So we convert to ascii and remove the '?' character to compare the strings and see if there is a link to replace.
+            if link.encode('ascii', 'replace').decode('ascii').replace('?', '') == old_url.replace('?', ''):
                 logging.debug("Changing link from %s to %s" % (old_url, new_url))
                 tag[tag_attribute] = new_url
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -153,6 +153,21 @@ class WPExporter:
         """
         Import a media to Wordpress
         """
+        # Try to encode the path in ascii, if it fails then the path contains non-ascii characters.
+        # In that case convert to ascii with 'replace' option which replaces unknown characters by '?',
+        # and rename the file with that new name.
+        try:
+            media.path.encode('ascii')
+        except UnicodeEncodeError:
+            ascii_path = media.path.encode('ascii', 'replace').decode('ascii')
+            os.rename(media.path, ascii_path)
+            media.path = ascii_path
+        try:
+            media.name.encode('ascii')
+        except UnicodeEncodeError:
+            ascii_file_name = media.name.encode('ascii', 'replace').decode('ascii')
+            os.rename(os.path.join(media.path, media.name), os.path.join(media.path, ascii_file_name))
+            media.name = ascii_file_name
         file_path = os.path.join(media.path, media.name)
         file = open(file_path, 'rb')
 

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -339,26 +339,10 @@ class Site:
         start = "%s/content/sites/%s/files" % (self.base_path, self.name)
 
         for (path, dirs, files) in os.walk(start):
-            # Try to encode the path in ascii, if it fails then the path contains non-ascii characters.
-            # In that case convert to ascii with 'replace' option which replaces unknown characters by '?',
-            # and rename the file with that new name.
-            try:
-                path.encode('ascii')
-            except UnicodeEncodeError:
-                ascii_path = path.encode('ascii', 'replace').decode('ascii')
-                os.rename(path, ascii_path)
-                path = ascii_path
             for file_name in files:
                 # we exclude the thumbnails
                 if file_name in ["thumbnail", "thumbnail2"]:
                     continue
-                # Same logic used for the path applied on the filename
-                try:
-                    file_name.encode('ascii')
-                except UnicodeEncodeError:
-                    ascii_file_name = file_name.encode('ascii', 'replace').decode('ascii')
-                    os.rename(os.path.join(path, file_name), os.path.join(path, ascii_file_name))
-                    file_name = ascii_file_name
 
                 self.files.append(File(name=file_name, path=path))
 

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -339,10 +339,26 @@ class Site:
         start = "%s/content/sites/%s/files" % (self.base_path, self.name)
 
         for (path, dirs, files) in os.walk(start):
+            # Try to encode the path in ascii, if it fails then the path contains non-ascii characters.
+            # In that case convert to ascii with 'replace' option which replaces unknown characters by '?',
+            # and rename the file with that new name.
+            try:
+                path.encode('ascii')
+            except UnicodeEncodeError:
+                ascii_path = path.encode('ascii', 'replace').decode('ascii')
+                os.rename(path, ascii_path)
+                path = ascii_path
             for file_name in files:
                 # we exclude the thumbnails
                 if file_name in ["thumbnail", "thumbnail2"]:
                     continue
+                # Same logic used for the path applied on the filename
+                try:
+                    file_name.encode('ascii')
+                except UnicodeEncodeError:
+                    ascii_file_name = file_name.encode('ascii', 'replace').decode('ascii')
+                    os.rename(os.path.join(path, file_name), os.path.join(path, ascii_file_name))
+                    file_name = ascii_file_name
 
                 self.files.append(File(name=file_name, path=path))
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. L'import de fichiers avec des caractères non ascii est maintenant possible.

**Low level changes:**

1. Les caractères non ascii sont remplacés par des '?', et lors de l'import, wordpress enlève les '?', sûrement pour des raisons de sécurité. Donc au final, vidéo.mp4 devient vido.mp4 après l'import.

Note : 
C'est améliorable, il faudrait remplacer les '?' par des '_', mais l'esthétique des noms de fichiers ne me semble pas être une priorité.

**Targetted version**: x.x.x
