### PR TITLE
Fix scheduler parse if no start_date

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -183,6 +183,11 @@ class Box:
                              " simply using content".format(start_date))
                 return content
 
+        # we don't need to check if end_date > today
+        # In case end_date < today the shortcode display nothing
+        if not start_date and end_date:
+            start_date = today
+
         return '[{} start_date="{}" end_date="{}" start_time="{}" end_time="{}"]{}[/{}]'.format(
             self.shortcode_name,
             start_date,


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Fix scheduler parse if no start_date

**Targetted version**: x.x.x
