### PR TITLE
Add 'src' attribute for 'embed' tag

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -311,8 +311,6 @@ class WPExporter:
         new_url = wp_media['source_url']
         self.medias_mapping[new_url] = wp_media['id']
 
-        tag_attribute_tuples = [("a", "href"), ("img", "src"), ("script", "src"), ("source", "src")]
-
         # 1. Looping through boxes
         for box in self.site.get_all_boxes():
 
@@ -323,7 +321,7 @@ class WPExporter:
             soup.body.hidden = True
 
             # fix in html tags
-            for tag_name, tag_attribute in tag_attribute_tuples:
+            for tag_name, tag_attribute in settings.FILE_LINKS_TAG_TO_FIX:
                 self.fix_links_in_tag(
                     soup=soup,
                     old_url=old_url,
@@ -342,7 +340,7 @@ class WPExporter:
 
             soup = BeautifulSoup(banner.content, 'html.parser')
 
-            for tag_name, tag_attribute in tag_attribute_tuples:
+            for tag_name, tag_attribute in settings.FILE_LINKS_TAG_TO_FIX:
                 self.fix_links_in_tag(
                     soup=soup,
                     old_url=old_url,

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -4,6 +4,7 @@ import os
 import logging
 import collections
 import re
+import settings
 
 from bs4 import BeautifulSoup
 from parser.box import Box
@@ -624,15 +625,13 @@ class Site:
         """
         Fix all the boxes and banners links. This must be done at the end, when all the pages have been parsed.
         """
-        # List of type and attributes that we have to fix
-        tag_attribute_tuples = [("a", "href"), ("img", "src"), ("script", "src"), ("source", "src")]
 
         # 1. Looping through Boxes
         for box in self.get_all_boxes():
             soup = BeautifulSoup(box.content, 'html5lib')
             soup.body.hidden = True
 
-            for tag_name, tag_attribute in tag_attribute_tuples:
+            for tag_name, tag_attribute in settings.FILE_LINKS_TAG_TO_FIX:
                 self.fix_all_links_in_tag(box=box, soup=soup, tag_name=tag_name, attribute=tag_attribute)
 
         # 2. Looping through banners to fix only file links
@@ -642,7 +641,7 @@ class Site:
             soup = BeautifulSoup(banner.content, 'html5lib')
             soup.body.hidden = True
 
-            for tag_name, tag_attribute in tag_attribute_tuples:
+            for tag_name, tag_attribute in settings.FILE_LINKS_TAG_TO_FIX:
                 self.fix_file_links_in_tag(soup=soup, tag_name=tag_name, attribute=tag_attribute)
 
             # save the new banner content

--- a/src/settings.py
+++ b/src/settings.py
@@ -93,6 +93,9 @@ SUPPORTED_LANGUAGES = {
     "it": "it_IT"
 }
 
+# List of tags and attribute to fix in file links when parsing and exporting Jahia site to WordPress
+FILE_LINKS_TAG_TO_FIX = [("a", "href"), ("img", "src"), ("script", "src"), ("source", "src"), ("embed", "src")]
+
 SUPPORTED_TRUE_STRINGS = ['true', 'yes', 'y', 'on', '1']
 
 DEFAULT_CONFIG_INSTALLS_LOCKED = True


### PR DESCRIPTION
**From issue**: WWP-482

**High level changes:**

1. Ajout de la gestion de l'attribut `src` pour le tag `embed` pour ce qui est de la liste des tags/attributs dans lesquels mettre à jour les liens.

**Low level changes:**

1. Déplacement de la liste des tags/attributs dans `settings.py` car la même liste est utilisée à la fois dans le parser et l'exporter et il est vite fait d'oublier de modifier d'un des deux côtés.

**Targetted version**: x.x.x
