### PR TITLE
Remove SVG plugin banner display in wp-admin

### DIFF
--- a/data/plugins/generic/svg-support/v1/config-plugin.yml
+++ b/data/plugins/generic/svg-support/v1/config-plugin.yml
@@ -1,2 +1,8 @@
 src: web
 activate: yes
+tables:
+  options:
+  - autoload: 'yes'
+    option_id: 255
+    option_name: bodhi_svgs_admin_notice_dismissed
+    option_value: '1'


### PR DESCRIPTION
**From issue**: WWP-609

**High level changes:**

1. Le plugin SVG affichait une banner pour activer le mode "advanced". Ce fix masque la bannière.

**Targetted version**: x.x.x
