### PR TITLE
Bugfix: take only first level children to look for overrided page title

### DIFF
--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -7,6 +7,7 @@ from settings import JAHIA_DATE_FORMAT
 from parser.sidebar import Sidebar
 import logging
 import re
+from utils import Utils
 
 
 class PageContent:
@@ -54,13 +55,18 @@ class PageContent:
         """
         # For menu title, we have to use default page title
         self.menu_title = self.element.getAttribute("jahia:title")
+        self.title = ""
 
-        # Looking if there is an overrided page title (that will be used only on page)
-        self.title = self.element.getElementsByTagName("pageTitle")
+        # Looking if there is an overrided page title (that will be used only on page). We have to look only
+        # in direct children otherwise there's a risque we get a child page's title.
+        page_list_list = Utils.get_dom_next_level_children(self.element, "pageTitleListList")
 
-        if self.title:
-            # Can have a value or be empty
-            self.title = self.title[0].getAttribute("jahia:value")
+        if page_list_list:
+            self.title = page_list_list[0].getElementsByTagName('pageTitle')
+
+            if self.title:
+                # Can have a value or be empty
+                self.title = self.title[0].getAttribute("jahia:value")
 
         # If page title is empty (equal to "")
         if not self.title:

--- a/src/parser/test/__init__.py
+++ b/src/parser/test/__init__.py
@@ -1797,7 +1797,7 @@ class Data:
                                                                    {'content__start': '', 'title': '', 'type': 'text'},
                                                                    {'content__start': '[memento url=]', 'title': '', 'type': 'memento'}],
                                                 'menu_title': 'Atelier web EPFL',
-                                                'title': 'Recommendations for use : Google Analytics'},
+                                                'title': 'Atelier web EPFL'},
                                          'fr': {'boxes': [{'content__start': '<p><img alt="" height="184" src="/files/pictures/web-services2.jpg" '
                                                                              'width="652"/></p> ',
                                                            'title': '',
@@ -1856,7 +1856,7 @@ class Data:
                                                                    {'content__start': '', 'title': '', 'type': 'text'},
                                                                    {'content__start': '[memento url=]', 'title': '', 'type': 'memento'}],
                                                 'menu_title': '',
-                                                'title': 'Recommendations for use : Google Analytics'},
+                                                'title': ''},
                                          'fr': {'boxes': [{'content__start': "<p>L'équipe des Services Web déploie des activités selon 3 missions "
                                                                              ':</p> <ul>  <li><span style="text-decoration: underline;">Coordinateur '
                                                                              'd’informati',


### PR DESCRIPTION
**From issue**: WWP-307

**High level changes:**

1. Correction d'un bug dans la cherche des titres de pages surchargés, on ne cherchait pas que dans les enfants directs dont on pouvait tomber sur une surcharge d'une page enfant de la page courante.

**Targetted version**: x.x.x
