### PR TITLE
Bugfixes: infinite redirect (redirect to same page), subfoler handling

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -971,6 +971,12 @@ class WPExporter:
         """
         redirect_list = []
 
+        # Init WP install folder path for source URLs
+        if self.wp_generator.wp_site.folder == "":
+            folder = ""
+        else:
+            folder = "/{}".format(self.wp_generator.wp_site.folder)
+
         # Add all rewrite jahia URI to WordPress URI
         for element in self.urls_mapping:
 
@@ -981,7 +987,10 @@ class WPExporter:
 
                 # We skip this redirection to avoid infinite redirection...
                 if jahia_url != "/index.html":
-                    redirect_list.append("Redirect 301 {} {}".format(jahia_url, wp_url))
+                    source_url = "{}{}".format(folder, jahia_url)
+                    # To avoid Infinite loop
+                    if source_url != wp_url[:-1]:
+                        redirect_list.append("Redirect 301 {} {}".format(source_url,  wp_url))
 
         if redirect_list:
             # Updating .htaccess file


### PR DESCRIPTION
**From issue**: WWP-594

**High level changes:**

1. Correction des redirections infinies dans le cas où la vanity URL égale le nom de la page
1. Gestion du fait que le site soit déployé dans un sous-dossier (ça ne fonctionnait que pour les sites en mode "subdomains"). Cela pouvait poser problème dans le cas où on avait une vanity URL égale au nom du dossier dans lequel le site était déployé


**Targetted version**: x.x.x
