### PR TITLE
Bugfix: PHP Notice, way to recover current lang in footer

### DIFF
--- a/data/wp/wp-content/themes/epfl-master/footer.php
+++ b/data/wp/wp-content/themes/epfl-master/footer.php
@@ -19,10 +19,26 @@
     			<nav class="footer-navigation" role="navigation">
       			
       			<?php
-          			
-        			$currentLang = pll_current_language(locale);
-        			
-        			if( $currentLang == "fr_FR" ) {
+
+                    /* Configuration */
+                    $epfl_allowed_langs = array('en', 'fr');
+                    $epfl_default_lang = 'en';
+                    /* If Polylang installed */
+                    if(function_exists('pll_current_language'))
+                    {
+                        /* Get current lang */
+                         $epfl_cur_lang = pll_current_language('slug');
+                         /* Check if current lang is supported. If not, use default lang*/
+                         if(!in_array($epfl_cur_lang, $epfl_allowed_langs)) $epfl_cur_lang=$epfl_default_lang;
+
+                    }
+                    else /* Polylang not installed */
+                    {
+                        $epfl_cur_lang = $epfl_default_lang;
+                    }
+
+
+        			if( $epfl_cur_lang == "fr" ) {
           			$linkLegal = "https://mediacom.epfl.ch/disclaimer-fr";
                 $linkAccess = "https://www.epfl.ch/accessibility.fr.shtml";
         			} else {

--- a/data/wp/wp-content/themes/epfl-master/header.php
+++ b/data/wp/wp-content/themes/epfl-master/header.php
@@ -32,24 +32,24 @@
 	<div class="header-top wrap">
 		<?php
 		/* Configuration */
-		$allowed_langs = array('en', 'fr');
-		$default_lang = 'en';
+		$epfl_allowed_langs = array('en', 'fr');
+		$epfl_default_lang = 'en';
 		/* If Polylang installed */
 		if(function_exists('pll_current_language'))
 		{
 			/* Get current lang */
-			 $cur_lang = pll_current_language('slug');
+			 $epfl_cur_lang = pll_current_language('slug');
 			 /* Check if current lang is supported. If not, use default lang*/
-			 if(!in_array($cur_lang, $allowed_langs)) $cur_lang=$default_lang;
+			 if(!in_array($epfl_cur_lang, $epfl_allowed_langs)) $epfl_cur_lang=$epfl_default_lang;
 
 		}
 		else /* Polylang not installed */
 		{
-			$cur_lang = $default_lang;
+			$epfl_cur_lang = $epfl_default_lang;
 		}
 
 		?>
-  	<header id="epfl-header" class="site-header epfl" data-ajax-header="https://static.epfl.ch/latest/includes/epfl-header.<?php echo $cur_lang; ?>.html"></header>
+  	<header id="epfl-header" class="site-header epfl" data-ajax-header="https://static.epfl.ch/latest/includes/epfl-header.<?php echo $epfl_cur_lang; ?>.html"></header>
 	</div><!-- .header-top -->
 
 	<header id="masthead" class="site-header" role="banner">


### PR DESCRIPTION
**From issue**: -

**Low level changes:**

1. Il y avait un `PHP Notice` qui s'affichait dans le fichier `debug.log` lorsque je débuggais un truc donc j'ai investigué. En fait, le `footer.php`du thème n'avait pas été modifié correctement pour identifier la langue de la page (récupération de l'info dans Polylang s'il existait)... Ceci a été corrigé.
1. Ajout d'un préfix `epfl_` aux variables utilisées pour identifier la langue dans le `footer.php` et `header.php`

**Targetted version**: x.x.x
