### PR TITLE
Bugfix: if parsed tag is... surprising

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -944,7 +944,10 @@ Parsed for %s :
         self.report += "  - tags :\n\n"
 
         for tag in num_tags_ordered:
-            self.report += "    - <%s> %s\n" % (tag, self.num_tags[tag])
+            # Tag is encoded and decoded to remove special char that cause script to crash when report is printed if
+            # it contains surprising tags !
+            self.report += "    - <%s> %s\n" % (tag.encode('ascii', 'replace').decode('ascii').replace('?', ''),
+                                                self.num_tags[tag])
 
     def __repr__(self):
         return self.name


### PR DESCRIPTION
**From issue**: WWP-814

**High level changes:**

1. Le site "atelierweb" contient quelque part dans le XML un tag avec un caractère spécial. Ceci fait que lorsque l'on affiche le rapport de parsing du site, ça part aux fraises...

**Low level changes:**

1. Ajout d'un encodage/décodage des tags lors de la génération du rapport qui fait que les caractères spéciaux sont réencodés correctement pour qu'ils puissent être affichés dans la console sans que ça fasse crasher le script. Y'avait peut-être une autre manière de faire mais là, ça fonctionne.

**Targetted version**: x.x.x
