### PR TITLE
Bugfix: Tagline check (duplicated code)

### DIFF
--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -42,13 +42,6 @@ class WPSite:
         if wp_site_title is not None:
             validate_string(wp_site_title)
 
-        if wp_tagline is not None:
-            for lang, lang_tagline in wp_tagline.items():
-                # If tagline empty, we set it to site title. Same behaviour as 'export' function in jahia2wp.py file
-                if lang_tagline == "":
-                    lang_tagline = wp_site_title
-                validate_string(lang_tagline)
-
         # set WP information
         self.domain = url.netloc.strip('/')
         self.folder = url.path.strip('/')
@@ -63,6 +56,7 @@ class WPSite:
             for lang, wp_tagline in self.wp_tagline.items():
                 if not wp_tagline:
                     self.wp_tagline[lang] = self.DEFAULT_TAGLINE
+                validate_string(self.wp_tagline[lang])
 
     def __repr__(self):
         return self.url

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -44,6 +44,9 @@ class WPSite:
 
         if wp_tagline is not None:
             for lang, lang_tagline in wp_tagline.items():
+                # If tagline empty, we set it to site title. Same behaviour as 'export' function in jahia2wp.py file
+                if lang_tagline == "":
+                    lang_tagline = wp_site_title
                 validate_string(lang_tagline)
 
         # set WP information


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Erreur d'import pour le site 'emahp' car la tagline pour une des 2 langues est vide dans le ZIP. Le problème provenait de code partiellement dupliqué qui existait pour le check de la tagline. Peut-être que ceci provenait un merge manuel foireux... bref. Réadaptation du code.

**Targetted version**: x.x.x
