### PR TITLE
Fix install mu plugins 

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -365,6 +365,8 @@ class WPGenerator:
         WPMuPluginConfig(self.wp_site, "epfl-functions.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL-SC-infoscience.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_custom_editor_menu.php").install()
+        WPMuPluginConfig(self.wp_site, "EPFL-map.php").install()
+        WPMuPluginConfig(self.wp_site, "EPFL-scheduler.php").install()
 
         if self.wp_config.installs_locked:
             WPMuPluginConfig(self.wp_site, "EPFL_installs_locked.php").install()


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Installation des shortcodes scheduler et map.

**Low level changes:**

1. Pour que le fichier php d'un shortcode se retrouve après installation dans le répertoire wp-content/mu-plugins il faut l'instancier dans le generator. Ceci avait été oublié pour le shortcode map et scheduler

**Targetted version**: x.x.x
