### PR TITLE
Customize ComingSoon login URL for website

### DIFF
--- a/data/plugins/generic/coming-soon/v1/config-plugin.yml
+++ b/data/plugins/generic/coming-soon/v1/config-plugin.yml
@@ -1,11 +1,9 @@
 src: web
 activate: yes
+config_class: wordpress.plugins.custom.comingsoon.WPComingSoonConfig
+# Only one option is set here. The other on needs to be specifically configured so it is done in a dedicated Python Class (specified above)
 tables:
   options:
-  - autoload: 'yes'
-    option_id: 186
-    option_name: seed_csp4_settings_content
-    option_value: a:9:{s:6:"status";s:1:"1";s:4:"logo";s:73:"https://mediacom.epfl.ch/files/content/sites/mediacom/files/EPFL-Logo.jpg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";} 
   - autoload: 'yes'
     option_id: 187
     option_name: seed_csp4_settings_design

--- a/src/wordpress/plugins/custom/comingsoon.py
+++ b/src/wordpress/plugins/custom/comingsoon.py
@@ -1,0 +1,36 @@
+import logging
+import json
+from wordpress import WPException
+from wordpress.plugins.config import WPPluginConfig
+import settings
+
+
+class WPComingSoonConfig(WPPluginConfig):
+
+    def configure(self, force, **kwargs):
+        """ kwargs:
+            - force -- True|False to tell if we have to erase configuration if already exists
+        """
+
+        # configure options
+        logging.info("{} - ComingSoon - Setting options...".format(self.wp_site))
+
+        # Loading current configuration
+        option = json.loads(self.run_wp_cli('option get seed_csp4_settings_content --format=json'))
+
+        option['logo'] = 'https://mediacom.epfl.ch/files/content/sites/mediacom/files/EPFL-Logo.jpg'
+        option['headline'] = 'Something new is coming...'
+        option['description'] = '&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"> \
+</nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt; \
+font-family:arial,helvetica,sans-serif;"><a href="{}/wp-admin/">Connexion / Login</a></span></p></div>'.format(
+            self.wp_site.url
+        )
+        option['footer_credit'] = '1'
+        # If we have to force update, we display "ComingSoon" screen
+        if force:
+            option['status'] = '1'
+
+        self.run_wp_cli("option update seed_csp4_settings_content --format=json ", pipe_input=json.dumps(option))
+
+        # configure raw plugin
+        super(WPComingSoonConfig, self).configure(force)


### PR DESCRIPTION
**From issue**: WWP-672

**High level changes:**

1. Le lien de connexion sur la page "ComingSoon" était une URL relative (`wp-admin/`) par rapport à la page du site demandée. Plusieurs personnes ayant tenté d'accéder une autre page du site se sont retrouvées sur la page "ComingSoon" et ont eu besoin de se connecter. Cependant, l'URL pointant sur `wp-admin` était mal construite car relative à la page donnée. Une classe de configuration spécifique à "ComingSoon" a donc été ajoutée afin de faire en sorte de mettre une URL de connexion (`wp-admin`) absolue en fonction de l'URL du site web.


**Targetted version**: x.x.x
