### PR TITLE
Remove TODO from sidebar SNIPPET widget title

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -858,7 +858,7 @@ class WPExporter:
                         continue
 
                     if box.type in [Box.TYPE_TOGGLE, Box.TYPE_TEXT, Box.TYPE_CONTACT, Box.TYPE_LINKS, Box.TYPE_FILES,
-                                    Box.TYPE_INCLUDE, Box.TYPE_MEMENTO, Box.TYPE_ACTU]:
+                                    Box.TYPE_INCLUDE, Box.TYPE_MEMENTO, Box.TYPE_ACTU, Box.TYPE_SNIPPETS]:
                         widget_type = 'custom_html'
                         title = prepare_html(box.title)
                         content = prepare_html(box.content)


### PR DESCRIPTION
**From issue**: WWP-1027

**High level changes:**

1. Suppression du "TODO" dans le titre de la box "snippets" qui s'affiche dans la sidebar

**Targetted version**: x.x.x
