### PR TITLE
Handle page vanity URL without language in it

### DIFF
--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -123,6 +123,12 @@ class PageContent:
             # vanity URLs defined.
             self.vanity_urls.append("/page-{}-{}.html".format(self.page.pid, self.language))
 
+            # If website has only one language, we also add another way to reach page, the URL without the language
+            # FIXME: It may also work if website have more than one language and in this case, URL without language
+            # points on the default language URL.
+            if len(self.site.languages) == 1:
+                self.vanity_urls.append("/page-{}.html".format(self.page.pid))
+
         # FIXME, the prefixing part should be done in exporter
         # add the site root_path at the beginning
         self.path = self.site.root_path + self.vanity_urls[0]

--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -127,7 +127,10 @@ class PageContent:
             # FIXME: It may also work if website have more than one language and in this case, URL without language
             # points on the default language URL.
             if len(self.site.languages) == 1:
-                self.vanity_urls.append("/page-{}.html".format(self.page.pid))
+                # Add if not exists
+                url_without_lang = "/page-{}.html".format(self.page.pid)
+                if url_without_lang not in self.vanity_urls:
+                    self.vanity_urls.append(url_without_lang)
 
         # FIXME, the prefixing part should be done in exporter
         # add the site root_path at the beginning


### PR DESCRIPTION
**From issue**: WWP-696

**Low level changes:**

1. Quand un site n'a qu'une seule langue, Jahia permet d'atteindre les pages de 2 manières :
- /page-1234-<lang>.html
- /page-1234.html
L'URL de la page sans la langue n'est pas dans la liste des Vanity URL de la page côté Jahia (même si on peut quand même atteindre la page de cette manière...). Et dans certains cas, la notation sans l'identifiant de la langue peut être utilisé et ceci fait que l'URL n'est pas mise à jour lors de l'import. Afin de corriger ceci dans le parsing, dans le cas où le site n'a qu'une langue, on ajoute le lien sans la langue dans les vanity URL s'il n'y est pas déjà.

**Targetted version**: x.x.x
