### PR TITLE
Clean HTML comments

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -552,8 +552,12 @@ class WPExporter:
                         title = prepare_html("TODO: {}".format(box.title))
                         content = prepare_html(box.content)
 
-                    cmd = 'widget add {} page-widgets {} ' \
-                          '--text="{}" --title="{}"'.format(widget_type, widget_pos, content, title)
+                    cmd = 'widget add {} page-widgets {} --text="{}" --title="{}"'.format(
+                        widget_type,
+                        widget_pos,
+                        WPUtils.clean_html_comments(content),
+                        title
+                    )
 
                     self.run_wp_cli(cmd)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,6 +11,7 @@ import string
 import binascii
 import random
 import xml.dom.minidom
+import re
 
 from urllib.parse import urlsplit
 from bs4 import BeautifulSoup
@@ -396,3 +397,10 @@ class Utils(object):
                 fp.write(new_file_data)
                 fp.truncate(fp.tell())
                 fp.flush()
+
+    @staticmethod
+    def clean_html_comments(content):
+        """
+        Clean HTML comments
+        """
+        return re.sub("(<!--.*?-->)", "", content)


### PR DESCRIPTION
**From issue**: WWP-521 ?

**High level changes:**

1. Pour certains sites, comme genomic-resources, la sidebar contient 200 808 caractères. Pourquoi ?
Car il y a des commentaires du style <!--[if gte mso 10]>... qui permettent de styler le HTML dans outlook. L'idée de cette PR est de simplement supprimer tous les commentaires HTML de la sidebar.

Ci-dessous, quelques idées pour améliorer l'utilisation des commentaires conditionnels
https://stackoverflow.com/questions/11703684/using-ie-conditional-comments-inside-a-stylesheet

**Low level changes:**

1. Clean HTML comments for the sidebar content

**Targetted version**: x.x.x
