### PR TITLE
Wwp syntax highlight box

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -31,4 +31,6 @@ plugins:
     config: !include shortcodes-ultimate/v1/config-plugin.yml
   - name: feedzy-rss-feeds
     config: !include feedzy-rss-feeds/v1/config-plugin.yml
+  - name: enlighter
+    config: !include enlighter/v1/config-plugin.yml
 

--- a/data/plugins/generic/enlighter/v1/config-plugin.yml
+++ b/data/plugins/generic/enlighter/v1/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -243,9 +243,9 @@ class Box:
 
     def set_box_syntax_highlight(self, element):
         """Set the attributes of a syntaxHighlight box"""
-        content = "<pre><code>"
+        content = "[enlighter]"
         content += Utils.get_tag_attribute(element, "code", "jahia:value")
-        content += "</code></pre>"
+        content += "[/enlighter]"
         self.content = content
 
     def _parse_links_to_list(self, element):

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -19,6 +19,7 @@ class Box:
     TYPE_LINKS = "links"
     TYPE_RSS = "rss"
     TYPE_FILES = "files"
+    TYPE_SYNTAX_HIGHLIGHT = "syntaxHighlight"
 
     # Mapping of known box types from Jahia to WP
     types = {
@@ -34,7 +35,8 @@ class Box:
         "epfl:xmlBox": TYPE_XML,
         "epfl:linksBox": TYPE_LINKS,
         "epfl:rssBox": TYPE_RSS,
-        "epfl:filesBox": TYPE_FILES
+        "epfl:filesBox": TYPE_FILES,
+        "epfl:syntaxHighlightBox": TYPE_SYNTAX_HIGHLIGHT
     }
 
     def __init__(self, site, page_content, element, multibox=False):
@@ -97,6 +99,9 @@ class Box:
         # files
         elif self.TYPE_FILES == self.type:
             self.set_box_files(element)
+        # syntaxHighlight
+        elif self.TYPE_SYNTAX_HIGHLIGHT == self.type:
+            self.set_box_syntax_highlight(element)
         # unknown
         else:
             self.set_box_unknown(element)
@@ -234,6 +239,13 @@ class Box:
             file_name = file_url.split("/")[-1]
             content += '<li><a href="{}">{}</a></li>'.format(file_url, file_name)
         content += "</ul>"
+        self.content = content
+
+    def set_box_syntax_highlight(self, element):
+        """Set the attributes of a syntaxHighlight box"""
+        content = "<pre><code>"
+        content += Utils.get_tag_attribute(element, "code", "jahia:value")
+        content += "</code></pre>"
         self.content = content
 
     def _parse_links_to_list(self, element):


### PR DESCRIPTION
**From issue**: WWP-615

J'ai trouvé un plugin fonctionnel et simple d'utilisation pour le syntax highlighting dans wordpress. il ajoute un bouton dans l'éditeur WYSIWYG. Il y a un soucis mineur, au moment de l'import les retours à la ligne dans le code à highlighté sont perdus et le rendu directement via le shortcode (sans passer par la fenêtre du plugin) est étrange. Mais, vu que cette boite n'apparait qu'une seule fois, sur un seul site, je propose d'importer tel quel, et de dire aux utilisateurs (ou le faire nous même) qu'il faut simplement éditer la page et ré-insérer le code via la fenêtre du plugin dans l'éditeur.

**High level changes:**

1. Handle syntaxHighlightBox and add a plugin to insert syntax highlighted text in pages.


**Targetted version**: x.x.x
