### PR TITLE
File url not fixed in header banner

### DIFF
--- a/src/parser/banner.py
+++ b/src/parser/banner.py
@@ -1,10 +1,6 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
 
 
-from bs4 import BeautifulSoup
-import re
-
-
 class Banner:
     """ To store website banner information. """
 
@@ -13,16 +9,4 @@ class Banner:
         """ Constructor
 
         content - HTML content of the banner """
-
-        # If there are image in banner, they may have following code aspect, so cleaning is necessary :
-        # ###file:/content/sites/skyrmions/files/Image-1.jpg?uuid=default:d1c1c1d4-7d23-45d7-b6fc-c10df12ef91e
-        soup = BeautifulSoup(content, 'html.parser')
-
-        images = soup.find_all('img')
-
-        for image in images:
-            # Cleaning image source
-            # FIXME: Maybe there's a better way to remove the /content/sites/<sitename> from URL...
-            image['src'] = re.sub(r"###file:/content/sites/[a-zA-Z0-9-\.]+|\?.+", "", image.get('src'))
-
-        self.content = str(soup)
+        self.content = content

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -35,6 +35,9 @@ class Site:
         # FIXME: would be better in exporter, or set by exporter
         self.root_path = root_path
 
+        # Type of links we have to ignore during link fix process
+        self.link_type_to_ignore = ["javascript", "tel://", "tel:", "callto:", "smb://", "file://"]
+
         # parse the properties at the beginning, we need the
         # server_name for later
         self.parse_properties()
@@ -574,20 +577,97 @@ class Site:
 
     def fix_links(self):
         """
-        Fix all the boxes links. This must be done at the end,
-        when all the pages have been parsed.
+        Fix all the boxes and banners links. This must be done at the end, when all the pages have been parsed.
         """
+        # List of type and attributes that we have to fix
+        tag_attribute_tuples = [("a", "href"), ("img", "src"), ("script", "src")]
+
+        # 1. Looping through Boxes
         for box in self.get_all_boxes():
             soup = BeautifulSoup(box.content, 'html5lib')
             soup.body.hidden = True
 
-            self.fix_links_in_tag(box=box, soup=soup, tag_name="a", attribute="href")
-            self.fix_links_in_tag(box=box, soup=soup, tag_name="img", attribute="src")
-            self.fix_links_in_tag(box=box, soup=soup, tag_name="script", attribute="src")
+            for tag_name, tag_attribute in tag_attribute_tuples:
+                self.fix_all_links_in_tag(box=box, soup=soup, tag_name=tag_name, attribute=tag_attribute)
 
-    def fix_links_in_tag(self, box, soup, tag_name, attribute):
+        # 2. Looping through banners to fix only file links
+        # FIXME: Maybe, in the future, we will have to also fix other types of links in banners
+        for lang, banner in self.banner.items():
+
+            soup = BeautifulSoup(banner.content, 'html5lib')
+            soup.body.hidden = True
+
+            for tag_name, tag_attribute in tag_attribute_tuples:
+                self.fix_file_links_in_tag(soup=soup, tag_name=tag_name, attribute=tag_attribute)
+
+            # save the new banner content
+            banner.content = str(soup.body)
+
+    def fix_file_links_in_tag(self, soup, tag_name, attribute):
         """
-        Fix the links in the given type of tag
+        Fix only links to files in given BeautifulSoup object.
+        This code was previously in fix_all_links_in_tag() function but because we also have to fix file links for
+        banners and not only for boxes, it has been moved to a dedicated function.
+        File links update will be directly done in 'soup' parameter and nothing will be returned by the function
+
+        :param soup: instance of BeautifulSoup in which file links have to be fixed.
+        :param tag_name: name of tag to look for
+        :param attribute: name of tag attribute to update
+        :return:
+        """
+
+        tags = soup.find_all(tag_name)
+
+        for tag in tags:
+            link = tag.get(attribute)
+
+            if not link:
+                continue
+
+            for link_type in self.link_type_to_ignore:
+                if link.startswith(link_type):
+                    return
+
+            if link.startswith("###file"):
+
+                if "/files/" in link:
+                    new_link = link[link.index('/files/'):]
+
+                    # If we have a link like this :
+                    # ?uuid=default:a6d36162-07da-4036-9b58-a32e416f7769
+                    if "?" in new_link and "?uuid=default:" in new_link:
+
+                        uuid = new_link[new_link.index(":") + 1:]
+
+                        # If we have an UUID match, we take it. Otherwise, we take the "real" link.
+                        if uuid in self.file_uuid_to_url:
+                            new_link = self.file_uuid_to_url[uuid]
+                        else:
+                            new_link = new_link[:new_link.index("?")]
+
+                    else:  # We don't have an UUID in the link
+                        if "?" in new_link:
+                            new_link = new_link[:new_link.index("?")]
+
+                    tag[attribute] = self.full_path(new_link)
+
+                    self.file_links += 1
+
+                # if we don't have /files/ in the path the link is broken (happen
+                # only in 3 sites)
+                else:
+                    self.broken_links += 1
+                    logging.debug("Found broken file link %s", link)
+
+    def fix_all_links_in_tag(self, box, soup, tag_name, attribute):
+        """
+        Fix all types of links in given box for given tag and attribute.
+        Updates will directly be done in 'box' parameter and nothing will be returned by function.
+
+        :param box: instance of Box in which links have to be fixed
+        :param soup: instance of BeautifulSoup with box content
+        :param tag_name: name of tag to look for
+        :param attribute: name of tag attribute to update
         """
         tags = soup.find_all(tag_name)
 
