### PR TITLE
Fix stickers actu display

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -301,9 +301,9 @@ class Box:
             template = ""
             logging.warning("News Shortcode - template is missing")
 
-        # in actu.epfl.ch if sticker parameter exists, sticker is not display
+        # in actu.epfl.ch if sticker parameter exists, sticker is not displayed
         # (whatever the value of sticker parameter)
-        # if sticker parameter does not exist, sticker is display
+        # if sticker parameter does not exist, sticker is displayed
         if 'sticker' in parameters:
             stickers = "no"
         else:

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -301,9 +301,13 @@ class Box:
             template = ""
             logging.warning("News Shortcode - template is missing")
 
-        stickers = "no"
+        # in actu.epfl.ch if sticker parameter exists, sticker is not display
+        # (whatever the value of sticker parameter)
+        # if sticker parameter does not exist, sticker is display
         if 'sticker' in parameters:
-            stickers = parameters['sticker'][0]
+            stickers = "no"
+        else:
+            stickers = "yes"
 
         category = ""
         if 'category' in parameters:


### PR DESCRIPTION
**From issue**: #xx

**Low level changes:**

1. Pour le shortcode des actus, le sticker (l'étiquette sur l'image est le nom de la catégorie de la news) ne s'affichait pas pour un site. C'est corrigé !
 
**Targetted version**: x.x.x
