### PR TITLE
Add mkdir of /srv/${WP_ENV}/jahia2wp

### DIFF
--- a/build/httpd/docker-entrypoint.sh
+++ b/build/httpd/docker-entrypoint.sh
@@ -24,6 +24,7 @@ VirtualDocumentRoot "/srv/${WP_ENV}/%0/htdocs"
 EOF
 
 /bin/mkdir -p /srv/${WP_ENV}/logs
+/bin/mkdir -p /srv/${WP_ENV}/jahia2wp
 /bin/chown www-data: /srv/${WP_ENV}
 /bin/chown www-data: /srv/${WP_ENV}/logs
 /bin/chown www-data: /srv/${WP_ENV}/jahia2wp


### PR DESCRIPTION
Container will fail to start for an environment (WP_ENV) who has never been populated. The chown on /srv/${WP_ENV}/jahia2wp fail.