### PR TITLE
Several bugfixes

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -13,7 +13,6 @@ from wordpress_json import WordpressJsonWrapper, WordpressError
 import settings
 from exporter.utils import Utils
 from utils import Utils as WPUtils
-from urllib.parse import urlparse
 from parser.file import File
 
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -788,7 +788,7 @@ class WPExporter:
                 # menu entry is page
                 else:
                     # Trying to get corresponding page corresponding to current page UUID
-                    child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
+                    child = self.site.homepage.get_child_with_uuid(menu_item.target, 4)
 
                     if child is None:
                         logging.error("Submenu creation: No page found for UUID %s", menu_item.target)
@@ -964,11 +964,13 @@ class WPExporter:
         Delete all pages in DRAFT status
         """
         cmd = "post list --post_type='page' --post_status=draft --format=csv --field=ID"
-        pages_id_list = self.run_wp_cli(cmd).split("\n")[1:]
-        for page_id in pages_id_list:
-            cmd = "post delete {} --force".format(page_id)
-            self.run_wp_cli(cmd)
-        logging.info("All pages in DRAFT status deleted")
+        pages_id_list = self.run_wp_cli(cmd)
+
+        if not pages_id_list:
+            for page_id in pages_id_list.split("\n")[1:]:
+                cmd = "post delete {} --force".format(page_id)
+                self.run_wp_cli(cmd)
+            logging.info("All pages in DRAFT status deleted")
 
     def delete_pages(self):
         """

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1050,9 +1050,10 @@ class WPExporter:
                 # We skip this redirection to avoid infinite redirection...
                 if jahia_url != "/index.html":
                     source_url = "{}{}".format(folder, jahia_url)
+                    target_url = "{}{}".format(folder, wp_url)
                     # To avoid Infinite loop
-                    if source_url != wp_url[:-1]:
-                        redirect_list.append("Redirect 301 {} {}".format(source_url,  wp_url))
+                    if source_url != target_url[:-1]:
+                        redirect_list.append("Redirect 301 {} {}".format(source_url,  target_url))
 
         if redirect_list:
             # Updating .htaccess file

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -964,7 +964,7 @@ class WPExporter:
         """
         Delete all pages in DRAFT status
         """
-        cmd = "post list --post_type='page' --post_status=draft --format=csv --fields=ID"
+        cmd = "post list --post_type='page' --post_status=draft --format=csv --field=ID"
         pages_id_list = self.run_wp_cli(cmd).split("\n")[1:]
         for page_id in pages_id_list:
             cmd = "post delete {} --force".format(page_id)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -363,7 +363,7 @@ class WPExporter:
 
             # fix in HTML tags
             for url_mapping in self.urls_mapping:
