### PR TITLE
Fix unnecessery env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,8 +22,6 @@ WP_PORT_HTTPS=443
 # WP MANAGEMENT
 WP_PORT_PHPMA=8080
 WP_PORT_SSHD=2222
-# relative to jahia2wp/src
-PLUGINS_CONFIG_BASE_PATH=wordpress/tests/plugins/
 
 
 # JAHIA variables


### PR DESCRIPTION
**Low level changes:**

1. Remove PLUGINS_CONFIG_BASE_PATH from sample .env file, as there is a working fallback if it is missing