### PR TITLE
Have "make bootstrap-local" do "make pull" first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ down: check-env
 	 WP_PORT_HTTPS=${WP_PORT_HTTPS} \
 	 docker-compose down
 
-bootstrap-local:
+bootstrap-local: pull
 	[ -f .env ] || cp .env.sample .env
 	[ -f etc/.bash_history ] || cp etc/.bash_history.sample etc/.bash_history
 	sudo chown -R `whoami`:33 .


### PR DESCRIPTION
In case the named (tagged) image is not available, the behavior of
docker-compose is to use "build" rather than pulling. Force the
opposite to happen through the Makefile, by ensuring that the tagged
image is indeed available before "make up".

N.B.: this problem only presents itself for new users that *do not*
yet have the images downloaded.

**From issue**: The one that @LuluTchab warned me about and I stubbornly refused to listen ☺

**High level changes:**

`make bootstrap local` now causes `make pull`

**Low level changes:**

That's pretty much all there is to it.
