### PR TITLE
Fix rotate backup 

### DIFF
--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -5,6 +5,6 @@ django==1.11.5
 clint==0.5.1
 PyYAML==3.12
 PyMySQL==0.7.11
-git+https://github.com/GregLeBarbar/python-rotate-backups.git
+git+https://github.com/epfl-idevelop/python-rotate-backups.git
 simplejson==3.11.1
 git+https://github.com/epfl-idevelop/python-wordpress-json.git

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -5,6 +5,6 @@ django==1.11.5
 clint==0.5.1
 PyYAML==3.12
 PyMySQL==0.7.11
-rotate-backups==4.4
+git+https://github.com/GregLeBarbar/python-rotate-backups.git
 simplejson==3.11.1
 git+https://github.com/epfl-idevelop/python-wordpress-json.git


### PR DESCRIPTION
**From issue**: WWP-533

**High level changes:**

1. Fixe un bug dans la librairie python-rotate-backups 

**Low level changes:**

1. Lorsque le nom du site comporte une année (exemple: 2doptoelectronics2018) la librairie prend en compte l'année pour calculer le timestamp => BUG

**Targetted version**: x.x.x
