### PR TITLE
remove unwanted spaces in urls

### DIFF
--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -8,6 +8,8 @@ class MenuItem:
 
         self.txt = txt
         self.target_url = target_url
+        if self.target_url:
+            self.target_url = self.target_url.strip()
         self.hidden = hidden
         self.children = []
         self.children_sort_way = None


### PR DESCRIPTION
**From issue**: WWP-595

Sur le site lme, une des entrées de menu se retouve avec une URL statique contenant un espace, du coup le match `is_url` ne se fait pas correctement et l'export plante car on entre dans le else alors qu'on ne devrait pas

**High level changes:**

**Low level changes:**

1. strip() spaces in target_url in menu_item objects

**Targetted version**: x.x.x
