### PR TITLE
Add Jahia redirection for Jahia files to be accessed on WordPress

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1274,7 +1274,7 @@ class WPExporter:
         Update .htaccess file with redirections.
         The added redirections are for :
         - Jahia pages to WordPress pages
-        - Jahia medias (files) to WordPress medias. For medias, we will redirect to the upload directory corresponding
+        - Jahia media (files) to WordPress media. For media, we will redirect to the upload directory corresponding
         to year/month of Jahia to WordPress site migration.
         """
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1279,13 +1279,13 @@ class WPExporter:
         """
 
         # Step 1 - Medias
-        current_month = datetime.now().strftime('%m')
-        current_year = datetime.now().strftime('%Y')
+        if self.site.files:
+            current_month = datetime.now().strftime('%m')
+            current_year = datetime.now().strftime('%Y')
 
-        redirect_list = ["RewriteRule ^files/content/(.*/)*(.*)$ wp-content/uploads/{}/{}/$2 "
-                         "[R=301,NC,L]".format(current_year, current_month)]
+            redirect_list = ["RewriteRule ^files/content/(.*/)*(.*)$ wp-content/uploads/{}/{}/$2 "
+                             "[R=301,NC,L]".format(current_year, current_month)]
 
-        if redirect_list:
             # Updating .htaccess file
             WPUtils.insert_in_htaccess(self.wp_generator.wp_site.path,
                                        "Jahia-Files-Redirect",

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1271,15 +1271,34 @@ class WPExporter:
 
     def write_redirections(self):
         """
-        Update .htaccess file with redirections
+        Update .htaccess file with redirections.
+        The added redirections are for :
+        - Jahia pages to WordPress pages
+        - Jahia medias (files) to WordPress medias. For medias, we will redirect to the upload directory corresponding
+        to year/month of Jahia to WordPress site migration.
         """
-        redirect_list = []
 
+        # Step 1 - Medias
+        current_month = datetime.now().strftime('%m')
+        current_year = datetime.now().strftime('%Y')
+
+        redirect_list = ["RewriteRule ^files/content/(.*/)*(.*)$ wp-content/uploads/{}/{}/$2 "
+                         "[R=301,NC,L]".format(current_year, current_month)]
+
+        if redirect_list:
+            # Updating .htaccess file
+            WPUtils.insert_in_htaccess(self.wp_generator.wp_site.path,
+                                       "Jahia-Files-Redirect",
+                                       redirect_list,
+                                       at_beginning=True)
+
+        # Step 2 - Pages
         # Init WP install folder path for source URLs
         if self.wp_generator.wp_site.folder == "":
             folder = ""
         else:
             folder = "/{}".format(self.wp_generator.wp_site.folder)
+        redirect_list = []
 
         # Add all rewrite jahia URI to WordPress URI
         for element in self.urls_mapping:


### PR DESCRIPTION
**From issue**: WWP-1132

**High level changes:**

1. Une fois migrés de Jahia à WordPress, les fichiers n'étaient plus accessibles si référencés depuis d'autres sites. Ajout d'une règle `RewriteRule` dans le `.htaccess` pour rediriger les demandes à des fichiers afin qu'ils puissent être affichés par WordPress.

**Low level changes:**

1. La `RewriteRule` dans le fichier `.htaccess` attrape les demandes pour l'URL commençant par `files/content/`, extrait le nom du fichier demandé et reconstruit l'URL pour pointer sur `wp-content/uploads/...`. Arrivés dans ce dossier, il faut ajouter 2 niveaux de dossiers en l'état de l'année et du mois (ex:  `wp-content/uploads/2018/06/`) et ajouter le nom du fichier demandé afin qu'il puisse être atteint. L'année et le mois correspondent au moment où le site a été importé dans WordPress.

**Targetted version**: x.x.x
