### PR TITLE
Bugfix: greek language

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -89,7 +89,7 @@ SUPPORTED_LANGUAGES = {
     "de": "de_CH",
     "es": "es_ES",
     "ro": "ro_RO",
-    "gr": "el",
+    "el": "el",
     "it": "it_IT"
 }
 


### PR DESCRIPTION
**From issue**: WWP-813

**High level changes:**

1. Correction de l'erreur de l'ajout du langage "Grec" lors de la création du site.

**Low level changes:**

1. Mise à jour de `settings.py` pour mettre "el" au lieu de "gr" comme identificateur de la langue grecque

**Targetted version**: x.x.x
