### PR TITLE
Skip hidden root menu entries

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -665,14 +665,16 @@ class WPExporter:
 
                     # If root menu entry is an hardcoded URL
                     if self.site.menus[lang].target_is_url(root_entry_index):
-                        cmd = 'menu item add-custom {} "{}" "{}" --porcelain' \
-                            .format(menu_name,
-                                    self.site.menus[lang].txt(root_entry_index),
-                                    self.site.menus[lang].target_url(root_entry_index))
-                        menu_id = self.run_wp_cli(cmd)
-                        if not menu_id:
-                            logging.warning("Root menu item not created for URL (%s) " %
-                                            self.site.menus[lang].target_url())
+                        # If root entry is visible
+                        if not self.site.menus[lang].hidden:
+                            cmd = 'menu item add-custom {} "{}" "{}" --porcelain' \
+                                .format(menu_name,
+                                        self.site.menus[lang].txt(root_entry_index),
+                                        self.site.menus[lang].target_url(root_entry_index))
+                            menu_id = self.run_wp_cli(cmd)
+                            if not menu_id:
+                                logging.warning("Root menu item not created for URL (%s) " %
+                                                self.site.menus[lang].target_url())
 
                     # root menu entry is page
                     else:
@@ -684,18 +686,22 @@ class WPExporter:
                             logging.warning("Page not translated %s" % homepage_child.pid)
                             continue
 
-                        if homepage_child.contents[lang].wp_id:
-                            cmd = 'menu item add-post {} {} --porcelain' \
-                                  .format(menu_name, homepage_child.contents[lang].wp_id)
-                            menu_id = self.run_wp_cli(cmd)
-                            if not menu_id:
-                                logging.warning("Root menu item not created %s for page " % homepage_child.pid)
-                            else:
-                                self.menu_id_dict[homepage_child.contents[lang].wp_id] = Utils.get_menu_id(menu_id)
-                                self.report['menus'] += 1
+                        # If root entry is visible
+                        if not self.site.menus[lang].is_hidden(root_entry_index):
 
-                        # create recursively submenus
-                        self.create_submenu(homepage_child.children, lang, menu_name)
+                            if homepage_child.contents[lang].wp_id:
+                                cmd = 'menu item add-post {} {} --porcelain' \
+                                      .format(menu_name, homepage_child.contents[lang].wp_id)
+                                menu_id = self.run_wp_cli(cmd)
+                                if not menu_id:
+                                    logging.warning("Root menu item not created %s for page " % homepage_child.pid)
+                                else:
+                                    self.menu_id_dict[homepage_child.contents[lang].wp_id] = Utils.get_menu_id(menu_id)
+                                    self.report['menus'] += 1
+
+                            # create recursively submenus
+                            # FIXME: Also handle submenu visibility
+                            self.create_submenu(homepage_child.children, lang, menu_name)
 
                 logging.info("WP menus populated for '%s' language", lang)
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -666,7 +666,7 @@ class WPExporter:
                     # If root menu entry is an hardcoded URL
                     if self.site.menus[lang].target_is_url(root_entry_index):
                         # If root entry is visible
