### PR TITLE
Handle links to other pages in menu entries

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -736,7 +736,8 @@ class WPExporter:
                     child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
 
                     if child is None:
-                        raise Exception("Submenu creation: No page found for UUID {}".format(menu_item.target))
+                        logging.error("Submenu creation: No page found for UUID %s", menu_item.target)
+                        continue
 
                     if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
                             child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
@@ -832,7 +833,8 @@ class WPExporter:
                             homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
 
                             if homepage_child is None:
-                                raise Exception("Menu creation: No page found for UUID {}".format(menu_item.target))
+                                logging.error("Menu creation: No page found for UUID %s", menu_item.target)
+                                continue
 
                             if lang not in homepage_child.contents:
                                 logging.warning("Page not translated %s" % homepage_child.pid)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -709,10 +709,12 @@ class WPExporter:
 
         for sub_entry_index, menu_item in enumerate(parent_menu_item.children):
 
-            # If menu entry is an hardcoded URL
-            if menu_item.target_is_url() or menu_item.target_is_sitemap():
-                # If entry is visible
-                if not menu_item.hidden:
+            # If entry is visible
+            if not menu_item.hidden:
+
+                # If menu entry is an hardcoded URL
+                if menu_item.target_is_url() or menu_item.target_is_sitemap():
+
                     # Recovering URL
                     url = menu_item.target
 
@@ -728,16 +730,13 @@ class WPExporter:
                     else:
                         self.report['menus'] += 1
 
-            # menu entry is page
-            else:
-                # Trying to get corresponding page corresponding to current page UUID
-                child = parent_page.get_child_with_uuid(menu_item.target)
+                # menu entry is page
+                else:
+                    # Trying to get corresponding page corresponding to current page UUID
+                    child = parent_page.get_child_with_uuid(menu_item.target)
 
-                if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
-                        child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
-
-                    # If entry is visible
-                    if not menu_item.hidden:
+                    if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
+                            child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
 
                         command = 'menu item add-post {} {} --parent-id={} --porcelain' \
                             .format(menu_name, child.contents[lang].wp_id, parent_menu_id)
@@ -787,27 +786,28 @@ class WPExporter:
 
                 # In the following loop, we will have two differents sources for menu entries and their children.
                 # One is "self.site.menus[lang]" and is containing all the root menus and their submenus.
-                # Those menus entries are for existing WordPress pages OR are hardcoded URLs. For
-                # hardcoded URL, the URL has been recovered in the parser and is present in the structure. For
-                # WordPress pages, we have info about menu title and page pid.
+                # Those menus entries are for existing WordPress pages OR are hardcoded URLs OR references to
+                # other pages already pointed by another menu entry.
+                # For hardcoded URL, the URL has been recovered in the parser and is present in the structure.
+                # For WordPress pages and references, we have info about menu title and page uuid.
                 # The other is "self.site.homepage.children" and is containing pages and subpages existing in
                 # WordPress (used to build the menu) but we don't have any information about hardcoded URL here.
                 # So, all the information we need to create the menu is splitted between two different sources...
                 # and the goal of the following loop is to go through the first structure (which contains all the
-                # menu entries) and every time we encounter a WordPress page, we take the next available item in
-                # the second list (which contains information about pointed page name). The information in the second
-                # structure is also used to build submenus.
+                # menu entries) and every time we encounter a WordPress page, we look for the corresponding item in
+                # the second list (which contains information about pointed page id in WP).
 
                 # Looping through root menu entries
                 for root_entry_index, menu_item in enumerate(self.site.menus[lang]):
 
-                    # FIXME: Sub menu entries for menu entries which are hardcoded URL are not handled here
-                    # If root menu entry is an hardcoded URL
-                    # OR a sitemap link
-                    if menu_item.target_is_url() or \
-                            menu_item.target_is_sitemap():
-                        # If root entry is visible
-                        if not menu_item.hidden:
+                    # If root entry is visible
+                    if not menu_item.hidden:
+
+                        # If root menu entry is an hardcoded URL
+                        # OR a sitemap link
+                        if menu_item.target_is_url() or \
+                                menu_item.target_is_sitemap():
+
                             # Recovering URL
                             url = menu_item.target
 
