### PR TITLE
Fix ETX character sometimes present in XML files

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -10,7 +10,7 @@ Usage:
     [--username=<USERNAME> --host=<HOST> --zip-path=<ZIP_PATH> --force]
     [--output-dir=<OUTPUT_DIR>]
   jahia2wp.py parse                 <site>                          [--debug | --quiet]
-    [--output-dir=<OUTPUT_DIR>] [--use-cache] [--fix-etx-chars]
+    [--output-dir=<OUTPUT_DIR>] [--use-cache]
   jahia2wp.py export     <site>  <wp_site_url> <unit_name>          [--debug | --quiet]
     [--to-wordpress] [--clean-wordpress] [--to-dictionary]
     [--admin-password=<PASSWORD>]
@@ -19,7 +19,6 @@ Usage:
     [--openshift-env=<OPENSHIFT_ENV> --theme=<THEME>]
     [--use-cache]
     [--keep-extracted-files]
-    [--fix-etx-chars]
   jahia2wp.py clean                 <wp_env> <wp_url>               [--debug | --quiet]
     [--stop-on-errors]
   jahia2wp.py clean-many            <csv_file>                      [--debug | --quiet]
@@ -331,7 +330,7 @@ def unzip(site, username=None, host=None, zip_path=None, force=False, output_dir
 
 
 @dispatch.on('parse')
-def parse(site, output_dir=None, use_cache=False, fix_etx_chars=False, **kwargs):
+def parse(site, output_dir=None, use_cache=False, **kwargs):
     """
     Parse the give site.
     """
@@ -362,7 +361,7 @@ def parse(site, output_dir=None, use_cache=False, fix_etx_chars=False, **kwargs)
             site = pickle_site
         else:
             logging.info("Cache not used, parsing the Site")
-            site = Site(site_dir, site, fix_etx_chars=fix_etx_chars)
+            site = Site(site_dir, site, fix_etx_chars=True)
 
         print(site.report)
 
@@ -386,7 +385,7 @@ def parse(site, output_dir=None, use_cache=False, fix_etx_chars=False, **kwargs)
 @dispatch.on('export')
 def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=False, to_dictionary=False,
            admin_password=None, output_dir=None, theme=None, installs_locked=False, updates_automatic=False,
-           openshift_env=None, use_cache=None, keep_extracted_files=False, fix_etx_chars=False, **kwargs):
+           openshift_env=None, use_cache=None, keep_extracted_files=False, **kwargs):
     """
     Export the jahia content into a WordPress site.
 
@@ -406,7 +405,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     """
 
     # Download, Unzip the jahia zip and parse the xml data
-    site = parse(site=site, use_cache=use_cache, output_dir=output_dir, fix_etx_chars=fix_etx_chars)
+    site = parse(site=site, use_cache=use_cache, output_dir=output_dir)
 
     # Define the default language
     default_language = _get_default_language(site.languages)

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -25,7 +25,17 @@ This file is named jahia_site to avoid a conflict with Site [https://docs.python
 class Site:
     """A Jahia Site. Have 1 to N Pages"""
 
-    def __init__(self, base_path, name, root_path=""):
+    def __init__(self, base_path, name, root_path="", fix_etx_chars=False):
+        """
+        Create an instance of object
+
+        :param base_path: Base path to dir containing extracted Jahia ZIP files
+        :param name: Site name
+        :param root_path: (optional) ?
+        :param fix_etx_chars: (optional) to tell if we have to fix x03 chars that may be in export_<lang>.xml files.
+                              If this character (=ETX -> End Of Text) is present in a value read by DOM utils, the
+                              string is truncated at x03 position and the following characters are ignored.
+        """
         # FIXME: base_path should not depend on output-dir
         self.base_path = base_path
         self.name = name
@@ -63,6 +73,10 @@ class Site:
                 path = self.base_path + "/" + file
                 self.export_files[language] = path
                 self.languages.append(language)
+
+        # If we have to fix ETX char in XML file,
+        if fix_etx_chars:
+            self.fix_etx_chars()
 
         # site params that are parsed later. There are dicts because
         # we have a value for each language. The dict key is the language,
@@ -132,6 +146,32 @@ class Site:
 
         # generate the report
         self.generate_report()
+
+    def fix_etx_chars(self):
+        """
+        Remove ETX (End of Text) characters from XML files. If this character is present in a value read by DOM utils,
+        the string is truncated at ETX position and the following characters are ignored.
+        :return:
+        """
+
+        # Fixing all XML files
+        for language, dom_path in self.export_files.items():
+            # To rename original file before reading it to remove ETX chars.
+            old_export_file = "{}.old".format(dom_path)
+            # Remove if exists
+            if os.path.exists(old_export_file):
+                os.remove(old_export_file)
+            os.rename(dom_path, old_export_file)
+
+            in_file = open(old_export_file, 'rb')
+            out_file = open(dom_path, 'wb')
+            # Reading file content, replacing ETX char and writing back to output file
+            out_file.write(in_file.read().replace(b'\x03', b''))
+
+            in_file.close()
+            out_file.close()
+            # Remove temp file
+            os.remove(old_export_file)
 
     def full_path(self, path):
         """

--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -56,7 +56,11 @@ class PageContent:
         self.menu_title = self.element.getAttribute("jahia:title")
 
         # Looking if there is an overrided page title (that will be used only on page)
-        self.title = self.element.getElementsByTagName("pageTitle")[0].getAttribute("jahia:value")
+        self.title = self.element.getElementsByTagName("pageTitle")
+
+        if self.title:
+            # Can have a value or be empty
+            self.title = self.title[0].getAttribute("jahia:value")
 
         # If page title is empty (equal to "")
         if not self.title:


### PR DESCRIPTION
**From issue**: WWP-735
**Low level changes:**

1. Pour une raison inconnue, il peut y avoir un caractère ETX (end of text) au milieu d'une chaîne de caractères dans le fichier XML. Ceci arrive pour 2 pages du site https://repro.epfl.ch. La conséquence est que lorsque l'on utilise la bibliothèque DOM pour lire le contenu du fichier et récupérer la valeur d'un attribut, la lecture s'arrête à ce caractère ETX et la suite de la chaîne de caractères n'est pas renvoyée. 
Une option a donc été ajoutée à `jahia2wp.py` en l'état de `--fix-etx-chars`. Elle est disponible pour les commandes `export` et `parse` et permet de dire au système de commencer par supprimer les caractères ETX des fichiers XML avant de commencer le parsing de ceux-ci.
Après discussion durant le daily, il a été décidé de faire ce "nettoyage" pour tous les sites parsés.
1. Petite correction d'un formatage de chaîne de caractères.
1. Ajout de quelques commentaires

**Targetted version**: x.x.x
