### PR TITLE
Add default lang info in WPExporter to set correct default lang

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -455,7 +455,8 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     wp_exporter = WPExporter(
         site,
         wp_generator,
-        output_dir
+        default_language,
+        output_dir=output_dir
     )
 
     if to_wordpress:


### PR DESCRIPTION
**From issue**: WWP-604

**High level changes:**

1. La langue par défaut du site n'était parfois pas initialisée correctement. Problème constaté pour le site http://bachelor.epfl.ch

**Low level changes:**

1. La manière de définir la langue par défaut pour la page d'accueil du site était incorrect et se basait sur l'ordre dans lequel les fichiers "export_<lang>.xml" étaient renvoyé par `os.listdir()`. Le premier fichier renvoyé devenait la langue par défaut. 
1. Ajout d'une donnée membre à la classe `WPExporter` afin de pouvoir initialiser la langue par défaut lors de la construction de l'objet. Celle-ci est ensuite réutilisée pour initialiser la page d'accueil dans la bonne langue.

**Vu que je suis en vacances pour 10j, vous pouvez merge cette PR une fois approuvée. Et n'oubliez pas de fermer l'issue WWP-604 en plus**
