### PR TITLE
DIV around shortcodes

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL-SC-infoscience.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-infoscience.php
@@ -60,7 +60,9 @@ function epfl_infoscience_process_shortcode( $attributes, $content = null )
             wp_cache_set( $url, $page, 'epfl_infoscience' );
 
             // return the page
-            return $page;
+            return '<div class="infoscienceBox">'.
+                    $page.
+                    '</div>';
         } else {
             $error = new WP_Error( 'not found', 'The url passed is not part of Infoscience or is not found', $url );
             epfl_infoscience_log( $error );

--- a/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
+++ b/data/wp/wp-content/mu-plugins/EPFL-SC-people.php
@@ -62,7 +62,9 @@ function epfl_people_process_shortcode( $attributes, $content = null )
             wp_cache_set( $url, $page, 'epfl_people' );
 
             // return the page
-            return $page;
+            return '<div class="peopleListBox">'.
+                    $page.
+                    '</div>';
         } else {
             $error = new WP_Error( 'not found', 'The url passed is not part of people or is not found', $url );
             epfl_people_log( $error );

--- a/data/wp/wp-content/mu-plugins/EPFL_snippets.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_snippets.php
@@ -33,7 +33,7 @@ function epfl_snippets_debug( $var ) {
  */
 function epfl_snippets_build_html( string $url, string $title, string $subtitle, string $description, string $image, string $big_image, string $enable_zoom )
 {
-    $html  = '<div class="snippets">';
+    $html  = '<div class="snippetsBox">';
 
     $has_url = filter_var($url, FILTER_VALIDATE_URL);
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -500,7 +500,8 @@ class WPExporter:
                 # create the page content
                 for box in page.contents[lang].boxes:
 
-                    contents[lang] += '<div class="{}">'.format(box.type + "Box")
+                    if not box.is_shortcode():
+                        contents[lang] += '<div class="{}">'.format(box.type + "Box")
                     if box.title:
                         contents[lang] += '<h3 id="{0}">{0}</h3>'.format(box.title)
 
@@ -511,7 +512,8 @@ class WPExporter:
                             box.content = box.content.replace(Box.UPDATE_LANG, lang)
 
                     contents[lang] += box.content
-                    contents[lang] += "</div>"
+                    if not box.is_shortcode():
+                        contents[lang] += "</div>"
 
                 info_page[lang] = {
                     'post_name': page.contents[lang].path,

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -59,6 +59,7 @@ class Box:
         self.site = site
         self.page_content = page_content
         self.type = ""
+        self.shortcode_name = ""
         self.set_type(element)
         self.title = Utils.get_tag_attribute(element, "boxTitle", "jahia:value")
         self.content = ""
@@ -205,6 +206,8 @@ class Box:
         More information here:
         https://c4science.ch/source/kis-jahia6-dev/browse/master/core/src/main/webapp/common/box/display/peopleListBoxDisplay.jsp
         """
+        self.shortcode_name = "epfl_people"
+
         BASE_URL = "https://people.epfl.ch/cgi-bin/getProfiles?"
 
         # prepare a dictionary with all GET parameters
@@ -240,7 +243,7 @@ class Box:
         parameters['lang'] = self.UPDATE_LANG
 
         url = "{}{}".format(BASE_URL, urlencode(parameters))
-        self.content = '[epfl_people url="{}" /]'.format(url)
+        self.content = '[{} url="{}" /]'.format(self.shortcode_name, url)
 
     def set_box_actu(self, element):
         """set the attributes of an actu box"""
@@ -256,9 +259,12 @@ class Box:
 
     def set_box_infoscience(self, element):
         """set the attributes of a infoscience box"""
+
+        self.shortcode_name = "epfl_infoscience"
+
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[epfl_infoscience url={}]".format(url)
+        self.content = "[{} url={}]".format(self.shortcode_name, url)
 
     def set_box_faq(self, element):
         """set the attributes of a faq box"""
@@ -279,7 +285,10 @@ class Box:
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
         if "://people.epfl.ch/cgi-bin/getProfiles?" in url:
             url = url.replace("tmpl=", "tmpl=WP_")
-            self.content = '[epfl_people url="{}" /]'.format(url)
+
+            self.shortcode_name = "epfl_people"
+
+            self.content = '[{} url="{}" /]'.format(self.shortcode_name, url)
         else:
             self.content = '[remote_content url="{}"]'.format(url)
 
@@ -294,7 +303,9 @@ class Box:
         xml = Utils.get_tag_attribute(element, "xml", "jahia:value")
         xslt = Utils.get_tag_attribute(element, "xslt", "jahia:value")
 
-        self.content = "[xml xml={} xslt={}]".format(xml, xslt)
+        self.shortcode_name = "xml"
+
+        self.content = "[{} xml={} xslt={}]".format(self.shortcode_name, xml, xslt)
 
     def set_box_rss(self, element):
         """set the attributes of an rss box"""
@@ -356,10 +367,10 @@ class Box:
     def set_box_snippets(self, element):
         """set the attributes of a snippets box"""
 
-        shortcode_name = "epfl_snippets"
+        self.shortcode_name = "epfl_snippets"
 
         # register the shortcode
-        self.site.register_shortcode(shortcode_name, ["url", "image", "big_image"], self)
+        self.site.register_shortcode(self.shortcode_name, ["url", "image", "big_image"], self)
 
         # check if the list is not empty
         if not element.getElementsByTagName("snippetListList"):
@@ -406,7 +417,7 @@ class Box:
 
             self.content = '[{} url="{}" title="{}" subtitle="{}" image="{}"' \
                            ' big_image="{}" enable_zoom="{}" description="{}"]'\
-                .format(shortcode_name, url, title, subtitle, image, big_image, enable_zoom, description)
+                .format(self.shortcode_name, url, title, subtitle, image, big_image, enable_zoom, description)
 
     def set_box_syntax_highlight(self, element):
         """Set the attributes of a syntaxHighlight box"""
@@ -468,6 +479,8 @@ class Box:
     def set_box_map(self, element):
         """set the attributes of a map box"""
 
+        self.shortcode_name = "epfl_map"
+
         # parse info
         height = Utils.get_tag_attribute(element, "height", "jahia:value")
         width = Utils.get_tag_attribute(element, "width", "jahia:value")
@@ -477,7 +490,14 @@ class Box:
         # so we assign a string that we will replace by the current language in the exporter
         lang = self.UPDATE_LANG
 
-        self.content = '[epfl_map width="{}" height="{}" query="{}" lang="{}"]'.format(width, height, query, lang)
+        self.content = '[{} width="{}" height="{}" query="{}" lang="{}"]'.format(self.shortcode_name,
+                                                                                 width,
+                                                                                 height,
+                                                                                 query,
+                                                                                 lang)
+
+    def is_shortcode(self):
+        return self.shortcode_name != ""
 
     def __str__(self):
         return self.type + " " + self.title

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -142,6 +142,8 @@ class Box:
     def _set_scheduler_box(self, element, content):
         """set the attributes of a scheduler box"""
 
+        self.shortcode_name = "epfl_scheduler"
+
         start_datetime = Utils.get_tag_attribute(element, "comboList", "jahia:validFrom")
 
         if start_datetime and "T" in start_datetime:
@@ -157,12 +159,14 @@ class Box:
         if not end_datetime and not start_datetime:
             logging.warning("Scheduler shortcode has no startdate and no enddate")
 
-        return '[epfl_scheduler start_date="{}" end_date="{}" start_time="{}" end_time="{}"]{}[/epfl_scheduler]'.format(
+        return '[{} start_date="{}" end_date="{}" start_time="{}" end_time="{}"]{}[/{}]'.format(
+            self.shortcode_name,
             start_date,
             end_date,
             start_time,
             end_time,
-            content
+            content,
+            self.shortcode_name
         )
 
     def set_box_text(self, element, multibox=False):
@@ -249,13 +253,17 @@ class Box:
         """set the attributes of an actu box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[actu url={}]".format(url)
+        self.shortcode_name = "actu"
+
+        self.content = "[{} url={}]".format(self.shortcode_name, url)
 
     def set_box_memento(self, element):
         """set the attributes of a memento box"""
         url = Utils.get_tag_attribute(element, "url", "jahia:value")
 
-        self.content = "[memento url={}]".format(url)
+        self.shortcode_name = "memento"
+
+        self.content = "[{} url={}]".format(self.shortcode_name, url)
 
     def set_box_infoscience(self, element):
         """set the attributes of a infoscience box"""


### PR DESCRIPTION
**From issue**: WWP-682

**High level changes:**

1. Les shortcodes pour lesquels ce sont des plugins qui renvoient du code étaient par défaut "entourés" de `<div class="<name>Box">` (le contenu renvoyé par le plugin était ensuite entouré du div en question). L'affichage est OK mais si un utilisateur veut réutiliser le même shortcode sur une autre page, il va mettre le shortcode seul et donc il n'y aura pas le `<div>` autour, ce qui va potentiellement faire foirer l'affichage. Ce code `<div>` doit donc être généré par le plugin qui traite le shortcode. Tous les plugins ont été modifiés et le `<div>` entourant n'est plus ajouté dans le rendu si c'est le plugin qui renvoie le contenu.

**Targetted version**: x.x.x
