### PR TITLE
Handle "target" option in hardcoded menu url + menu URLs with #anchor

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1005,16 +1005,12 @@ class WPExporter:
                                     (menu_item.points_to_anchor() and not url.startswith('http')):
                                 url = "{}/{}".format(self.wp_generator.wp_site.url, url)
 
-<<<<<<< HEAD
                             # Generate target information if exists
                             target = "--target={}".format(menu_item.target) if menu_item.target else ""
 
                             cmd = 'menu item add-custom {} "{}" "{}" {} --porcelain' \
-                                .format(menu_name, menu_item.txt, url, target)
-=======
-                            cmd = 'menu item add-custom {} "{}" "{}" --porcelain' \
-                                .format(menu_name, menu_item.txt.replace('"', '\\"'), url)
->>>>>>> 8768927eeec58aa3ea6c31a2d179892011019829
+                                .format(menu_name, menu_item.txt.replace('"', '\\"'), url, target)
+
                             menu_id = self.run_wp_cli(cmd)
                             if not menu_id:
                                 logging.warning("Root menu item not created for URL (%s) ", url)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -877,12 +877,18 @@ class WPExporter:
 
                     # Recovering URL
                     url = menu_item.points_to
-                    # Generate target information if exists
-                    target = "--target={}".menu_item.target if menu_item.target else ""
 
-                    # If menu entry is sitemap, we add WP site base URL
-                    if menu_item.points_to_sitemap():
+                    # If menu entry is sitemap
+                    # OR
+                    # If points to an anchor on a page, URL is not is absolute (starts with 'http').
+                    # If URL is not absolute, this is because it points to a vanity URL defined in Jahia
+                    # THEN we add WP site base URL
+                    if menu_item.points_to_sitemap() or \
+                            (menu_item.points_to_anchor() and not url.startswith('http')):
                         url = "{}/{}".format(self.wp_generator.wp_site.url, url)
+
+                    # Generate target information if exists
+                    target = "--target={}".format(menu_item.target) if menu_item.target else ""
 
                     cmd = 'menu item add-custom {} "{}" "{}" {} --parent-id={} --porcelain' \
                         .format(menu_name, menu_item.txt, url, target, parent_menu_id)
@@ -980,12 +986,18 @@ class WPExporter:
 
                             # Recovering URL
                             url = menu_item.points_to
-                            # Generate target information if exists
-                            target = "--target={}".menu_item.target if menu_item.target else ""
 
-                            # If menu entry is sitemap, we add WP site base URL
-                            if menu_item.points_to_sitemap():
+                            # If menu entry is sitemap
+                            # OR
+                            # If points to an anchor on a page, URL is not is absolute (starts with 'http').
+                            # If URL is not absolute, this is because it points to a vanity URL defined in Jahia
+                            # THEN we add WP site base URL
+                            if menu_item.points_to_sitemap() or \
+                                    (menu_item.points_to_anchor() and not url.startswith('http')):
                                 url = "{}/{}".format(self.wp_generator.wp_site.url, url)
+
+                            # Generate target information if exists
+                            target = "--target={}".format(menu_item.target) if menu_item.target else ""
 
                             cmd = 'menu item add-custom {} "{}" "{}" {} --porcelain' \
                                 .format(menu_name, menu_item.txt, url, target)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -406,7 +406,7 @@ class WPExporter:
             if "content" in wp_page:
                 content = wp_page["content"]["raw"]
             else:
-                logging.error("Expected content for page %s" % wp_page)
+                logging.error("Expected content for page %s", wp_page)
 
             # Step 1 - Fix in shortcode attributes
             # We loop 2 times through self.urls_mapping because the first time we modify directly HTML content
@@ -517,7 +517,7 @@ class WPExporter:
             # point the link to the new url of the page.
             if link.encode('ascii', 'replace').decode('ascii').replace('?', '') == old_url.replace('?', '') \
                     or (pid and link == pid):
-                logging.debug("Changing link from %s to %s" % (old_url, new_url))
+                logging.debug("Changing link from %s to %s", (old_url, new_url))
                 tag[tag_attribute] = new_url
 
     def fix_key_visual_boxes(self):
@@ -749,7 +749,7 @@ class WPExporter:
                 widget_pos_to_lang[str(widget_pos)] = lang
                 widget_pos += 1
 
-                logging.info("Banner imported for '%s' language" % lang)
+                logging.info("Banner imported for '%s' language", lang)
 
             # Then we import sidebar widgets
             for lang in self.site.homepage.contents.keys():
@@ -894,7 +894,7 @@ class WPExporter:
                         .format(menu_name, menu_item.txt, url, target, parent_menu_id)
                     menu_id = self.run_wp_cli(cmd)
                     if not menu_id:
-                        logging.warning("Root menu item not created for URL (%s) " % url)
+                        logging.warning("Root menu item not created for URL (%s) ", url)
                     else:
                         self.report['menus'] += 1
 
