### PR TITLE
Fix internal link lang

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -389,31 +389,6 @@ class WPExporter:
         data = {"content": content}
         return self.wp.post_pages(page_id=page_id, data=data)
 
-    def import_page(self, slug, title, content):
-
-        wp_page_info = {
-            # date: auto => date/heure du jour
-            # date_gmt: auto => date/heure du jour GMT
-            'slug': slug,
-            'status': 'publish',
-            # password
-            'title': title,
-            'content': content,
-            # author
-            # excerpt
-            # featured_media
-            # comment_status: 'closed'
-            # ping_status: 'closed'
-            # format
-            # meta
-            # sticky
-            # template
-            # categories
-            # tags
-        }
-
-        return self.wp.post_pages(data=wp_page_info)
-
     def import_pages(self):
         """
         Import all pages of jahia site to Wordpress

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -3,6 +3,7 @@
 import os
 import logging
 import collections
+import re
 
 from bs4 import BeautifulSoup
 from parser.box import Box
@@ -544,14 +545,32 @@ class Site:
             # /cms/op/edit/PAGE_NAME or
             # /cms/site/SITE_NAME/op/edit/lang/LANGUAGE/PAGE_NAME
             elif "/op/edit/" in link:
+                # To have /PAGE_NAME$
+                # or /lang/LANGUAGE/PAGE_NAME
                 new_link = link[link.index("/op/edit") + 8:]
 
+                # if link like /lang/LANGUAGE/PAGE_NAME
                 if new_link.startswith("/lang/"):
+                    link_lang = new_link.split("/")[2]
+                    # To have /PAGE_NAME
                     new_link = new_link[8:]
+
+                else:  # Link like /PAGE_NAME
+                    # Site has probably only one language so we take it to build new URL
+                    link_lang = self.languages[0]
+
+                # If link doesn't contains lang => /page-92507.html
+                # We transform it to => /page-92507-<defaultLang>.html
+                reg = re.compile("/page-[0-9]+\.html")
+                if reg.match(new_link):
+                    link_parts = new_link.split(".")
+                    # Adding default language to link
+                    new_link = "{}-{}.{}".format(link_parts[0], link_lang, link_parts[1])
 
                 tag[attribute] = new_link
 
                 self.internal_links += 1
+
             # internal links written by hand, e.g.
             # /team
             # /page-92507-fr.html


### PR DESCRIPTION
**From issue**: WWP-586

**High level changes:**

1. Ajout de la gestion des liens internes qui n'ont pas de langue dans le lien. 

**Low level changes:**

1. Lors de l'ajout des pages, on fait en sorte de mettre la langue dans le slug. Cependant, dans le cas où le site était seulement en une seule langue, les liens internes du site n'étaient pas mis à jour correctement. L'id de la langue (unique) du site n'était pas ajoutée aux liens.
1. Suppression d'une méthode plus utilisée nulle part dans `WPExporter`

**Targetted version**: x.x.x
