### PR TITLE
Handle 'interfaculte' for 'theme_faculty' parsed value

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -315,6 +315,8 @@ class Site:
             self.theme[language] = Utils.get_tag_attribute(dom, "theme", "jahia:value")
             if self.theme[language] == 'associations':
                 self.theme[language] = 'assoc'
+            if self.theme[language] == 'interfaculte':
+                self.theme[language] = None
             self.acronym[language] = Utils.get_tag_attribute(dom, "acronym", "jahia:value")
             self.css_url[language] = "//static.epfl.ch/v0.23.0/styles/{}-built.css".format(self.theme[language])
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. L'import du site "ptnn" ne démarrait pas car la valeur parsée pour le champ `theme_faculty` n'était pas admise comme "correcte"... celle-ci était "interfaculte". 
Après zieutage sur le site officiel https://ptnn.epfl.ch, le look du site est rouge comme les sites qui n'ont pas d'options de couleur de faculté. Donc le code du parser a été modifié pour mettre `None` à la valeur `theme_faculty` si on parsait la valeur "interfaculte".

**Targetted version**: x.x.x
