### PR TITLE
Handle custom header ('epfl-blank' theme)

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -240,7 +240,6 @@ class WPExporter:
             self.report['failed_files'] += 1
             raise e
 
-
     def import_breadcrumb(self):
         """
         Import breadcrumb in default language by setting correct option in DB

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -74,7 +74,7 @@ from crawler import JahiaCrawler
 from exporter.wp_exporter import WPExporter
 from parser.jahia_site import Site
 from settings import VERSION, FULL_BACKUP_RETENTION_THEME, INCREMENTAL_BACKUP_RETENTION_THEME, \
-    DEFAULT_THEME_NAME, DEFAULT_CONFIG_INSTALLS_LOCKED, DEFAULT_CONFIG_UPDATES_AUTOMATIC
+    DEFAULT_THEME_NAME, BANNER_THEME_NAME, DEFAULT_CONFIG_INSTALLS_LOCKED, DEFAULT_CONFIG_UPDATES_AUTOMATIC
 from tracer.tracer import Tracer
 from unzipper.unzip import unzip_one
 from utils import Utils
@@ -413,6 +413,10 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
         wp_tagline = None
     else:
         wp_tagline = site.title[default_language]
+
+    if not theme:
+        # Setting correct theme depending on parsing result
+        theme = BANNER_THEME_NAME if default_language in site.banner else DEFAULT_THEME_NAME
 
     info = {
         # information from parser

--- a/src/parser/banner.py
+++ b/src/parser/banner.py
@@ -4,6 +4,7 @@
 from bs4 import BeautifulSoup
 import re
 
+
 class Banner:
     """ To store website banner information. """
 

--- a/src/parser/banner.py
+++ b/src/parser/banner.py
@@ -1,0 +1,27 @@
+"""(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
+
+
+from bs4 import BeautifulSoup
+import re
+
+class Banner:
+    """ To store website banner information. """
+
+    # FIXME: extend class with more information if html content is not enough to handle banner
+    def __init__(self, content):
+        """ Constructor
+
+        content - HTML content of the banner """
+
+        # If there are image in banner, they may have following code aspect, so cleaning is necessary :
+        # ###file:/content/sites/skyrmions/files/Image-1.jpg?uuid=default:d1c1c1d4-7d23-45d7-b6fc-c10df12ef91e
+        soup = BeautifulSoup(content, 'html.parser')
+
+        images = soup.find_all('img')
+
+        for image in images:
+            # Cleaning image source
+            # FIXME: Maybe there's a better way to remove the /content/sites/<sitename> from URL...
+            image['src'] = re.sub(r"###file:/content/sites/[a-zA-Z0-9-\.]+|\?.+", "", image.get('src'))
+
+        self.content = str(soup)

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -735,4 +735,3 @@ Parsed for %s :
 
         for tag in num_tags_ordered:
             self.report += "    - <%s> %s\n" % (tag, self.num_tags[tag])
-

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -12,7 +12,9 @@ from parser.page import Page
 from parser.page_content import PageContent
 from parser.sitemap_node import SitemapNode
 from parser.menu_item import MenuItem
+from parser.banner import Banner
 from utils import Utils
+
 
 """
 This file is named jahia_site to avoid a conflict with Site [https://docs.python.org/3/library/site.html]
@@ -67,6 +69,10 @@ class Site:
         self.breadcrumb_title = {}
         self.breadcrumb_url = {}
 
+        # Banner (may stay empty if no custom banner defined)
+        # Dict with language as key and Banner object as value
+        self.banner = {}
+
         # footer
         self.footer = {}
 
@@ -94,7 +100,6 @@ class Site:
         self.num_templates = {}
         # the number of each html tags, e.g. "br": 10
         self.num_tags = {}
-        self.num_url_menu_root = 0
         # we have a SitemapNode for each language
         self.sitemaps = {}
         self.report = ""
@@ -233,6 +238,17 @@ class Site:
 
                     self.parse_menu_entries(language, nav_list_list, None)
 
+    def parse_banner(self):
+        """ Extracting banner information if found """
+        for language, dom_path in self.export_files.items():
+            dom = Utils.get_dom(dom_path)
+
+            banner_list_list = dom.getElementsByTagName("bannerListList")
+            # If banner information is found
+            if banner_list_list:
+                # Adding banner for current lang
+                self.banner[language] = Banner(Utils.get_tag_attribute(banner_list_list[0], "banner", "jahia:value"))
+
     def get_report_info(self, box_types):
         """
         Return the report info as a dict. As an argument you can
@@ -266,6 +282,7 @@ class Site:
         self.parse_site_params()
         self.parse_menu()
         self.parse_breadcrumb()
+        self.parse_banner()
         self.parse_footer()
         self.parse_pages()
         self.parse_pages_content()
@@ -710,7 +727,7 @@ Parsed for %s :
         self.report += "    - %s anchor links\n" % self.anchor_links
         self.report += "    - %s broken links\n" % self.broken_links
         self.report += "    - %s unknown links\n" % self.unknown_links
-        self.report += "    - %s root menu entries with URLs\n" % self.num_url_menu_root
+        self.report += "    - %s menu entries with URLs\n" % self.num_url_menu
 
         # tags
         self.report += "\n"

--- a/src/settings.py
+++ b/src/settings.py
@@ -95,6 +95,7 @@ DEFAULT_CONFIG_INSTALLS_LOCKED = True
 DEFAULT_CONFIG_UPDATES_AUTOMATIC = True
 
 DEFAULT_THEME_NAME = 'epfl-master'
+BANNER_THEME_NAME = 'epfl-blank'
 
 PLUGINS_CONFIG_BASE_PATH = Utils.get_optional_env(
     "PLUGINS_CONFIG_BASE_PATH", os.path.sep.join(['..', 'data', 'plugins']))

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -174,10 +174,10 @@ class WPGenerator:
         # install and configure theme (default is settings.DEFAULT_THEME_NAME)
         logging.info("%s - Installing all themes...", repr(self))
         WPThemeConfig.install_all(self.wp_site)
-        logging.info("%s - Activating theme...", repr(self))
+        logging.info("%s - Activating theme '%s'...", repr(self), self._site_params['theme'])
         theme = WPThemeConfig(self.wp_site, self._site_params['theme'], self._site_params['theme_faculty'])
         if not theme.activate():
-            logging.error("%s - could not activate theme", repr(self))
+            logging.error("%s - could not activate theme '%s'", repr(self), self._site_params['theme'])
             return False
 
         # install, activate and config mu-plugins


### PR DESCRIPTION
**From issue**: WWP-565

**High level changes:**

1. Ajout de la gestion du thème "epfl-blank" afin de pouvoir avoir un header différent que celui par défaut.

**Low level changes:**

1. Les infos de la banner se trouvent dans le fichier XML d'export. C'est du simple code HTML. Celui-ci a donc été repris et mis dans une Widget de type "text" car c'est un espace pour les Widgets (donc une sidebar selon le terme utilisé dans WordPress) qui a été ajouté en haut du thème par Aline.
1. La mise à jour des liens de la nouvelle widget a été faite pour que les images présentes dedans soient bien affichées.
1. Ajout d'une classe `Banner` pour gérer les infos de la banner en haut du site. La classe est relativement simple pour le moment mais pourrait être amenée à évoluer.
1. S'il y a des banners différentes pour les langues du site, c'est aussi géré.
1. Amélioration de la fonction de nettoyage des Widgets car en fait, ça ne nettoyait rien... seule une sidebar était "nettoyée" mais elle était déjà vide. Maintenant, les sidebar existantes sont listées puis pour chacune, toutes les widgets présentes sont supprimées.

**Notes**

L'affichage se fait correctement mais il y a des espaces verticaux de tailles différentes entre le site WP et Jahia. Il faudra voir en fonction des retours des webmasters mais à priori, les corrections devront plutôt être faites au niveau du thème par Aline.
Sites testés:
- https://skyrmions.epfl.ch
- https://www.fix-the-leaky-pipeline.ch



**Targetted version**: x.x.x