@@ -1017,7 +1017,7 @@ class WPExporter:
                                 continue
 
                             if lang not in homepage_child.contents:
-                                logging.warning("Page not translated %s" % homepage_child.pid)
+                                logging.warning("Page not translated %s", homepage_child.pid)
                                 continue
 
                             if homepage_child.contents[lang].wp_id:

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -346,11 +346,11 @@ class WPExporter:
             banner.content = str(soup)
 
     def fix_file_links_in_menu_items(self, menu_item, old_url, new_url):
-        if menu_item.target_is_file():
-                normalized_url = menu_item.target.encode('ascii', 'replace').decode('ascii').replace('?', '')
+        if menu_item.points_to_file():
+                normalized_url = menu_item.points_to.encode('ascii', 'replace').decode('ascii').replace('?', '')
                 normalized_url = normalized_url[normalized_url.rfind("/files"):]
                 if normalized_url == old_url.replace('?', ''):
-                    menu_item.target = new_url
+                    menu_item.points_to = new_url
 
     def fix_file_links_in_menus(self, old_url, new_url):
         for lang in self.site.languages:
@@ -873,17 +873,19 @@ class WPExporter:
             if not menu_item.hidden:
 
                 # If menu entry is an hardcoded URL
-                if menu_item.target_is_url() or menu_item.target_is_sitemap():
+                if menu_item.points_to_url() or menu_item.points_to_sitemap():
 
                     # Recovering URL
-                    url = menu_item.target
+                    url = menu_item.points_to
+                    # Generate target information if exists
+                    target = "--target={}".menu_item.target if menu_item.target else ""
 
                     # If menu entry is sitemap, we add WP site base URL
-                    if menu_item.target_is_sitemap():
+                    if menu_item.points_to_sitemap():
                         url = "{}/{}".format(self.wp_generator.wp_site.url, url)
 
-                    cmd = 'menu item add-custom {} "{}" "{}" --parent-id={} --porcelain' \
-                        .format(menu_name, menu_item.txt, url, parent_menu_id)
+                    cmd = 'menu item add-custom {} "{}" "{}" {} --parent-id={} --porcelain' \
+                        .format(menu_name, menu_item.txt, url, target, parent_menu_id)
                     menu_id = self.run_wp_cli(cmd)
                     if not menu_id:
                         logging.warning("Root menu item not created for URL (%s) " % url)
@@ -893,10 +895,10 @@ class WPExporter:
                 # menu entry is page
                 else:
                     # Trying to get corresponding page corresponding to current page UUID
-                    child = self.site.homepage.get_child_with_uuid(menu_item.target, 4)
+                    child = self.site.homepage.get_child_with_uuid(menu_item.points_to, 4)
 
                     if child is None:
-                        logging.error("Submenu creation: No page found for UUID %s", menu_item.target)
+                        logging.error("Submenu creation: No page found for UUID %s", menu_item.points_to)
                         continue
 
                     if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
@@ -973,18 +975,20 @@ class WPExporter:
 
                         # If root menu entry is an hardcoded URL
                         # OR a sitemap link
-                        if menu_item.target_is_url() or \
-                                menu_item.target_is_sitemap():
+                        if menu_item.points_to_url() or \
+                                menu_item.points_to_sitemap():
 
                             # Recovering URL
-                            url = menu_item.target
+                            url = menu_item.points_to
+                            # Generate target information if exists
+                            target = "--target={}".menu_item.target if menu_item.target else ""
 
                             # If menu entry is sitemap, we add WP site base URL
-                            if menu_item.target_is_sitemap():
+                            if menu_item.points_to_sitemap():
                                 url = "{}/{}".format(self.wp_generator.wp_site.url, url)
 
-                            cmd = 'menu item add-custom {} "{}" "{}" --porcelain' \
-                                .format(menu_name, menu_item.txt, url)
+                            cmd = 'menu item add-custom {} "{}" "{}" {} --porcelain' \
+                                .format(menu_name, menu_item.txt, url, target)
                             menu_id = self.run_wp_cli(cmd)
                             if not menu_id:
                                 logging.warning("Root menu item not created for URL (%s) ", url)
@@ -994,10 +998,10 @@ class WPExporter:
                         # root menu entry is pointing to a page
                         else:
                             # Trying to get corresponding page corresponding to current page UUID
-                            homepage_child = self.site.homepage.get_child_with_uuid(menu_item.target, 3)
+                            homepage_child = self.site.homepage.get_child_with_uuid(menu_item.points_to, 3)
 
                             if homepage_child is None:
-                                logging.error("Menu creation: No page found for UUID %s", menu_item.target)
+                                logging.error("Menu creation: No page found for UUID %s", menu_item.points_to)
                                 continue
 
                             if lang not in homepage_child.contents:

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -40,7 +40,7 @@ class MenuItem:
                                             '',
                                             self.points_to,
                                             0,
