### PR TITLE
Allow empty title and so default title is now empty string

### DIFF
--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -22,7 +22,7 @@ class WPSite:
     """
 
     PROTOCOL = "https"
-    DEFAULT_TITLE = "New WordPress"
+    DEFAULT_TITLE = ""
     DEFAULT_TAGLINE = "EPFL"
     WP_VERSION = Utils.get_mandatory_env(key="WP_VERSION")
 


### PR DESCRIPTION
**From issue**: WWP-520

**High level changes:**

1. Autorise un tittre vide pour les sites

**Low level changes:**

1. Modification de la valeur pour défaut du titre pour une chaine vide


Note importante, quand il n'y a pas de titres wordpress, wordpress rempli tout seul le nom dans la barre du haut, exemple dans l'image en commentaire après.

**Targetted version**: x.x.x
