### PR TITLE
Add image to rotate apache logs

### DIFF
--- a/build/logrotate/Dockerfile
+++ b/build/logrotate/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gzip \
+  && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+COPY rotate.sh /
+RUN chmod a+x /rotate.sh
+
+ENTRYPOINT ["/rotate.sh"]

--- a/build/logrotate/rotate.sh
+++ b/build/logrotate/rotate.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+TODAY=$(date +%Y%m%d)
+
+# Delete the file older than DAYS
+find /srv/*/logs \( -name access_log.* -o -name error_log.* \) -mtime +${DAYS} -delete || echo "Failed to purge log files"
+
+# Compress the files
+find /srv/*/logs \( -name access_log.* -o -name error_log.* \) ! -name *.${TODAY} ! -name *.gz -exec gzip {} \; || echo "Failed to compress log files"
+
+exit 0


### PR DESCRIPTION
This docker image allows to create a cronjob that will rotate the apache logs