### PR TITLE
setuptools needed for "pip install -r requirements/local.txt"

### DIFF
--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-virtualenv \
+    python3-setuptools \
     virtualenv \
     screen \
     unzip \


### PR DESCRIPTION
**From issue**: "pip install -r requirements/local.txt" was failing (not listed in JIRA)

**High level changes:**

None

**Low level changes:**

Make sure the Docker image contains setuptools
