### PR TITLE
Fix only caching partial html for infoscience shortcode

### DIFF
--- a/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
@@ -45,13 +45,16 @@ function epfl_infoscience_process_shortcode( $attributes, $content = null )
             $response = wp_remote_get( $url );
             $page = wp_remote_retrieve_body( $response );
 
+            // wrap the page
+            $page = '<div class="infoscienceBox">'.
+                        $page.
+                    '</div>';
+
             // cache the result
             wp_cache_set( $url, $page, 'epfl_infoscience' );
 
             // return the page
-            return '<div class="infoscienceBox">'.
-                    $page.
-                    '</div>';
+            return $page;
         } else {
             $error = new WP_Error( 'not found', 'The url passed is not part of Infoscience or is not found', $url );
             epfl_infoscience_log( $error );


### PR DESCRIPTION
Selon que l'on attaquait le cache ou en direct pour afficher la liste des publications Infoscience, la div InfoscienceBox n'était pas à chaque fois incluse.