-                                            re.IGNORECASE)
+                                            re.IGNORECASE).strip()
 
         self.hidden = hidden
         self.children = []

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -1,14 +1,15 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017"""
+import re
 
 
 class MenuItem:
     """ To store menu item information """
 
-    def __init__(self, txt, target, hidden):
+    def __init__(self, txt, points_to, hidden):
         """ Constructor
 
         txt - Menu link text
-        target - Can be several things
+        points_to - On what link is pointing to. Can be several things
             -- Reference to another jahia page,using its uuid (like c058dc4f-247d-4b23-90d7-25e1206f7de3)
             -- hardcoded URL (absolute URL)
             -- link to sitemap (so equals 'sitemap')
@@ -16,21 +17,43 @@ class MenuItem:
             -- None if normal menu entry for page
         """
         self.txt = txt
-        self.target = target
-        if self.target:
-            self.target = self.target.strip()
+        self.target = None
+        self.points_to = points_to
+        if self.points_to:
+            self.points_to = self.points_to.strip()
+
+            # If is link and value contains a specific target
+            # ex: http://tmclub.eu/signup.php" target="_blank
+            if self.points_to_url() and 'target=' in self.points_to.lower():
+                # Extracting target
+                # http://tmclub.eu/signup.php" target="_blank
+                # To
+                # _blank
+                target = re.findall(r'target="([^".]*)', self.points_to, re.IGNORECASE)
+                if target:
+                    self.target = target[0]
+                    # Extracting URL
+                    # http://tmclub.eu/signup.php" target="_blank
+                    # To
+                    # http://tmclub.eu/signup.php
+                    self.points_to = re.sub(r'target="{}("?)|"'.format(self.target),
+                                            '',
+                                            self.points_to,
+                                            0,
+                                            re.IGNORECASE)
+
         self.hidden = hidden
         self.children = []
         self.children_sort_way = None
 
-    def target_is_url(self):
-        return False if self.target is None else self.target.startswith('http')
+    def points_to_url(self):
+        return False if self.points_to is None else self.points_to.startswith('http')
 
-    def target_is_sitemap(self):
-        return self.target == "sitemap"
+    def points_to_sitemap(self):
+        return self.points_to == "sitemap"
 
-    def target_is_file(self):
-        return False if self.target is None else '/files/' in self.target
+    def points_to_file(self):
+        return False if self.points_to is None else '/files/' in self.points_to
 
     def sort_children(self, sort_way):
         self.children_sort_way = sort_way

--- a/src/parser/menu_item.py
+++ b/src/parser/menu_item.py
@@ -19,6 +19,7 @@ class MenuItem:
         self.txt = txt
         self.target = None
         self.points_to = points_to
+
         if self.points_to:
             self.points_to = self.points_to.strip()
 
@@ -46,8 +47,11 @@ class MenuItem:
         self.children = []
         self.children_sort_way = None
 
+    def points_to_anchor(self):
+        return False if self.points_to is None else '#' in self.points_to
+
     def points_to_url(self):
-        return False if self.points_to is None else self.points_to.startswith('http')
+        return False if self.points_to is None else self.points_to.startswith('http') or self.points_to_anchor()
 
     def points_to_sitemap(self):
         return self.points_to == "sitemap"


### PR DESCRIPTION
**From issue**: WWP-739

**High level changes:**

1. Dans les URL hardcodées des entrées de menus Jahia, les personnes ont parfois ajouté un paramètre ` target="..."` qui était pris comme faisant partie de l'URL, donc l'importation du menu foirait. 
Ajout de la gestion des "target" et adaptation des noms de données membres utilisées dans la classe `MenuItem` afin d'être logique. Le menu est ensuite construit en ajoutant ce paramètre dans la commande WPCLI (qui supporte `--target=...`)
1. Les entrées de menu du style `<pageName>#<anchor>` étaient identifiées comme des ID de pages alors que ce sont des URLs (qui pointent sur une Vanity URL de page, sur un anchor en particulier).
Identification de ce type d'entrée de menu comme étant des URL et ajout de l'URL du site au début pour créer des entrées de menu avec des URL hard-codées. Même si on a un ID de page dans l'URL et qu'on pourrait l'utiliser pour pointer sur la bonne page dans le menu, il n'est pas possible (ou alors j'ai pas trouvé dans WPCLI) de passer l'ancre (#) en paramètre.

**Low level changes:**

1. Changement de `self.target` par `self.points_to` dans la classe `MenuItem` pour pouvoir utiliser `self.target` pour stocker le paramètre de "target=" mentionné précédemment.
1. Correction de quelques formattage de string utilisant encore `%` au lieu de `,` pour séparer la chaîne et les paramètres

**Targetted version**: x.x.x
