### PR TITLE
Wwp include box

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -31,4 +31,5 @@ plugins:
     config: !include shortcodes-ultimate/v1/config-plugin.yml
   - name: feedzy-rss-feeds
     config: !include feedzy-rss-feeds/v1/config-plugin.yml
-
+  - name: remote-content-shortcode
+    config: !include remote-content-shortcode/v1/config-plugin.yml

--- a/data/plugins/generic/remote-content-shortcode/v1/config-plugin.yml
+++ b/data/plugins/generic/remote-content-shortcode/v1/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -164,7 +164,7 @@ class Box:
         """set the attributes of an include box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[include url=%s]" % url
+        self.content = '[remote_content url="%s"]'.format(url)
 
     def set_box_contact(self, element):
         """set the attributes of a contact box"""

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -164,7 +164,7 @@ class Box:
         """set the attributes of an include box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = '[remote_content url="%s"]'.format(url)
+        self.content = '[remote_content url="{}"]'.format(url)
 
     def set_box_contact(self, element):
         """set the attributes of a contact box"""


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Pour voir inclure le contenu provenant d'un autre site = include box

**Low level changes:**

1. installation du shortcode [Remote Content Shortcode](https://wordpress.org/plugins/remote-content-shortcode)
1. Adaptation du parser

**Remarques:** 
1. Ce shortcode pourrait remplacer les shortcode EPFL-infoscience et EPFL-people car dans les 2 cas, il s'agit d'insérer le contentu HTML provenant d'un autre outil.
Ce nouveau plugin gère le cache également.
1. Si le msg MOVED PERMANENTLY s'affiche c'est que l'URL nécessite une redirection. On (le webmaster) peut alors facilement corriger l'URL à la main :-)

**Attention** : Cette PR doit être mergée après la PR "Parse information for shortcode people #320"

**CETTE PR EST FERMÉE CAR UNE AUTRE PR MODIFIE LE COMPORTEMENT DU SHORTCODE REMOTE CONTENT POUR PERMETTRE LA VÉRIFICATION DE IP DANS LE RANGE EPFL**

**Targetted version**: x.x.x
