### PR TITLE
Handle 'None' parsed taglines

### DIFF
--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -50,7 +50,16 @@ class WPSite:
         self.domain = url.netloc.strip('/')
         self.folder = url.path.strip('/')
         self.wp_site_title = wp_site_title or self.DEFAULT_TITLE
-        self.wp_tagline = wp_tagline or self.DEFAULT_TAGLINE
+        # If parameter not given
+        if not wp_tagline:
+            self.wp_tagline = self.DEFAULT_TAGLINE
+        # Parameter given (dict)
+        else:
+            self.wp_tagline = wp_tagline
+            # We check given information to be sure that we don't have a 'None' given
+            for lang, wp_tagline in self.wp_tagline.items():
+                if not wp_tagline:
+                    self.wp_tagline[lang] = self.DEFAULT_TAGLINE
 
     def __repr__(self):
         return self.url


### PR DESCRIPTION
**From issue**: WWP-655

**High level changes:**

1. Le site https://sportstech.epfl.ch ne contient aucune tagline dans l'export Jahia et ceci n'était pas géré par l'exporter et ça faisait ensuite planter le site lors de la tentative de configuration de Polylang.... Ajout de la gestion de la chose pour mettre la tagline définie par défaut dans `WPSite` dans le cas où elle serait à `None` dans le dictionnaire retourné par le parsing.

**Targetted version**: x.x.x