@@ -823,17 +823,14 @@ class WPExporter:
                             else:
                                 self.report['menus'] += 1
 
-                    # root menu entry is pointing to a page
-                    else:
-                        # Trying to get corresponding page corresponding to current page UUID
-                        homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target)
+                        # root menu entry is pointing to a page
+                        else:
+                            # Trying to get corresponding page corresponding to current page UUID
+                            homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target)
 
-                        if lang not in homepage_child.contents:
-                            logging.warning("Page not translated %s" % homepage_child.pid)
-                            continue
-
-                        # If root entry is visible
-                        if not menu_item.hidden:
+                            if lang not in homepage_child.contents:
+                                logging.warning("Page not translated %s" % homepage_child.pid)
+                                continue
 
                             if homepage_child.contents[lang].wp_id:
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -314,10 +314,10 @@ class WPExporter:
 
     def fix_file_links_in_menu_items(self, menu_item, old_url, new_url):
         if menu_item.target_is_file():
-                normalized_url = menu_item.target_url.encode('ascii', 'replace').decode('ascii').replace('?', '')
+                normalized_url = menu_item.target.encode('ascii', 'replace').decode('ascii').replace('?', '')
                 normalized_url = normalized_url[normalized_url.rfind("/files"):]
                 if normalized_url == old_url.replace('?', ''):
-                    menu_item.target_url = new_url
+                    menu_item.target = new_url
 
     def fix_file_links_in_menus(self, old_url, new_url):
         for lang in self.site.languages:
@@ -690,22 +690,22 @@ class WPExporter:
         # Report
         self.report['menus'] += 2
 
-    def create_submenu(self, children, parent_menu_item, lang, menu_name, parent_menu_id):
+    def create_submenu(self, parent_page, parent_menu_item, lang, menu_name, parent_menu_id):
         """
         Create recursively submenus for one main menu entry
 
-        children - children pages of main menu entry
+        parent_page - parent page for which we have to create submenu
         parent_menu_item - MenuItem object coming from self.menus and representing parent of submenu entries to create
         lang - language
         menu_name - name of WP menu where to put sub-menu entries
         parent_menu_id - ID of parent menu (in WP) of submenu we have to create
         """
-        child_index = 0
 
         # If the sub-entries are sorted
         if parent_menu_item.children_sort_way is not None:
             # Sorting information in the other structure storing the menu information
-            children.sort(key=lambda x: x.contents[lang].title, reverse=(parent_menu_item.children_sort_way == 'desc'))
+            parent_page.children.sort(key=lambda x: x.contents[lang].title,
+                                      reverse=(parent_menu_item.children_sort_way == 'desc'))
 
         for sub_entry_index, menu_item in enumerate(parent_menu_item.children):
 
@@ -714,7 +714,7 @@ class WPExporter:
                 # If entry is visible
                 if not menu_item.hidden:
                     # Recovering URL
-                    url = menu_item.target_url
+                    url = menu_item.target
 
                     # If menu entry is sitemap, we add WP site base URL
                     if menu_item.target_is_sitemap():
@@ -730,8 +730,8 @@ class WPExporter:
 
             # menu entry is page
             else:
-                child = children[child_index]
-                child_index += 1
+                # Trying to get corresponding page corresponding to current page UUID
+                child = parent_page.get_child_with_uuid(menu_item.target)
 
                 if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
                         child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
@@ -749,7 +749,7 @@ class WPExporter:
                             self.menu_id_dict[child.contents[lang].wp_id] = Utils.get_menu_id(menu_id)
                             self.report['menus'] += 1
 
