### PR TITLE
Bump PHP to 7.1

### DIFF
--- a/build/httpd/Dockerfile
+++ b/build/httpd/Dockerfile
@@ -2,18 +2,29 @@ FROM debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apache2 \
+    curl \
     ca-certificates \
-    libapache2-mod-php7.0 \
     libapache2-mod-security2 \
     modsecurity-crs \
-    php7.0 \
-    php7.0-gd \
-    php7.0-curl \
-    php7.0-mysql \
-    php7.0-mbstring \
-    php7.0-ldap \
-    php7.0-xml \
     vim \
+  && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+RUN curl https://packages.sury.org/php/apt.gpg > /etc/apt/trusted.gpg.d/php.gpg
+RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
+# The following goodies have dependencies above this line, and
+# thus must be installed in another round of apt-get
+RUN  apt-get -y update && \
+  apt-get -y install nodejs \
+    libapache2-mod-php7.1 \
+    php7.1 \
+    php7.1-gd \
+    php7.1-cli \
+    php7.1-curl \
+    php7.1-mysql \
+    php7.1-zip \
+    php7.1-xml \
   && \
     apt-get -y autoremove && \
     apt-get clean

--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
     bash-completion \
     curl \
     composer \
@@ -12,24 +12,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mysql-client \
     openssh-server \
     tree \
-    php7.0 \
-    php7.0-gd \
-    php7.0-cli \
-    php7.0-curl \
-    php7.0-mysql \
-    php7.0-zip \
-    php7.0-xml \
     python3 \
     python3-pip \
     python3-virtualenv \
     virtualenv \
     screen \
+    software-properties-common \
     unzip \
-    vim && \
+    vim \
+  && \
+    apt-get -y autoremove && \
     apt-get clean
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get -y install nodejs
+RUN curl https://packages.sury.org/php/apt.gpg > /etc/apt/trusted.gpg.d/php.gpg
+RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
+RUN apt-get -y update
+# The following goodies have dependencies above this line, and
+# thus must be installed in another round of apt-get
+RUN apt-get -y install nodejs \
+    php7.1 \
+    php7.1-gd \
+    php7.1-cli \
+    php7.1-curl \
+    php7.1-mysql \
+    php7.1-zip \
+    php7.1-xml \
+  && \
+    apt-get -y autoremove && \
+    apt-get clean
+
 
 RUN mkdir /var/run/sshd && \
     sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config && \


### PR DESCRIPTION
**From issue**: Required by Antistatique's composer.json

As explained in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886722 , Debian
doesn't care to track even minor versions of PHP in their backports.
Instead, use the "ppa for Debian" approach from
https://unix.stackexchange.com/a/129590/1595

⚠ Again, this is against master and needs to be merged onto release.

**High level changes:**

PHP 7.1!

**Low level changes:**

* Split Dockerfiles differently (two bouts of apt-get install are necessary e.g. before/after installing curl and adding the repository for PHP 7.1)