### PR TITLE
[WIP] Wwp 521 sidebar content too long

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -855,7 +855,7 @@ class WPExporter:
             # We skip this redirection to avoid infinite redirection...
             if element['jahia_url'] != "/index.html":
 
-                content.append("Redirect 301 {} {}".format(element['jahia_url'][1:],
+                content.append("Redirect 301 {} {}".format(element['jahia_url'],
                                                            urlparse(element['wp_url']).path))
 
         if content:


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Pour certains sites, comme genomic-resources, la sidebar contient 200 808 caractères. Pourquoi ?
Car il y a des commentaires du style <!--[if gte mso 10]>... qui permettent de styler le HTML dans outlook. L'idée de cette PR est de simplement supprimer tous les commentaires HTML de la sidebar.

**Low level changes:**

1. Clean HTML comments for the sidebar content

**Targetted version**: x.x.x