-                        if not self.site.menus[lang].hidden:
+                        if not self.site.menus[lang].is_hidden(root_entry_index):
                             cmd = 'menu item add-custom {} "{}" "{}" --porcelain' \
                                 .format(menu_name,
                                         self.site.menus[lang].txt(root_entry_index),

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -160,12 +160,14 @@ class Site:
 
                             for jahia_type in nav_page.childNodes:
 
+                                hidden = False
                                 # If normal jahia page
                                 if jahia_type.nodeName == "jahia:page":
                                     # Page is a link to sitemap, we skip it
                                     if jahia_type.getAttribute("jahia:template") == "sitemap":
                                         continue
                                     txt = jahia_type.getAttribute("jahia:title")
+                                    hidden = jahia_type.getAttribute("jahia:hideFromNavigationMenu") != ""
                                     target = None
                                 # If URL
                                 elif jahia_type.nodeName == "jahia:url":
@@ -174,7 +176,7 @@ class Site:
                                 else:
                                     continue
 
-                                entry_index = self.menus[language].add_main_entry(txt, target)
+                                entry_index = self.menus[language].add_main_entry(txt, target, hidden)
 
                                 # FIXME: Handle sub-sub-pages in menu
                                 # Looping through subpages below main entry
@@ -182,9 +184,11 @@ class Site:
 
                                     for jahia_sub_type in sub_page.childNodes:
 
+                                        hidden = False
                                         # If normal jahia page
                                         if jahia_sub_type.nodeName == "jahia:page":
                                             txt = jahia_sub_type.getAttribute("jahia:title")
+                                            hidden = jahia_sub_type.getAttribute("jahia:hideFromNavigationMenu") != ""
                                             target = None
                                         # If URL
                                         elif jahia_sub_type.nodeName == "jahia:url":
@@ -193,7 +197,7 @@ class Site:
                                         else:
                                             continue
 
-                                        self.menus[language].add_sub_entry(txt, target, entry_index)
+                                        self.menus[language].add_sub_entry(txt, target, hidden, entry_index)
 
     def parse_root_menu_entries_url(self):
         """

--- a/src/parser/menu.py
+++ b/src/parser/menu.py
@@ -41,6 +41,9 @@ class Menu:
     def target_is_url(self, index):
         return self.root_menu[index].target_is_url()
 
+    def is_hidden(self, index):
+        return self.root_menu[index].hidden
+
     def txt(self, index):
         return self.root_menu[index].txt
 

--- a/src/parser/menu.py
+++ b/src/parser/menu.py
@@ -10,7 +10,7 @@ class Menu:
 
         self.root_menu = []
 
-    def add_main_entry(self, txt, target_url):
+    def add_main_entry(self, txt, target_url, hidden):
         """
         Add entry to main menu
 
@@ -20,15 +20,15 @@ class Menu:
         Ret : main menu entry index
         """
 
-        menu_item = MenuItem(txt, target_url)
+        menu_item = MenuItem(txt, target_url, hidden)
 
         self.root_menu.append(menu_item)
 
         return len(self.root_menu) - 1
 
-    def add_sub_entry(self, txt, target, parent_index):
+    def add_sub_entry(self, txt, target, hidden, parent_index):
 
-        return self.root_menu[parent_index].add_child(txt, target)
+        return self.root_menu[parent_index].add_child(txt, target, hidden)
 
     def get_sub_entries(self, parent_index):
         """

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -4,17 +4,18 @@
 class MenuItem:
     """ To store menu item information """
 
-    def __init__(self, txt, target_url):
+    def __init__(self, txt, target_url, hidden):
 
         self.txt = txt
         self.target_url = target_url
+        self.hidden = hidden
         self.children = []
 
     def target_is_url(self):
 
         return self.target_url is not None
 
-    def add_child(self, txt, target_url):
+    def add_child(self, txt, target_url, hidden):
         """
         Add child to current menu entry
 
@@ -24,7 +25,7 @@ class MenuItem:
         Ret : sub menu entry index
         """
 
-        menu_item = MenuItem(txt, target_url)
+        menu_item = MenuItem(txt, target_url, hidden)
         self.children.append(menu_item)
 
         return len(self.children) - 1


### PR DESCRIPTION
**From issue**: (site https://nal.epfl.ch, https://migration-wp.epfl.ch/nal/) 

**High level changes:**

1. Les entrées de menu "root" qui sont cachées du côté de Jahia ne sont pas prise en compte lors de la création du menu côté WordPress

**Low level changes:**

1. Identification (lors du parsing) des entrées de menu "root" qui sont cachées
1. Construction du menu (root) en ne prenant pas en compte les entrées cachées.

**Notes**
Actuellement, le code ne prend en compte que les entrées de menu "root" qui sont cachées et pas celles des sous-menus. Si un jour il y a aussi des entrées de "sous-menu" à cacher, il faudra modifier le code pour les gérer (des FIXME ont été ajoutés dans le code pour rappeler la chose)

**Targetted version**: x.x.x
