### PR TITLE
Bugfix: Prepare ColoredTextBox title in case it contains (double) quotes

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -775,7 +775,7 @@ class WPExporter:
                         widget_type = 'text'
                         title = ""
                         content = "[colored-box]"
-                        content += "<h3>{}</h3>".format(box.title)
+                        content += prepare_html("<h3>{}</h3>".format(box.title))
                         content += prepare_html(box.content)
                         content += "[/colored-box]"
 


### PR DESCRIPTION
**From issue**: WWP-816

**High level changes:**

1. Si une coloredTextBox contient des (doubles) quotes dans le titre, l'import va foirer via WPCLI car les (doubles) quotes n'auront pas été échappés correctement.

**Low level changes:**

1. "préparation" du titre comme on le fait pour le contenu de la boîte.

**Targetted version**: x.x.x
