### PR TITLE
Multilang tagline handling

### DIFF
--- a/functional_tests/test_plugins.py
+++ b/functional_tests/test_plugins.py
@@ -44,6 +44,7 @@ def wp_generator_generic():
                  'wp_site_url': SITE_URL_GENERIC,
                  'wp_site_title': "TEST",
                  'wp_tagline': "My Test",
+                 'langs': 'en',
                  'unit_name': UNIT_NAME})
     generator.clean()
     generator.generate()
@@ -58,6 +59,7 @@ def wp_generator_specific():
                  'wp_site_url': SITE_URL_SPECIFIC,
                  'wp_site_title': "TEST",
                  'wp_tagline': "My Test",
+                 'langs': 'en',
                  'unit_name': UNIT_NAME})
     generator.clean()
     generator.generate()

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -883,6 +883,7 @@ class WPExporter:
         Add pages into the menu in wordpress.
         This menu was created when configuring the polylang plugin.
         """
+        logging.info("Populating menu...")
         try:
             # Create homepage menu
             for lang, page_content in self.site.homepage.contents.items():

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -243,7 +243,7 @@ def _generate_csv_line(wp_generator):
 
     # Recovering values from WPGenerator or hardcode some
     csv_columns['wp_site_url'] = wp_generator._site_params['wp_site_url']  # from csv
-    csv_columns['wp_tagline'] = wp_generator._site_params['wp_tagline']  # from parser
+    csv_columns['wp_tagline'] = wp_generator._site_params['wp_tagline'][wp_generator.default_lang()]  # from parser
     csv_columns['wp_site_title'] = wp_generator._site_params['wp_site_title']  # from parser
     csv_columns['site_type'] = 'wordpress'
     csv_columns['openshift_env'] = 'subdomains'
@@ -418,7 +418,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
         logging.warning("No wp tagline in %s", default_language)
         wp_tagline = None
     else:
-        wp_tagline = site.title[default_language]
+        wp_tagline = site.title
 
     if not theme:
         # Setting correct theme depending on parsing result

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -278,14 +278,16 @@ class WPGenerator:
             logging.error("%s - could not setup WP site", repr(self))
             return False
 
-        # Set Tagline (blog description)
-        # Command is in simple quotes and tagline between double quotes to avoid problems in case of simple quote
-        # in tagline text. We initialize blogdescription with default language
-        if not self.run_wp_cli('option update blogdescription "{}"'.format(
-                self._site_params['wp_tagline'][self.default_lang()]),
-                encoding="utf-8"):
-            logging.error("%s - could not configure blog description", repr(self))
-            return False
+        # Set Tagline (blog description) if we have one. If we don't have a tagline and set it to "empty", it won't
+        # be available in Polylang to translate it so we let the default value set by WordPress
+        if self._site_params['wp_tagline']:
+            # Command is in simple quotes and tagline between double quotes to avoid problems in case of simple quote
+            # in tagline text. We initialize blogdescription with default language
+            if not self.run_wp_cli('option update blogdescription "{}"'.format(
+                    self._site_params['wp_tagline'][self.default_lang()]),
+                    encoding="utf-8"):
+                logging.error("%s - could not configure blog description", repr(self))
+                return False
 
         # Configure permalinks
         command = "rewrite structure '/%postname%/' --hard"

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -42,6 +42,10 @@ class WPGenerator:
 
         Argument keywords:
         site_params -- dict with row coming from CSV file (source of truth)
+                    - Field wp_tagline can be :
+                    None    -> No information
+                    String  -> Same tagline for all languages
+                    Dict    -> key=language, value=tagline for language
         admin_password -- (optional) Password to use for 'admin' account
         """
 
@@ -57,6 +61,15 @@ class WPGenerator:
 
         if 'wp_tagline' not in self._site_params:
             self._site_params['wp_tagline'] = None
+        else:
+            # If information is not already in a dict,
+            if not isinstance(self._site_params['wp_tagline'], dict):
+                wp_tagline = {}
+                # We loop through languages to generate dict
+                for lang in self._site_params['langs'].split(','):
+                    # We set tagline for current language
+                    wp_tagline[lang] = self._site_params['wp_tagline']
+                self._site_params['wp_tagline'] = wp_tagline
 
         if self._site_params.get('installs_locked', None) is None:
             self._site_params['installs_locked'] = settings.DEFAULT_CONFIG_INSTALLS_LOCKED