-                new_url = url_mapping["wp_url"]
+                new_url = "/{}/".format(url_mapping["wp_slug"])
                 for old_url in url_mapping["jahia_urls"]:
                     self.fix_links_in_tag(
                         soup=soup,
@@ -489,7 +489,10 @@ class WPExporter:
 
         for page in self.site.pages_by_pid.values():
 
-            contents = {}
+            # We have to use OrderedDict to avoid bad surprises when page has only one language. Sometimes, Dict isn't
+            # taken in the "correct" order and we try to modify page which has been deleted because no translation. So
+            # it was editing a page which was in the Trash.
+            contents = OrderedDict()
             info_page = OrderedDict()
 
             for lang in page.contents.keys():
@@ -556,12 +559,12 @@ class WPExporter:
                 # prepare mapping for htaccess redirection rules
                 mapping = {
                     'jahia_urls': page.contents[lang].vanity_urls,
-                    'wp_url': wp_page['link']
+                    'wp_slug': wp_page['slug']
                 }
 
                 self.urls_mapping.append(mapping)
 
-                logging.info("WP page '%s' created", wp_page['link'])
+                logging.info("WP page '%s' created", wp_page['slug'])
 
                 # keep WordPress ID for further usages
                 page.contents[lang].wp_id = wp_page['id']
@@ -678,7 +681,7 @@ class WPExporter:
                     self.run_wp_cli(cmd)
 
                     # Saving widget position for current widget (as string because this is a string that is
-                    # used to index informations in DB)
+                    # used to index information in DB)
                     widget_pos_to_lang[str(widget_pos)] = lang
                     widget_pos += 1
 
@@ -961,10 +964,10 @@ class WPExporter:
         """
         Delete all pages in DRAFT status
         """
-        cmd = "post list --post_type='page' --post_status=draft --format=csv"
+        cmd = "post list --post_type='page' --post_status=draft --format=csv --fields=ID"
         pages_id_list = self.run_wp_cli(cmd).split("\n")[1:]
         for page_id in pages_id_list:
-            cmd = "post delete {}".format(page_id)
+            cmd = "post delete {} --force".format(page_id)
             self.run_wp_cli(cmd)
         logging.info("All pages in DRAFT status deleted")
 
@@ -1036,7 +1039,9 @@ class WPExporter:
 
         # Add all rewrite jahia URI to WordPress URI
         for element in self.urls_mapping:
-            wp_url = urlparse(element['wp_url']).path
+            # WordPress URL is generated from slug so if admin change page location, it still will be available
+            # if we request and "old" Jahia URL
+            wp_url = "/{}/".format(element['wp_slug'])
 
             # Going through vanity URLs
             for jahia_url in element['jahia_urls']:

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -246,19 +246,19 @@ class Box:
         """set the attributes of an actu box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[actu url=%s]" % url
+        self.content = "[actu url={}]".format(url)
 
     def set_box_memento(self, element):
         """set the attributes of a memento box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[memento url=%s]" % url
+        self.content = "[memento url={}]".format(url)
 
     def set_box_infoscience(self, element):
         """set the attributes of a infoscience box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[epfl_infoscience url=%s]" % url
+        self.content = "[epfl_infoscience url={}]".format(url)
 
     def set_box_faq(self, element):
         """set the attributes of a faq box"""
@@ -266,7 +266,7 @@ class Box:
 
         self.answer = Utils.get_tag_attribute(element, "answer", "jahia:value")
 
-        self.content = "<h2>%s</h2><p>%s</p>" % (self.question, self.answer)
+        self.content = "<h2>{}</h2><p>{}</p>".format(self.question, self.answer)
 
     def set_box_toggle(self, element):
         """set the attributes of a toggle box"""
@@ -294,7 +294,7 @@ class Box:
         xml = Utils.get_tag_attribute(element, "xml", "jahia:value")
         xslt = Utils.get_tag_attribute(element, "xslt", "jahia:value")
 
-        self.content = "[xml xml=%s xslt=%s]" % (xml, xslt)
+        self.content = "[xml xml={} xslt={}]".format(xml, xslt)
 
     def set_box_rss(self, element):
         """set the attributes of an rss box"""
@@ -334,7 +334,7 @@ class Box:
 
     def set_box_unknown(self, element):
         """set the attributes of an unknown box"""
-        self.content = "[%s]" % element.getAttribute("jcr:primaryType")
+        self.content = "[{}]".format(element.getAttribute("jcr:primaryType"))
 
     def set_box_files(self, element):
         """set the attributes of a files box"""
@@ -356,8 +356,10 @@ class Box:
     def set_box_snippets(self, element):
         """set the attributes of a snippets box"""
 
+        shortcode_name = "epfl_snippets"
+
         # register the shortcode
-        self.site.register_shortcode("epfl_snippets", ["url", "image", "big_image"], self)
+        self.site.register_shortcode(shortcode_name, ["url", "image", "big_image"], self)
 
         # check if the list is not empty
         if not element.getElementsByTagName("snippetListList"):
@@ -402,9 +404,9 @@ class Box:
 
                         url = "/page-{}-{}.html".format(page.pid, self.page_content.language)
 
-            self.content = '[epfl_snippets url="{}" title="{}" subtitle="{}" image="{}"' \
+            self.content = '[{} url="{}" title="{}" subtitle="{}" image="{}"' \
                            ' big_image="{}" enable_zoom="{}" description="{}"]'\
-                .format(url, title, subtitle, image, big_image, enable_zoom, description)
+                .format(shortcode_name, url, title, subtitle, image, big_image, enable_zoom, description)
 
     def set_box_syntax_highlight(self, element):
         """Set the attributes of a syntaxHighlight box"""

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -784,3 +784,6 @@ Parsed for %s :
 
         for tag in num_tags_ordered:
             self.report += "    - <%s> %s\n" % (tag, self.num_tags[tag])
+
+    def __repr__(self):
+        return self.name

--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -117,9 +117,10 @@ class PageContent:
                     url = re.sub(r'(true|false)(===)?', '', url)
                     if url:
                         self.vanity_urls.append(url)
-            else:
-                # use the old Jahia page id
-                self.vanity_urls = ["/page-{}-{}.html".format(self.page.pid, self.language)]
+
+            # We also add the "default" page name because it can also be used internally in website even if there are
+            # vanity URLs defined.
+            self.vanity_urls = ["/page-{}-{}.html".format(self.page.pid, self.language)]
 
         # FIXME, the prefixing part should be done in exporter
         # add the site root_path at the beginning

--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -120,7 +120,7 @@ class PageContent:
 
             # We also add the "default" page name because it can also be used internally in website even if there are
             # vanity URLs defined.
-            self.vanity_urls = ["/page-{}-{}.html".format(self.page.pid, self.language)]
+            self.vanity_urls.append("/page-{}-{}.html".format(self.page.pid, self.language))
 
         # FIXME, the prefixing part should be done in exporter
         # add the site root_path at the beginning

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -349,7 +349,7 @@ class WPGenerator:
         cmd = "post list --post_type=page,post --field=ID --format=csv"
         posts_list = self.run_wp_cli(cmd).split("\n")
         for post in posts_list:
-            cmd = "post delete {}".format(post)
+            cmd = "post delete {} --force".format(post)
             self.run_wp_cli(cmd)
         logging.info("%s - All demo posts deleted", repr(self))
 


### PR DESCRIPTION
**From issues**: WWP-673, WWP-676, WWP-678, WWP-679

**High level changes:**

1. Utilisation du slug pour identifier les pages et reconstruire les liens et les redirections car l'URL qui était récupérée avant changeait potentiellement juste après lorsque les pages étaient réorganisées hiérarchiquement. Le fait d'utiliser le slug permet de palier à ceci car WordPress arrive à reconstruire le chemin d'accès à une page qui est donnée par son slug. 
1. Utilisation du slug pour les redirections. Ceci permet de toujours avoir quelque chose de valable dans le cas où le webmaster décide de changer la localisation d'une page dans l'arborescence.
1. Prise en compte également du nom de page style Jahia (page-1234-en.html) même s'il y a des vanity URLs de définies car le webmaster peut avoir utilisé ces noms par défaut pour référencer la page depuis d'autres pages du site.
1. Suppression complète de la page de démo. Elle était uniquement mise dans "Trash" jusqu'à présent
1. Suppression complète des pages créées en "draft" lors de l'import puis effacées car pas de traduction dans la langue donnée. Jusqu'à présent, la page était mise dans "Trash"
1. Seuls 3 niveaux de sous-menus étaient gérés et ça ne passait pas correctement pour le site sac.epfl.ch. Passage à 4 niveaux.

**Low level changes:**

1. Mise à jour de certains formattage de string qui utilisaient encore `%`
1. Ajouter d'une méthode `__repr__` pour `Site` car c'était quelque chose du style `<object id...>` qui était affiché dans la console lors de l'exécution du script.
1. Suppression de la référence à `urllib.urlparse` ou un truc du style car PEP8 disait que plus utilisée.
1. Le listing des "draft" à effacer lors de l'import des pages était incorrect mais fonctionnait quand même !?!. Il manquait `--field=ID` dans la commande WP-CLI afin de ne prendre que l'ID et pas tous les champs d'infos.
1. Utilisation d'un `OrderdDict` à la place d'un dictionnaire standard lors de l'import des pages car il pouvait arriver que lors de l'import, le dictionnaire ne soit pas parcouru dans le "bon sens" et qu'on modifie donc le mauvais ID de page, celui de la page placée dans "Trash". La modification passait car le système nous permet de modifier une page dans "Trash" mais la page n'était ensuite pas visible dans le site. Si la page avait été supprimée (sans être mise dans "Trash"), une erreur aurait été levée car on n'aurait pas pu la modifier.


**Targetted version**: x.x.x
