### PR TITLE
people shortcode

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -47,6 +47,7 @@ function epfl_people_process_shortcode( $attributes, $content = null )
 
     // Check if the result is already in cache
     $result = wp_cache_get( $url, 'epfl_people' );
+
     if ( false === $result ){
 
         // Make sure the content is actually coming from the people pages and does exist
@@ -64,6 +65,9 @@ function epfl_people_process_shortcode( $attributes, $content = null )
             $error = new WP_Error( 'not found', 'The url passed is not part of people or is not found', $url );
             epfl_people_log( $error );
         }
+    } else {
+        $page = file_get_contents( $url );
+        return $page;
     }
 }
 

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -55,7 +55,8 @@ function epfl_people_process_shortcode( $attributes, $content = null )
         if ( ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'people.epfl.ch' ) == 0 or strcasecmp( parse_url( $url, PHP_URL_HOST ), 'test-people.epfl.ch' ) == 0 ) && epfl_people_url_exists( $url ) ) {
 
             // Get the content of the page
-            $page = file_get_contents( $url );
+            $response = wp_remote_get( $url );
+            $page = wp_remote_retrieve_body( $response );
 
             // cache the result
             wp_cache_set( $url, $page, 'epfl_people' );

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -20,7 +20,7 @@ function epfl_people_log( $message ) {
     }
 }
 
-function epfl_people_urlExists( $url )
+function epfl_people_url_exists( $url )
 {
     $handle = curl_init( $url );
     curl_setopt( $handle, CURLOPT_RETURNTRANSFER, TRUE );
@@ -50,7 +50,7 @@ function epfl_people_process_shortcode( $attributes, $content = null )
     if ( false === $result ){
 
         // Make sure the content is actually coming from the people pages and does exist
-        if ( ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'people.epfl.ch' ) == 0 or strcasecmp( parse_url( $url, PHP_URL_HOST ), 'test-people.epfl.ch' ) == 0 ) && epfl_people_urlExists( $url ) ) {
+        if ( ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'people.epfl.ch' ) == 0 or strcasecmp( parse_url( $url, PHP_URL_HOST ), 'test-people.epfl.ch' ) == 0 ) && epfl_people_url_exists( $url ) ) {
 
             // Get the content of the page
             $page = file_get_contents( $url );

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -4,9 +4,10 @@
  * Plugin Name: EPFL People shortcode
  * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
  * Description: provides a shortcode to display results from People
- * Version: 1.0
- * Author: Emmanuel JAEP
+ * Version: 1.1
+ * Authors: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
+ * Contributors: LuluTchab, GregLeBarbar
  * License: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  **/
 
@@ -66,7 +67,7 @@ function epfl_people_process_shortcode( $attributes, $content = null )
             epfl_people_log( $error );
         }
     } else {
-        // Use the cache
+        // Use cache
         return $result;
     }
 }

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
  * Description: provides a shortcode to display results from People
  * Version: 1.1
- * Authors: Emmanuel JAEP
+ * Author: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
  * Contributors: LuluTchab, GregLeBarbar
  * License: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -66,8 +66,8 @@ function epfl_people_process_shortcode( $attributes, $content = null )
             epfl_people_log( $error );
         }
     } else {
-        $page = file_get_contents( $url );
-        return $page;
+        // Use the cache
+        return $result;
     }
 }
 

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Plugin Name: EPFL People shortcode
+ * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
+ * Description: provides a shortcode to display results from People
+ * Version: 1.0
+ * Author: Emmanuel JAEP
+ * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
+ * License: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
+ **/
+
+function epfl_people_log( $message ) {
+    if ( WP_DEBUG === true ) {
+        if ( is_array( $message ) || is_object( $message ) ) {
+            error_log( print_r( $message, true ) );
+        } else {
+            error_log( $message );
+        }
+    }
+}
+
+function epfl_people_urlExists( $url )
+{
+    $handle = curl_init( $url );
+    curl_setopt( $handle, CURLOPT_RETURNTRANSFER, TRUE );
+
+    $response = curl_exec( $handle );
+    $httpCode = curl_getinfo( $handle, CURLINFO_HTTP_CODE );
+
+    if ( $httpCode >= 200 && $httpCode <= 400 ) {
+        return true;
+    } else {
+        return false;
+    }
+    curl_close( $handle );
+}
+
+function epfl_people_process_shortcode( $attributes, $content = null )
+{
+    $attributes = shortcode_atts( array(
+        'url' => ''
+    ), $attributes );
+
+    // Sanitize parameter
+    $url = sanitize_text_field( $attributes['url'] );
+
+    // Check if the result is already in cache
+    $result = wp_cache_get( $url, 'epfl_people' );
+    if ( false === $result ){
+
+        // Make sure the content is actually coming from the people pages and does exist
+        if ( ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'people.epfl.ch' ) == 0 or strcasecmp( parse_url( $url, PHP_URL_HOST ), 'test-people.epfl.ch' ) == 0 ) && epfl_people_urlExists( $url ) ) {
+
+            // Get the content of the page
+            $page = file_get_contents( $url );
+
+            // cache the result
+            wp_cache_set( $url, $page, 'epfl_people' );
+
+            // return the page
+            return $page;
+        } else {
+            $error = new WP_Error( 'not found', 'The url passed is not part of people or is not found', $url );
+            epfl_people_log( $error );
+        }
+    }
+}
+
+add_shortcode('epfl_people', 'epfl_people_process_shortcode');
+
+?>

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -222,7 +222,7 @@ class Box:
             template = 'default_list'
         else:
             template = Utils.get_tag_attribute(minidom.parseString(template_html), "jahia-resource", "key")
-        parameters['WP_tmpl'] = template
+        parameters['tmpl'] = "WP_" + template
 
         # in the parser we can't know the current language.
         # so we assign a string that we will replace by the current language in the exporter
@@ -267,7 +267,7 @@ class Box:
         """set the attributes of an include box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
         if "://people.epfl.ch/cgi-bin/getProfiles?" in url:
-            url = url.replace("tmpl=", "WP_tmpl=")
+            url = url.replace("tmpl=", "tmpl=WP_")
             self.content = '[epfl_people url="{}" /]'.format(url)
         else:
             self.content = "[include url={}]".format(url)

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -268,7 +268,7 @@ class Box:
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
         if "://people.epfl.ch/cgi-bin/getProfiles?" in url:
             url = url.replace("tmpl=", "WP_tmpl=")
-            self.content = "[epfl_people url={} /]".format(url)
+            self.content = '[epfl_people url="{}" /]'.format(url)
         else:
             self.content = "[include url={}]".format(url)
 

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -365,6 +365,7 @@ class WPGenerator:
         WPMuPluginConfig(self.wp_site, "epfl-functions.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL-SC-infoscience.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_custom_editor_menu.php").install()
+        WPMuPluginConfig(self.wp_site, "EPFL-SC-people.php").install()
 
         if self.wp_config.installs_locked:
             WPMuPluginConfig(self.wp_site, "EPFL_installs_locked.php").install()


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. people shortcode : J'ai repris le shortcode de Manu J. et j'ai simplement rendu plus compatible avec [php coding standard](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/)
et avec des règles WP pour le [dév d'un shortcode](https://developer.wordpress.org/plugins/shortcodes/)

**Low level changes:**

1. people shortcode
2. ajout dans generator pour que le plugin soit présent après l'installation
3. correction d'un bug : les templates pour people commence par WP_ (et ce n'est pas le paramètre GET de tmpl qui est préfixé par WP_ mais sa valeur)

**Targetted version**: x.x.x
