### PR TITLE
Handle case when link references non-existing jahia page

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -227,7 +227,12 @@ class Box:
                 if jahia_tag.ELEMENT_NODE != jahia_tag.nodeType:
                     continue
                 if jahia_tag.tagName == "jahia:link":
-                    page = self.site.pages_by_uuid[jahia_tag.getAttribute("jahia:reference")]
+                    # It happens that a link references a page that does not exist anymore
+                    # observed on site dii
+                    try:
+                        page = self.site.pages_by_uuid[jahia_tag.getAttribute("jahia:reference")]
+                    except KeyError as e:
+                        continue
                     content += '<li><a href="{}">{}</a></li>'.format(page.pid, jahia_tag.getAttribute("jahia:title"))
                 elif jahia_tag.tagName == "jahia:url":
                     url = jahia_tag.getAttribute("jahia:value")


### PR DESCRIPTION
**From issue**: WWP-603

Sur le site DII, le lien "Informatic (IT)" se trouvant dans la sidebar à droite de la page https://dii.epfl.ch/page-18534-en.html pointe apparemment sur une page de dit.epfl.ch, mais redirige sur it.epfl.ch quand on clique dessus. De mon côté j'ai un erreur de référence vers un UUID inconnu pendant le parsing. Je pense qu'ils ont tenté de cross-référencé des pages jahia entre les sites dit.epfl et dii.epfl.ch en utilisant les UUID plutot que les URLs, chose que l'on ne peut pas gérer vu qu'on importe les sites un par un.

**Low level changes:**

1. Add a try catch when trying to find a page from reference when parsing <jahia:link> tags in boxes

**Targetted version**: x.x.x
