### PR TITLE
WWP fix 503

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -384,6 +384,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
 
         # determined information
         'unit_id': get_unit_id(unit_name),
+        'from_export': True
     }
 
     # Generate a WordPress site
@@ -424,6 +425,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
         logging.info("Data of WordPress site %s successfully deleted", site.name)
 
     wp_generator.uninstall_basic_auth_plugin()
+    wp_generator.enable_updates_automatic_if_allowed()
 
     return wp_exporter
 

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -22,7 +22,8 @@ class WPConfig:
 
     def __init__(self, wp_site,
                  installs_locked=settings.DEFAULT_CONFIG_INSTALLS_LOCKED,
-                 updates_automatic=settings.DEFAULT_CONFIG_UPDATES_AUTOMATIC):
+                 updates_automatic=settings.DEFAULT_CONFIG_UPDATES_AUTOMATIC,
+                 from_export=False):
         """
         Class constructor
 
@@ -44,6 +45,7 @@ class WPConfig:
         # set additionnal options
         self.installs_locked = cast_yes_or_no(installs_locked)
         self.updates_automatic = cast_yes_or_no(updates_automatic)
+        self.from_export = from_export
 
     def __repr__(self):
         installed_string = '[ok]' if self.is_installed else '[ko]'

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -66,6 +66,9 @@ class WPGenerator:
         if self._site_params.get('updates_automatic', None) is None:
             self._site_params['updates_automatic'] = settings.DEFAULT_CONFIG_UPDATES_AUTOMATIC
 
+        if self._site_params.get('from_export', None) is None:
+            self._site_params['from_export'] = False
+
         if self._site_params.get('theme', None) is None:
             self._site_params['theme'] = settings.DEFAULT_THEME_NAME
 
@@ -100,7 +103,8 @@ class WPGenerator:
         self.wp_config = WPConfig(
             self.wp_site,
             installs_locked=self._site_params['installs_locked'],
-            updates_automatic=self._site_params['updates_automatic'])
+            updates_automatic=self._site_params['updates_automatic'],
+            from_export=self._site_params['from_export'])
 
         # prepare admin for exploitation/maintenance
         self.wp_admin = WPUser(self.WP_ADMIN_USER, self.WP_ADMIN_EMAIL)
@@ -373,10 +377,16 @@ class WPGenerator:
         if self.wp_config.installs_locked:
             WPMuPluginConfig(self.wp_site, "EPFL_installs_locked.php").install()
 
-        if self.wp_config.updates_automatic:
+        # If the site is created from a jahia export, the automatic update is disabled and will be re-enabled
+        # after the export process is done.
+        if self.wp_config.updates_automatic and not self.config.from_export:
             WPMuPluginConfig(self.wp_site, "EPFL_enable_updates_automatic.php").install()
         else:
             WPMuPluginConfig(self.wp_site, "EPFL_disable_updates_automatic.php").install()
+
+    def enable_updates_automatic_if_allowed(self):
+        if self.wp_config.updates_automatic:
+            WPMuPluginConfig(self.wp_site, "EPFL_enable_updates_automatic.php").install()
 
     def generate_plugins(self, only_one=None, force=True, **kwargs):
         """

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -379,7 +379,7 @@ class WPGenerator:
 
         # If the site is created from a jahia export, the automatic update is disabled and will be re-enabled
         # after the export process is done.
-        if self.wp_config.updates_automatic and not self.config.from_export:
+        if self.wp_config.updates_automatic and not self.wp_config.from_export:
             WPMuPluginConfig(self.wp_site, "EPFL_enable_updates_automatic.php").install()
         else:
             WPMuPluginConfig(self.wp_site, "EPFL_disable_updates_automatic.php").install()


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Deactivate auto updates during export and reactivate it after

**Low level changes:**

1. Deactivate auto updates during export and reactivate it after

Note : 

J'ajoute une variable `from_export` afin de désactiver l'auto update dès la génération du site lorsque le site est construit depuis un export jahia. Cela me permet de découpler ce comportement de celui de la variable `updates_automatic`.

Je la laisse en WIP car je n'arrive pas à reproduire le soucis d'erreur 503 en local, je vais relancer un export complet depuis cette branche et on verra si le problème se pose toujours.

**Targetted version**: x.x.x
