### PR TITLE
Bugfix for page which doesn't exists in a specific lang

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -454,6 +454,11 @@ class WPExporter:
             self.delete_draft_pages()
 
             for wp_id, (lang, content) in zip(wp_ids, contents.items()):
+                # If page doesn't exists for current lang (but it was created as draft before and then deleted),
+                # we skip the update (because there is nothing to update and we don't have needed information...
+                if lang not in page.contents:
+                    continue
+                # Updating page in WordPress
                 wp_page = self.update_page(page_id=wp_id, title=page.contents[lang].title, content=content)
 
                 # prepare mapping for the nginx conf generation


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Suppression de la tentative de mise à jour des pages n'existant pas dans une langue... la page dans la langue manquante est créée vide mais on tente quand même de la mettre à jour par la suite.

**Low level changes:**

1. Ajout d'un check de l'existence de la langue pour la page et skip si n'existe pas

**Targetted version**: x.x.x
