### PR TITLE
[WIP] use copy instead of deepcopy

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -646,7 +646,7 @@ class WPExporter:
                         self.report['menus'] += 1
 
                 # We do a copy of the list because we will use "pop()" later and empty the list
-                children_copy = copy.deepcopy(self.site.homepage.children)
+                children_copy = copy.copy(self.site.homepage.children)
 
                 # Looping through root menu entries
                 for root_entry_index in range(0, self.site.menus[lang].nb_main_entries()):


### PR DESCRIPTION
**From issue**: #xx

Avant la correction : RecursionError: maximum recursion depth exceeded
N'apparait plus après et le site se déploie correctement.

Exemple de site avec le problème : dcgprogram

**High level changes:**

1.No more recursion error on menu construction

**Low level changes:**

1. Use copy instead of deepcopy to copy the list containing the children of the homepage.

En fait deepcopy tente de faire des deepcopy sur les objets Page que contient la liste. Mais ces objets sont construits de telle façon que la deepcopy se retrouve en récursion infinie sur certains sites. En plus, ici ce qu'on veut c'est copier la liste en elle-même, le fait que les références dans les deux listes pointent vers les même objets Page n'est pas un soucis. Au final on a deux listes complètement distinctes avec le copy, ce qui permet de faire le pop() sur une sans modifier l'autre, ce qui est le but recherché.

**Targetted version**: x.x.x
