### PR TITLE
Add source of truth line generation with migrated website information

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -855,7 +855,7 @@ class WPExporter:
             # We skip this redirection to avoid infinite redirection...
             if element['jahia_url'] != "/index.html":
 
-                content.append("Redirect 301 {} {}".format(element['jahia_url'][1:],
+                content.append("Redirect 301 {} {}".format(element['jahia_url'],
                                                            urlparse(element['wp_url']).path))
 
         if content:

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -63,6 +63,7 @@ import json
 import csv
 import os
 import yaml
+from collections import OrderedDict
 from docopt import docopt
 from docopt_dispatch import dispatch
 from epflldap.ldap_search import get_unit_id
@@ -434,6 +435,37 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
 
     wp_generator.uninstall_basic_auth_plugin()
     wp_generator.enable_updates_automatic_if_allowed()
+
+    # CSV columns in correct order for source of truth line generation
+    csv_columns = OrderedDict()
+
+    # Recovering values from WPGenerator or hardcode some
+    csv_columns['wp_site_url'] = wp_generator._site_params['wp_site_url']  # from csv
+    csv_columns['wp_tagline'] = wp_generator._site_params['wp_tagline']  # from parser
+    csv_columns['wp_site_title'] = wp_generator._site_params['wp_site_title']  # from parser
+    csv_columns['site_type'] = 'wordpress'
+    csv_columns['openshift_env'] = 'subdomains'
+    csv_columns['category'] = 'GeneralPublic'  # from csv
+    csv_columns['theme'] = wp_generator._site_params['theme']  # from csv
+    csv_columns['theme_faculty'] = wp_generator._site_params['theme_faculty']  # from parser
+    csv_columns['status'] = 'yes'
+    csv_columns['installs_locked'] = wp_generator._site_params['installs_locked']  # from csv (bool)
+    csv_columns['updates_automatic'] = wp_generator._site_params['updates_automatic']  # from csv (bool)
+    csv_columns['langs'] = wp_generator._site_params['langs']  # from parser
+    csv_columns['unit_name'] = wp_generator._site_params['unit_name']  # from csv
+    csv_columns['comment'] = 'Migrated from Jahia to WP'
+
+    # Formatting values depending on their type/content
+    for col in csv_columns:
+        # Bool are translated to 'yes' or 'no'
+        if isinstance(csv_columns[col], bool):
+            csv_columns[col] = 'yes' if csv_columns[col] else 'no'
+        # None become empty string
+        elif csv_columns[col] is None:
+            csv_columns[col] = ''
+
+    print("\nHere is the line with up-to-date information to add in source of truth:\n")
+    print('"{}"'.format('","'.join(csv_columns.values())))
 
     return wp_exporter
 

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -262,8 +262,8 @@ def _generate_csv_line(wp_generator):
         elif csv_columns[col] is None:
             csv_columns[col] = ''
 
-    print("\nHere is the line with up-to-date information to add in source of truth:\n")
-    print('"{}"'.format('","'.join(csv_columns.values())))
+    logging.info("Here is the line with up-to-date information to add in source of truth:\n")
+    logging.info('"%s"', '","'.join(csv_columns.values()))
 
 
 @dispatch.on('download')

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -227,6 +227,45 @@ def _add_extra_config(extra_config_file, current_config):
     return {**current_config, **extra_config}
 
 
+def _generate_csv_line(wp_generator):
+    """
+    Generate a CSV line to add to source of truth. The line contains information about exported WP site.
+
+    :param wp_generator: Object used to create WP website
+    :return:
+    """
+    # CSV columns in correct order for source of truth line generation
+    csv_columns = OrderedDict()
+
+    # Recovering values from WPGenerator or hardcode some
+    csv_columns['wp_site_url'] = wp_generator._site_params['wp_site_url']  # from csv
+    csv_columns['wp_tagline'] = wp_generator._site_params['wp_tagline']  # from parser
+    csv_columns['wp_site_title'] = wp_generator._site_params['wp_site_title']  # from parser
+    csv_columns['site_type'] = 'wordpress'
+    csv_columns['openshift_env'] = 'subdomains'
+    csv_columns['category'] = 'GeneralPublic'  # from csv
+    csv_columns['theme'] = wp_generator._site_params['theme']  # from csv
+    csv_columns['theme_faculty'] = wp_generator._site_params['theme_faculty']  # from parser
+    csv_columns['status'] = 'yes'
+    csv_columns['installs_locked'] = wp_generator._site_params['installs_locked']  # from csv (bool)
+    csv_columns['updates_automatic'] = wp_generator._site_params['updates_automatic']  # from csv (bool)
+    csv_columns['langs'] = wp_generator._site_params['langs']  # from parser
+    csv_columns['unit_name'] = wp_generator._site_params['unit_name']  # from csv
+    csv_columns['comment'] = 'Migrated from Jahia to WP'
+
+    # Formatting values depending on their type/content
+    for col in csv_columns:
+        # Bool are translated to 'yes' or 'no'
+        if isinstance(csv_columns[col], bool):
+            csv_columns[col] = 'yes' if csv_columns[col] else 'no'
+        # None become empty string
+        elif csv_columns[col] is None:
+            csv_columns[col] = ''
+
+    print("\nHere is the line with up-to-date information to add in source of truth:\n")
+    print('"{}"'.format('","'.join(csv_columns.values())))
+
+
 @dispatch.on('download')
 def download(site, username=None, host=None, zip_path=None, force=False, **kwargs):
     # prompt for password if username is provided
@@ -436,36 +475,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     wp_generator.uninstall_basic_auth_plugin()
     wp_generator.enable_updates_automatic_if_allowed()
 
-    # CSV columns in correct order for source of truth line generation
-    csv_columns = OrderedDict()
-
-    # Recovering values from WPGenerator or hardcode some
-    csv_columns['wp_site_url'] = wp_generator._site_params['wp_site_url']  # from csv
-    csv_columns['wp_tagline'] = wp_generator._site_params['wp_tagline']  # from parser
-    csv_columns['wp_site_title'] = wp_generator._site_params['wp_site_title']  # from parser
-    csv_columns['site_type'] = 'wordpress'
-    csv_columns['openshift_env'] = 'subdomains'
-    csv_columns['category'] = 'GeneralPublic'  # from csv
-    csv_columns['theme'] = wp_generator._site_params['theme']  # from csv
-    csv_columns['theme_faculty'] = wp_generator._site_params['theme_faculty']  # from parser
-    csv_columns['status'] = 'yes'
-    csv_columns['installs_locked'] = wp_generator._site_params['installs_locked']  # from csv (bool)
-    csv_columns['updates_automatic'] = wp_generator._site_params['updates_automatic']  # from csv (bool)
-    csv_columns['langs'] = wp_generator._site_params['langs']  # from parser
-    csv_columns['unit_name'] = wp_generator._site_params['unit_name']  # from csv
-    csv_columns['comment'] = 'Migrated from Jahia to WP'
-
-    # Formatting values depending on their type/content
-    for col in csv_columns:
-        # Bool are translated to 'yes' or 'no'
-        if isinstance(csv_columns[col], bool):
-            csv_columns[col] = 'yes' if csv_columns[col] else 'no'
-        # None become empty string
-        elif csv_columns[col] is None:
-            csv_columns[col] = ''
-
-    print("\nHere is the line with up-to-date information to add in source of truth:\n")
-    print('"{}"'.format('","'.join(csv_columns.values())))
+    _generate_csv_line(wp_generator)
 
     return wp_exporter
 


### PR DESCRIPTION
**From issue**: WWP-532

**High level changes:**

1. Ajout du nécessaire pour générer et afficher dans la console la ligne qu'il faut ajouter à la source de vérité pour un site qui vient d'être migré depuis Jahia à WordPress. Les données sont séparées par des virgules en entre double quotes afin de ne pas avoir de surprises (notamment s'il y a plusieurs langues pour le site).

Exemples de lignes générées (déploiement en local chez moi) :
> "https://jahia2wp-httpd","Print Center","REPRO","wordpress","subdomains","GeneralPublic","epfl-master","","yes","yes","yes","en,fr","idevelop","Migrated from Jahia to WP"
"https://jahia2wp-httpd/nal","Network Architecture Lab","","wordpress","subdomains","GeneralPublic","epfl-master","ic","yes","yes","yes","en","idevelop","Migrated from Jahia to WP"




**Targetted version**: x.x.x