@@ -109,6 +122,13 @@ class WPGenerator:
 
     def __repr__(self):
         return repr(self.wp_site)
+
+    def default_lang(self):
+        """
+        Returns default language for generated website
+        :return:
+        """
+        return self._site_params['langs'].split(',')[0]
 
     def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """
@@ -260,9 +280,10 @@ class WPGenerator:
 
         # Set Tagline (blog description)
         # Command is in simple quotes and tagline between double quotes to avoid problems in case of simple quote
-        # in tagline text.
-        if not self.run_wp_cli('option update blogdescription "{}"'.format(self.wp_site.wp_tagline),
-                               encoding="utf-8"):
+        # in tagline text. We initialize blogdescription with default language
+        if not self.run_wp_cli('option update blogdescription "{}"'.format(
+                self._site_params['wp_tagline'][self.default_lang()]),
+                encoding="utf-8"):
             logging.error("%s - could not configure blog description", repr(self))
             return False
 

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -56,13 +56,16 @@ class WPGenerator:
             logging.info("WPGenerator.__init__(): Please use 'unit_id' from CSV file (now recovered from 'unit_name')")
             self._site_params['unit_id'] = self.get_the_unit_id(self._site_params['unit_name'])
 
+        # If not given (can happens), we initialize title with a default value so we will be able, later, to
+        # set a translation for it.
         if 'wp_site_title' not in self._site_params:
-            self._site_params['wp_site_title'] = None
+            self._site_params['wp_site_title'] = 'Title'
 
         if 'wp_tagline' not in self._site_params:
             self._site_params['wp_tagline'] = None
         else:
-            # If information is not already in a dict,
+            # If information is not already in a dict (happens if info is coming for the source of truth in which
+            # we only have tagline in primary language
             if not isinstance(self._site_params['wp_tagline'], dict):
                 wp_tagline = {}
                 # We loop through languages to generate dict

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -27,7 +27,13 @@ class WPSite:
     WP_VERSION = Utils.get_mandatory_env(key="WP_VERSION")
 
     def __init__(self, openshift_env, wp_site_url, wp_site_title=None, wp_tagline=None):
-
+        """
+        Class constructor
+        :param openshift_env: name of openshift environement
+        :param wp_site_url: WordPress website URL
+        :param wp_site_title: WordPress website title (same for all languages)
+        :param wp_tagline: Dict with langs as key and tagline as value
+        """
         # validate & transform args
         self.openshift_env = openshift_env.lower()
         url = urlparse(wp_site_url.lower())
@@ -37,9 +43,10 @@ class WPSite:
             validate_string(wp_site_title)
 
         if wp_tagline is not None:
-            validate_string(wp_tagline)
+            for lang, lang_tagline in wp_tagline.items():
+                validate_string(lang_tagline)
 
-        # set WP informations
+        # set WP information
         self.domain = url.netloc.strip('/')
         self.folder = url.path.strip('/')
         self.wp_site_title = wp_site_title or self.DEFAULT_TITLE

--- a/src/wordpress/plugins/custom/polylang.py
+++ b/src/wordpress/plugins/custom/polylang.py
@@ -3,6 +3,7 @@ import json
 from wordpress import WPException
 from wordpress.plugins.config import WPPluginConfig
 import settings
+import html
 
 
 class WPPolylangConfig(WPPluginConfig):
@@ -23,6 +24,54 @@ class WPPolylangConfig(WPPluginConfig):
             if existing_menu['name'] == menu_name:
                 return True
         return False
+
+    def _update_taglines(self, languages):
+        """
+        Update tagline for all languages. This information is stored in "postmeta" table and we have to
+        gather some information in another table (post) before we can update string translation.
+        :param languages: list of languages. Default one is in first place.
+        :return:
+        """
+
+        options = []
+
+        # We get the configured names because they are used by Polylang to match translations to use.
+        tagline_key = self.run_wp_cli("option get blogdescription")
+        site_title_key = self.run_wp_cli("option get blogname")
+        date_format_key = self.run_wp_cli("option get date_format")
+        time_format_key = self.run_wp_cli("option get time_format")
+
+        for lang in languages:
+            # tagline for current lang, can be a string (if default value used) or a dict.
+            # If it's a string, we take the same tagline for all languages
+            lang_tagline = self.wp_site.wp_tagline[lang] if isinstance(self.wp_site.wp_tagline, dict) else \
+                self.wp_site.wp_tagline
+            # Transforming special characters
+            lang_tagline = html.escape(lang_tagline, quote=True).encode('ascii', 'xmlcharrefreplace').decode()
+
+            # Adding option for current lang
+            # The first option of each list is the key to find translation. Only the tagline is updated, all others
+            # information are the same as the one defined in the default language.
+            options.append([[site_title_key, site_title_key],
+                            [tagline_key, lang_tagline],
+                            [date_format_key, date_format_key],
+                            [time_format_key, time_format_key]])
+
+        # Listing post associated to Polylang translations
+        post_ids = self.run_wp_cli("post list --post_type=polylang_mo --field=ID --format=csv")
+
+        # Looping through post IDs to update string translations. We have to sort the list to loop correctly through
+        # languages. First one is the default and others are following. Sorting the list ensure that we update options
+        # in the correct order
+        for post_id in sorted(post_ids.split('\n')):
+
+            cmd = "post meta update {} _pll_strings_translations --format=json".format(post_id)
+            # Getting next option
+            option = options.pop(0)
+
+            if not self.run_wp_cli(cmd, pipe_input=json.dumps(option)):
+                logging.warning("{} - Polylang - Cannot add string translation for post {}".format(self.wp_site,
+                                                                                                   post_id))
 
     def _language_exists(self, locale):
         """