@@ -597,11 +677,8 @@ class Site:
             if not link:
                 continue
 
-            # links we are ignoring
-            ignore = ["javascript", "tel://", "tel:", "callto:", "smb://", "file://"]
-
-            for element in ignore:
-                if link.startswith(element):
+            for link_type in self.link_type_to_ignore:
+                if link.startswith(link_type):
                     return
 
             # internal Jahia links
@@ -673,32 +750,9 @@ class Site:
                 self.absolute_links += 1
             # file links
             elif link.startswith("###file"):
-                if "/files/" in link:
-                    new_link = link[link.index('/files/'):]
 
-                    # If we have a link like this :
-                    # ?uuid=default:a6d36162-07da-4036-9b58-a32e416f7769
-                    if "?" in new_link and "?uuid=default:" in new_link:
+                self.fix_file_links_in_tag(soup, tag_name, attribute)
 
-                        uuid = new_link[new_link.index(":")+1:]
-                        # If we have an UUID match, we take it. Otherwise, we take the "real" link.
-                        if uuid in self.file_uuid_to_url:
-                            new_link = self.file_uuid_to_url[uuid]
-                        else:
-                            new_link = new_link[:new_link.index("?")]
-
-                    else:  # We don't have an UUID in the link
-                        if "?" in new_link:
-                            new_link = new_link[:new_link.index("?")]
-
-                    tag[attribute] = self.full_path(new_link)
-
-                    self.file_links += 1
-                # if we don't have /files/ in the path the link is broken (happen
-                # only in 3 sites)
-                else:
-                    self.broken_links += 1
-                    logging.debug("Found broken file link %s", link)
             # broken file links
             elif link.startswith("/fileNotFound###"):
                 self.broken_links += 1


### PR DESCRIPTION
**From issue**:  WWP-740

**High level changes:**

1. Lors du parsing, le contenu (liens) des objets Banner n'était pas mis à jour pour que ça fonctionne sur WordPress. Le site https://complexdesign.epfl.ch/ n'avait pas sa banner qui était affichée en haut. Et pour cause, le fichier référencé dans le code HTML est une "surcharge" du vrai nom de fichier.

**Low level changes:**

1. Suppression du nettoyage fait dans la classe `Banner` pour les URL sur les images car ceci doit être fait plus loin dans le parser pour respecter la logique en place pour le reste. Du coup, il ne reste pas grand chose dans la classe...
1. Déplacement du code pour corriger les liens sur les fichiers dans une fonction dédiée (`fix_file_links_in_tag`) afin de pouvoir l'appeler aussi pour corriger le contenu des Banner en plus de celui des Box.
1. Renommage de la fonction `fix_links_in_tag` en `fix_all_links_in_tag` afin que ça soit quelque peu "logique" avec la nouvelle fonction `fix_file_links_in_tag` qui a été ajoutée.
1. Déplacement de la liste des types de liens à ignorer (`self.link_type_to_ignore`) lors de la reconstruction pour que ça soit une donnée membre car elle est finalement utilisée à plusieurs endroit.
1. Ajout de commentaires (entête de fonctions)

**Targetted version**: x.x.x
