### PR TITLE
Improve memory usage during Jahia ZIP download

### DIFF
--- a/src/crawler/crawler.py
+++ b/src/crawler/crawler.py
@@ -8,7 +8,6 @@ import timeit
 import requests
 from collections import OrderedDict
 from datetime import timedelta
-from clint.textui import progress
 import os
 
 from tracer.tracer import Tracer
@@ -30,7 +29,7 @@ class JahiaCrawler(object):
         if self.skip_download:
             files = self.config.existing_files
             file_path = files[-1]
-            logging.info("%s - zip already downloaded %sx. Last one is %s",
+            logging.info("%s - ZIP already downloaded %sx. Last one is %s",
                          self.site, len(files), file_path)
             Tracer.write_row(site=self.site, step="download", status="OK")
             return file_path
@@ -39,7 +38,7 @@ class JahiaCrawler(object):
         start_time = timeit.default_timer()
 
         # make query. The call to session.post will wait until ZIP has been generated on Jahia site.
-        logging.info("%s - downloading %s...", self.site, self.config.file_name)
+        logging.info("%s - Downloading %s...", self.site, self.config.file_name)
         response = self.session_handler.session.post(
             self.config.file_url,
             params=self.config.download_params,
@@ -54,27 +53,24 @@ class JahiaCrawler(object):
             response.raise_for_status()
 
         # adapt streaming function to content-length in header
-        logging.debug("%s - headers %s", self.site, response.headers)
-
-        def read_stream():
-            return response.iter_content(chunk_size=4096)
+        logging.debug("%s - Headers %s", self.site, response.headers)
 
         # download file
-        logging.info("%s - saving response into %s...", self.site, self.config.file_path)
+        logging.info("%s - Saving response into %s...", self.site, self.config.file_path)
         with open(self.config.file_path, 'wb') as output:
-            for chunk in read_stream():
+            for chunk in response.iter_content(chunk_size=4096):
                 if chunk:
                     output.write(chunk)
                     output.flush()
 
         zip_stats = os.stat(self.config.file_path)
         if zip_stats.st_size < 200:
-            logging.error("The jahia zip file for WordPress site is empty")
-            raise Exception("Jahia zip is empty")
+            logging.error("The Jahia ZIP file for WordPress site is empty")
+            raise Exception("Jahia ZIP is empty")
 
         # log execution time and return path to downloaded file
         elapsed = timedelta(seconds=timeit.default_timer() - start_time)
-        logging.info("%s - file downloaded in %s", self.site, elapsed)
+        logging.info("%s - File downloaded in %s", self.site, elapsed)
         Tracer.write_row(site=self.site, step="download", status="OK")
 
         # return PosixPath converted to string


### PR DESCRIPTION
**From issue**: WWP-756

**High level changes:**

1. Avant, tout le contenu du ZIP était mis en mémoire avant d'être écrit. C'est la faute à Greg qui a ajouté le bout de code posant problème ici : https://github.com/epfl-idevelop/jahia2wp/commit/39de1c5bf29379c1c0a7652f4d8328e6d18f20d8#diff-c794fa8f045b3c47ef273fb8c8954fce 😝 
Le fait de demander la taille de `response` via  `len(response.content)` bah ça faisait que tout était téléchargé en mémoire... et la lecture "bloc par bloc" faite par la suite dans le Stream, bah ça lisait en mémoire et ça écrivait le fichier.
J'ai donc déplacé le check de Greg pour le mettre après download du ZIP, en regardant quelle taille ça faisait sur le disque.
1. Il y avait aussi une implémentation pour avoir une "ProgressBar" du téléchargement mais elle se basait sur la valeur du champ `Content-Length` du header de la `response`. Cependant, ce champ était toujours à `None` donc la "ProgressBar", n'était jamais affichée. J'ai donc viré ça aussi et simplifié l'appel à l'itérateur de `response` permettant de récupérer le contenu. 

**Low level changes:**

1. Petites correction "typo" dans le logging.

**Targetted version**: x.x.x
