### PR TITLE
Fix order to install plugins

### DIFF
--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import os
 import logging
 import copy
@@ -35,7 +37,7 @@ class WPPluginList:
             logging.error("%s - Specific config path not exists: %s", repr(self), specific_config_path)
 
         # For specific plugins configuration
-        self._generic_plugins = {}
+        self._generic_plugins = OrderedDict()
 
         # Extend possibilities of YAML reader
         yaml.add_constructor("!include", self._yaml_include)


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Installer les plugins dans l'ordre

**Low level changes:**

1. Si le plugin shortcode-ui est installé après shortcode-ui-richtext cela génère une erreur. Par contre si shortcode-ui est installé avant shortcode-ui-richtext aucun problème. Solution installer les plugins dans l'ordre défini dans data/plugins/generic/config-lot1.yml. Pour cela, la transformation du dict des plugins en OrderDict suffit 

**Targetted version**: x.x.x
