### PR TITLE
Correct sitemap order, remove 'index-html' page from URL when accessing other page than hompeage

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -694,10 +694,13 @@ class WPExporter:
         for page in self.site.pages_by_pid.values():
             for lang, page_content in page.contents.items():
 
-                if page.parent and page_content.wp_id:
-                    parent_id = page.parent.contents[lang].wp_id
+                # If page has parent (is not homepage)
+                # AND parent is not homepage
+                # AND we have an ID for its content,
+                if page.parent and not page.parent.is_homepage() and page_content.wp_id:
+                    # We use the page parent id to update it in WordPress
                     wp_page_info = {
-                        'parent': parent_id
+                        'parent': page.parent.contents[lang].wp_id
                     }
                     self.wp.post_pages(page_id=page.contents[lang].wp_id, data=wp_page_info)
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -725,7 +725,7 @@ class WPExporter:
             wp_page = self.update_page(
                 page_id=sitemap_wp_id,
                 title='sitemap',
-                content='[simple-sitemap show_label="false" types="page orderby="menu_order"]'
+                content='[simple-sitemap show_label="false" types="page" orderby="menu_order"]'
             )
             self.create_footer_menu_for_sitemap(sitemap_wp_id=wp_page['id'], lang=lang)
 

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -15,7 +15,7 @@ from parser.sitemap_node import SitemapNode
 from parser.menu_item import MenuItem
 from parser.banner import Banner
 from utils import Utils
-
+from collections import OrderedDict
 
 """
 This file is named jahia_site to avoid a conflict with Site [https://docs.python.org/3/library/site.html]
@@ -98,7 +98,7 @@ class Site:
         self.footer = {}
 
         # the Pages indexed by their pid and uuid
-        self.pages_by_pid = {}
+        self.pages_by_pid = OrderedDict()
         self.pages_by_uuid = {}
 
         # the PageContents indexed by their path


### PR DESCRIPTION
**From issue**: WWP-755, WWP-753

**High level changes:**

1. Lorsque l'on voulait accéder à une page différente de la "homepage", une page "intermédiaire" s'ajoutait dans l'URL, en l'état de "index-html". Ceci provient du fait que toutes les pages "racine" du menu ne sont pas des pages de niveau 0 lorsqu'elles sont importées mais de niveau 1, toutes "greffées" sous la homepage (qui est référencée par "index-html"). Sous Jahia, il ne peut pas y avoir de pages au même niveau que la homepage et celles qui sont au "premier niveau" sont en fait des enfants direct de la homepage. Le parsing du site prend ceci en compte. Du coup, pour corriger ceci, il a été plus simple de corriger l'export directement. Ainsi, les pages qui ont pour parent la homepage ne voient pas leur parent mis à jour une fois qu'elles ont été importées.
1. L'ordre des pages affichées sur le sitemap avait été configuré pour que cela reflète l'ordre du menu. Cependant, cela ne fonctionnait pas... pourquoi? simplement parce selon la documentation de Sitemap pour ce qui est du critère de tri (https://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters), lorsque l'on met `menu_order` il se base sur le champ `Order` d'une page et non sa réelle position dans le menu... Le champ `Order` d'une page est initialisé automatiquement lors de l'import de la page (incrémentation automatique). Et comme les pages étaient stockées dans un `Dict`, cet ordre changeait à chaque import du site. En utilisant un `OrderedDict`, cela affiche correctement le sitemap.

**Low level changes:**

1. Ajout d'un check pour savoir si une page avait la "homepage" comme parent avant de changer son parent après l'avoir importée dans WordPress
1. Correction d'une erreur de " manquante dans la génération du shortcode pour le sitemap.

**Targetted version**: x.x.x