@@ -75,6 +124,9 @@ class WPPolylangConfig(WPPluginConfig):
                     logging.info("{} - Polylang - Language installed: {}".format(self.wp_site, language))
 
         if force:
+            # Updating taglines
+            self._update_taglines(languages)
+
             # configure default language (using slug, not using locale)
             logging.info("{} - Polylang - Setting default language to {}...".format(self.wp_site, default))
             self.run_wp_cli("pll option default {}".format(default))
@@ -90,7 +142,7 @@ class WPPolylangConfig(WPPluginConfig):
             self.run_wp_cli("pll menu create {} top".format(settings.MAIN_MENU))
 
         if not self._menu_exists(settings.FOOTER_MENU):
-                self.run_wp_cli("pll menu create {} footer_nav".format(settings.FOOTER_MENU))
+            self.run_wp_cli("pll menu create {} footer_nav".format(settings.FOOTER_MENU))
 
         # configure raw plugin
         super(WPPolylangConfig, self).configure(force)

--- a/src/wordpress/tests/test_wordpress.py
+++ b/src/wordpress/tests/test_wordpress.py
@@ -15,7 +15,7 @@ class TestWPSite:
             openshift_env=settings.OPENSHIFT_ENV,
             wp_site_url="http://localhost/folder",
             wp_site_title="TST",
-            wp_tagline="Test site")
+            wp_tagline={'en': "Test site"})
 
     def test_path(self, wordpress):
         assert wordpress.path == ROOT_PATH + "htdocs/folder"
@@ -78,6 +78,7 @@ class TestWPGenerator:
              'wp_site_title': 'DM',
              'wp_tagline': self.TAGLINE_WITH_ACCENT,
              'unit_name': 'idevelop',
+             'langs': 'en',
              'updates_automatic': False})
         generator.clean()
         return generator


### PR DESCRIPTION
**From issue**: WWP-691

**High level changes:**

1. Ajout de la gestion des "tagline" en plusieurs langues.
1. Quand il n'y a pas de "tagline" ou de titre de site, on ne mets pas une valeur vide, on laisse celle par défaut. Si on ne fait pas ça, la possibilité pour traduire la valeur n'existe pas dans Polylang.
1. Quand il n'y a pas de "title" donné, on met simplement "Title" à la place histoire d'avoir la possibilité de traduire le titre dans Polylang

**Low level changes:**

1. Ajout d'une fonction dans la classe de configuration de Polylang pour mettre à jour les traductions de la tagline.
1. Lors de la génération de la ligne à ajouter dans la source de vérité à la fin d'un export Jahia vers WordPress, c'est la tagline de la langue par défaut qui est affichée.
1. Ajout d'une info dans la console au début de la création des menus
1. Adaptation des tests pour que ça passe avec la tagline multilangue

**Targetted version**: x.x.x
