### PR TITLE
Make dependency on lsb-release explicit

### DIFF
--- a/build/httpd/Dockerfile
+++ b/build/httpd/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     libapache2-mod-security2 \
+    lsb-release \
     modsecurity-crs \
     vim \
   && \

--- a/build/mgmt/Dockerfile
+++ b/build/mgmt/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     gnupg \
     htop \
     less \
+    lsb-release \
     make \
     mysql-client \
     openssh-server \


### PR DESCRIPTION
**From issue**: failed build on test Openshift

For whatever reason, I was lucky when trying to build the images on my
laptop and this dependency was implicitly added. Not so much on Openshift.

⚠ Again, to be merged to release too.