### PR TITLE
Fix travis : add chown on /srv/env/jahia2wp

### DIFF
--- a/build/httpd/docker-entrypoint.sh
+++ b/build/httpd/docker-entrypoint.sh
@@ -26,6 +26,7 @@ EOF
 /bin/mkdir -p /srv/${WP_ENV}/logs
 /bin/chown www-data: /srv/${WP_ENV}
 /bin/chown www-data: /srv/${WP_ENV}/logs
+/bin/chown www-data: /srv/${WP_ENV}/jahia2wp
 
 /bin/mkdir -p /etc/apache2/ssl
 /usr/bin/openssl req -x509 -sha256 -nodes -days 3650 -newkey rsa:4096 -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.cert -subj "/C=CH/ST=Vaud/L=Lausanne/O=Ecole Polytechnique Federale de Lausanne (EPFL)/CN=*.epfl.ch"


### PR DESCRIPTION
Tous les tests travis sur toutes les branches terminent avec l'erreur :

```
INTERNALERROR> PermissionError: [Errno 13] Permission denied: '/srv/test/jahia2wp/.coverage'
```

Je suppose donc qu'il faut ajouter un chown sur `/srv/{WP_ENV}/jahia2wp`. Le soucis c'est qu'il n'y a aucun moyen de tester sans merger cette PR dans master vu que travis pull l'image à chaque fois.
