### PR TITLE
Add "build" tools to the mgmt image

### DIFF
--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -3,7 +3,9 @@ FROM debian:stretch
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash-completion \
     curl \
+    composer \
     git \
+    gnupg \
     htop \
     less \
     make \
@@ -25,6 +27,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     vim && \
     apt-get clean
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get -y install nodejs
 
 RUN mkdir /var/run/sshd && \
     sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config && \


### PR DESCRIPTION
**From issue**: Need to "composer install" for Antistatique theme

**High level changes:**

None visible.
**Low level changes:**

Add the following to the "mgmt" image:
* composer for PHP
* node and npm for JS
* gnupg because Node's install script requires it to check the
  integrity chain

⚠ To be cherry-picked onto master