### PR TITLE
Ignore duplicated or unwanted text

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -96,7 +96,10 @@ class Box:
             content = ""
             elements = element.getElementsByTagName("text")
             for element in elements:
-                content += element.getAttribute("jahia:value")
+                # We have to skip 'text' element which are right under 'main' otherwise we have duplicated text
+                # displayed in page.
+                if element.parentNode.nodeName != 'main':
+                    content += element.getAttribute("jahia:value")
             self.content = content
 
     def set_box_actu(self, element):


### PR DESCRIPTION
**From issue**: WWP-571

**High level changes:**

1. Suppression de parties de pages (textes principalement) qui étaient affichées alors qu'il ne fallait pas.

**Low level changes:**

1. Ajout d'un test pour les boîtes textes "multibox" afin d'ignorer les éléments `<text>` ayant comme parent direct `<main>`. Il arrive en effet parfois qu'une balise `<text>` se retrouve directement sous `<main>` et celle-ci contient du texte qui ne doit pas être affiché sur la page. S'agit-il d'un problème Jahia lors de l'export? aucune idée... mais en ajoutant cette condition, l'export du contenu du site PBL passe correctement.

**Notes**

J'ai aussi exporté un autre site (master) afin de voir si tout était OK suite à la condition ajoutée dans le code et je n'ai pas vu de problème.

**Targetted version**: x.x.x
