### PR TITLE
Bugfix: menu entry name incorrect if reference to another page

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -932,7 +932,7 @@ class WPExporter:
 
                     # If menu entry is sitemap
                     # OR
-                    # If points to an anchor on a page, URL is not is absolute (starts with 'http').
+                    # If points to an anchor on a page AND URL is not is absolute (starts with 'http').
                     # If URL is not absolute, this is because it points to a vanity URL defined in Jahia
                     # THEN we add WP site base URL
                     if menu_item.points_to_sitemap() or \
@@ -963,10 +963,16 @@ class WPExporter:
                     if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
                             child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
 
+                        # If we have a menu entry title and it is different as the page title, we take the menu title
+                        if menu_item.txt != "" and menu_item.txt != child.contents[lang].menu_title:
+                            menu_txt = menu_item.txt
+                        else:
+                            menu_txt = child.contents[lang].menu_title
+
                         command = 'menu item add-post {} {} --title="{}" --parent-id={} --porcelain' \
                             .format(menu_name,
                                     child.contents[lang].wp_id,
-                                    child.contents[lang].menu_title.replace('"', '\\"'),
+                                    menu_txt.replace('"', '\\"'),
                                     parent_menu_id)
 
                         menu_id = self.run_wp_cli(command)

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -964,10 +964,7 @@ class WPExporter:
                             child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
 
                         # If we have a menu entry title and it is different as the page title, we take the menu title
-                        if menu_item.txt != "" and menu_item.txt != child.contents[lang].menu_title:
-                            menu_txt = menu_item.txt
-                        else:
-                            menu_txt = child.contents[lang].menu_title
+                        menu_txt = menu_item.txt if menu_item.txt != "" else child.contents[lang].menu_title
 
                         command = 'menu item add-post {} {} --title="{}" --parent-id={} --porcelain' \
                             .format(menu_name,

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -249,24 +249,24 @@ class Site:
                         if txt == '':
                             continue
                         hidden = jahia_type.getAttribute("jahia:hideFromNavigationMenu") != ""
-                        target = "sitemap" if jahia_type.getAttribute("jahia:template") == "sitemap" \
+                        points_to = "sitemap" if jahia_type.getAttribute("jahia:template") == "sitemap" \
                             else jahia_type.getAttribute("jcr:uuid")
                     # If URL
                     elif jahia_type.nodeName == "jahia:url":
                         txt = jahia_type.getAttribute("jahia:title")
-                        target = jahia_type.getAttribute("jahia:value")
+                        points_to = jahia_type.getAttribute("jahia:value")
 
                         self.num_url_menu += 1
                     # If link to another page in the menu
                     elif jahia_type.nodeName == "jahia:link":
                         txt = jahia_type.getAttribute("jahia:title")
-                        target = jahia_type.getAttribute("jahia:reference")
+                        points_to = jahia_type.getAttribute("jahia:reference")
 
                         self.num_link_menu += 1
                     else:
                         continue
 
-                    menu_item = MenuItem(txt, target, hidden)
+                    menu_item = MenuItem(txt, points_to, hidden)
 
                     # If we are parsing root menu entries
                     if parent_menu is None:


### PR DESCRIPTION
**From issue**: WWP-796

**High level changes:**

1. Lorsqu'une entrée de menu est une référence à une autre page, un titre est mis et celui-ci peut être différent de celui de la page. Modifications pour prendre le titre du menu à la place du titre de la page si celui-ci n'est pas vide.

**Low level changes:**

1. Changement du nom d'une variable dans le parser afin que ça corresponde au nom de la variable dans la classe `MenuItem`. Sinon ce n'est pas très logique...

**Targetted version**: x.x.x