-                        self.create_submenu(child.children,
+                        self.create_submenu(child,
                                             menu_item,
                                             lang,
                                             menu_name,
@@ -786,30 +786,30 @@ class WPExporter:
                         self.report['menus'] += 1
 
                 # In the following loop, we will have two differents sources for menu entries and their children.
-                # One is "self.site.menus[lang]" and is containing all the root menus and their submenus (only
-                # one level for now). Those menus entries are for existing WordPress pages OR are hardcoded URLs. For
-                # hardcoded URL, the URL has been recovered in the parser and is present in the structure. But for
-                # WordPress pages, we only have info about menu title but not about pointed page.
+                # One is "self.site.menus[lang]" and is containing all the root menus and their submenus.
+                # Those menus entries are for existing WordPress pages OR are hardcoded URLs. For
+                # hardcoded URL, the URL has been recovered in the parser and is present in the structure. For
+                # WordPress pages, we have info about menu title and page pid.
                 # The other is "self.site.homepage.children" and is containing pages and subpages existing in
                 # WordPress (used to build the menu) but we don't have any information about hardcoded URL here.
                 # So, all the information we need to create the menu is splitted between two different sources...
                 # and the goal of the following loop is to go through the first structure (which contains all the
                 # menu entries) and every time we encounter a WordPress page, we take the next available item in
-                # the second list (which contains information about pointed page). The information in the second
+                # the second list (which contains information about pointed page name). The information in the second
                 # structure is also used to build submenus.
-                child_index = 0
 
                 # Looping through root menu entries
                 for root_entry_index, menu_item in enumerate(self.site.menus[lang]):
 
                     # FIXME: Sub menu entries for menu entries which are hardcoded URL are not handled here
                     # If root menu entry is an hardcoded URL
+                    # OR a sitemap link
                     if menu_item.target_is_url() or \
                             menu_item.target_is_sitemap():
                         # If root entry is visible
                         if not menu_item.hidden:
                             # Recovering URL
-                            url = menu_item.target_url
+                            url = menu_item.target
 
                             # If menu entry is sitemap, we add WP site base URL
                             if menu_item.target_is_sitemap():
@@ -823,11 +823,10 @@ class WPExporter:
                             else:
                                 self.report['menus'] += 1
 
-                    # root menu entry is page
+                    # root menu entry is pointing to a page
                     else:
-                        # Getting next child containing information about pointed WordPress page.
-                        homepage_child = self.site.homepage.children[child_index]
-                        child_index += 1
+                        # Trying to get corresponding page corresponding to current page UUID
+                        homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target)
 
                         if lang not in homepage_child.contents:
                             logging.warning("Page not translated %s" % homepage_child.pid)
@@ -837,6 +836,7 @@ class WPExporter:
                         if not menu_item.hidden:
 
                             if homepage_child.contents[lang].wp_id:
+
                                 cmd = 'menu item add-post {} {} --porcelain' \
                                       .format(menu_name, homepage_child.contents[lang].wp_id)
                                 menu_id = self.run_wp_cli(cmd)
@@ -847,7 +847,7 @@ class WPExporter:
                                     self.report['menus'] += 1
 
                                 # create recursively submenus
-                                self.create_submenu(homepage_child.children,
+                                self.create_submenu(homepage_child,
                                                     menu_item,
                                                     lang,
                                                     menu_name,

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -735,6 +735,9 @@ class WPExporter:
                     # Trying to get corresponding page corresponding to current page UUID
                     child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
 
+                    if child is None:
+                        raise Exception("Submenu creation: No page found for UUID {}".format(menu_item.target))
+
                     if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
                             child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
 
@@ -827,6 +830,9 @@ class WPExporter:
                         else:
                             # Trying to get corresponding page corresponding to current page UUID
                             homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
+
+                            if homepage_child is None:
+                                raise Exception("Menu creation: No page found for UUID {}".format(menu_item.target))
 
                             if lang not in homepage_child.contents:
                                 logging.warning("Page not translated %s" % homepage_child.pid)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -733,7 +733,7 @@ class WPExporter:
                 # menu entry is page
                 else:
                     # Trying to get corresponding page corresponding to current page UUID
-                    child = parent_page.get_child_with_uuid(menu_item.target)
+                    child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
 
                     if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
                             child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
@@ -826,7 +826,7 @@ class WPExporter:
                         # root menu entry is pointing to a page
                         else:
                             # Trying to get corresponding page corresponding to current page UUID
-                            homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target)
+                            homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
 
                             if lang not in homepage_child.contents:
                                 logging.warning("Page not translated %s" % homepage_child.pid)

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -98,6 +98,7 @@ class Site:
         self.unknown_links = 0
         self.num_boxes = {}
         self.num_url_menu = 0
+        self.num_link_menu = 0
         self.num_templates = {}
         # the number of each html tags, e.g. "br": 10
         self.num_tags = {}
@@ -191,13 +192,19 @@ class Site:
                         txt = jahia_type.getAttribute("jahia:title")
                         hidden = jahia_type.getAttribute("jahia:hideFromNavigationMenu") != ""
                         target = "sitemap" if jahia_type.getAttribute("jahia:template") == "sitemap" \
-                            else None
+                            else jahia_type.getAttribute("jcr:uuid")
                     # If URL
                     elif jahia_type.nodeName == "jahia:url":
                         txt = jahia_type.getAttribute("jahia:title")
                         target = jahia_type.getAttribute("jahia:value")
 
                         self.num_url_menu += 1
+                    # If link to another page in the menu
+                    elif jahia_type.nodeName == "jahia:link":
+                        txt = jahia_type.getAttribute("jahia:title")
+                        target = jahia_type.getAttribute("jahia:reference")
+
+                        self.num_link_menu += 1
                     else:
                         continue
 
@@ -748,6 +755,7 @@ Parsed for %s :
         self.report += "    - %s broken links\n" % self.broken_links
         self.report += "    - %s unknown links\n" % self.unknown_links
         self.report += "    - %s menu entries with URLs\n" % self.num_url_menu
+        self.report += "    - %s duplicate menu entries to page\n" % self.num_link_menu
 
         # tags
         self.report += "\n"

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -4,24 +4,39 @@
 class MenuItem:
     """ To store menu item information """
 
-    def __init__(self, txt, target_url, hidden):
+    def __init__(self, txt, target, hidden):
+        """ Constructor
 
+        txt - Menu link text
+        target - Can be several things
+            -- Reference to another jahia page,using its uuid (like c058dc4f-247d-4b23-90d7-25e1206f7de3)
+            -- hardcoded URL (absolute URL)
+            -- link to sitemap (so equals 'sitemap')
+            -- hardcoded URL to file (includes '/files/' in string)
+            -- None if normal menu entry for page
+        """
         self.txt = txt
-        self.target_url = target_url
-        if self.target_url:
-            self.target_url = self.target_url.strip()
+        self.target = target
+        if self.target:
+            self.target = self.target.strip()
         self.hidden = hidden
         self.children = []
         self.children_sort_way = None
 
     def target_is_url(self):
-        return False if self.target_url is None else self.target_url.startswith('http')
+        return False if self.target is None else self.target.startswith('http')
 
     def target_is_sitemap(self):
-        return self.target_url == "sitemap"
+        return self.target == "sitemap"
 
     def target_is_file(self):
-        return False if self.target_url is None else '/files/' in self.target_url
+        return False if self.target is None else '/files/' in self.target
+
+    def target_is_reference(self):
+        # If it is not another possibility, it is a reference
+        return not self.target_is_sitemap() and \
+            not self.target_is_url() and \
+            self.target is not None
 
     def sort_children(self, sort_way):
         self.children_sort_way = sort_way

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -32,12 +32,6 @@ class MenuItem:
     def target_is_file(self):
         return False if self.target is None else '/files/' in self.target
 
-    def target_is_reference(self):
-        # If it is not another possibility, it is a reference
-        return not self.target_is_sitemap() and \
-            not self.target_is_url() and \
-            self.target is not None
-
     def sort_children(self, sort_way):
         self.children_sort_way = sort_way
         self.children.sort(key=lambda x: x.txt, reverse=(sort_way == 'desc'))

--- a/src/parser/page.py
+++ b/src/parser/page.py
@@ -72,21 +72,26 @@ class Page:
 
                 parent_page = parent_page.parent
 
-    def get_child_with_uuid(self, uuid):
+    def get_child_with_uuid(self, uuid, nb_recurse_max):
         """
         Returns child which have a jahia UUID equal to the one given as parameter
         :param uuid: UUID of the page we look for
+        :param nb_recurse_max: Max number of recursive calls. This is to avoid infinite loop if circular references
+                               between pages.
         :return: Page object or None if not found.
         """
         for child in self.children:
             # If found at this level
             if child.uuid == uuid:
                 return child
-            # Not found a this level, recurse search to next level
-            result = child.get_child_with_uuid(uuid)
-            # If found, return
-            if result is not None:
-                return result
+
+            # If we can go to next level
+            if nb_recurse_max > 0:
+                # Not found a this level, recurse search to next level
+                result = child.get_child_with_uuid(uuid, nb_recurse_max-1)
+                # If found, return
+                if result is not None:
+                    return result
 
         return None
 

--- a/src/parser/page.py
+++ b/src/parser/page.py
@@ -72,5 +72,23 @@ class Page:
 
                 parent_page = parent_page.parent
 
+    def get_child_with_uuid(self, uuid):
+        """
+        Returns child which have a jahia UUID equal to the one given as parameter
+        :param uuid: UUID of the page we look for
+        :return: Page object or None if not found.
+        """
+        for child in self.children:
+            # If found at this level
+            if child.uuid == uuid:
+                return child
+            # Not found a this level, recurse search to next level
+            result = child.get_child_with_uuid(uuid)
+            # If found, return
+            if result is not None:
+                return result
+
+        return None
+
     def __str__(self):
         return self.pid + " " + self.template


### PR DESCRIPTION
**From issue**: WWP-587

**High level changes:**

1. Ajout de la gestion des entrées de menu de type `jahia:link` qui pointent sur une page qui est déjà référencées dans une autre entrée de menu (ex: site http://lte.epfl.ch > "Open Positions")
1. Un effet de bord a été constaté au niveau du thème pour ce genre de page. En effet, à la fois l'entrée de menu initialement `jahia:link` ET l'entrée de menu référençant la page en premier lieu sont sur fond noir. Mais il est probable que ça soit un comportement WordPress complètement standard.

**Low level changes:**

1. Renommage d'une donnée membre de `MenuItem` de `target_url` en `target` car elle peut maintenant contenir divers types de cibles.
1. Modification du parser du menu pour enregistrer aussi les `uuid` des pages afin de plus facilement reconstruire le menu WordPress par la suite
1. Utilisation des `uuid` de pages afin de retrouver exactement la page pointée (via recherche récursive) par l'entrée de menu lors de la reconstruction. Ceci permet aussi de résoudre le problème d'import foireux d'un site que Gil rencontrait 1 fois sur 5.
1. La recherche récursive mentionnée avant est faite uniquement jusqu'à une profondeur donnée (via paramètre) car il me semble qu'il y avait un problème de référence circulaire entre les pages. Ceci permettra d'éviter de tomber dedans.
1. Si la recherche récursive de la page échoue (rien trouvé), une exception est levée.
1. Dans `WPExporter`, un `if` était fait dans les 2 possibilités d'un autre `if` donc celui-ci a été remonté d'un niveau afin qu'il ne soit effectué qu'une seule fois.

**Targetted version**: x.x.x
