### PR TITLE
Language not correctly handled if uuid used in linksBox

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -789,7 +789,8 @@ class Box:
                                 page = self.site.pages_by_uuid[jahia_tag.getAttribute("jahia:reference")]
                             except KeyError as e:
                                 continue
-                            link_html = '<a href="{}">{}</a>'.format(page.pid, jahia_tag.getAttribute("jahia:title"))
+                            url = "/page-{}-{}.html".format(page.pid, self.page_content.language)
+                            link_html = '<a href="{}">{}</a>'.format(url, jahia_tag.getAttribute("jahia:title"))
 
                         elif jahia_tag.tagName == "jahia:url":
                             link_html = '<a href="{}">{}</a>'.format(jahia_tag.getAttribute("jahia:value"),

--- a/src/parser/test/__init__.py
+++ b/src/parser/test/__init__.py
@@ -623,7 +623,7 @@ class Data:
                                                  'language': 'fr',
                                                  'last_update': datetime.datetime(2015, 3, 26, 15, 0, 41),
                                                  'path': '/outils-applications-web/cms-jahia',
-                                                 'sidebar__boxes': [{'content__start': '<ul><li><a href="41450">Obtenir un site web '
+                                                 'sidebar__boxes': [{'content__start': '<ul><li><a href="/page-41450-fr.html">Obtenir un site web '
                                                                                        'EPFL</a></li><li><a href="http://jahia.epfl.ch">En savoir '
                                                                                        'plus sur Jahia</a></li></ul>',
                                                                      'title': 'Liens utiles',
@@ -644,7 +644,7 @@ class Data:
                                                  'language': 'fr',
                                                  'last_update': datetime.datetime(2015, 3, 26, 15, 1, 50),
                                                  'path': '/outils-applications-web/hebergement-lamp',
-                                                 'sidebar__boxes': [{'content__start': '<ul><li><a href="97525">Obtenir un hébergement '
+                                                 'sidebar__boxes': [{'content__start': '<ul><li><a href="/page-97525-fr.html">Obtenir un hébergement '
                                                                                        'web</a></li><li><a '
                                                                                        'href="http://wiki.epfl.ch/lamp-help-fr">Consulter l\'aide '
                                                                                        "sur l'hébergement LAMP</a><",
@@ -4228,7 +4228,7 @@ class Data:
                                                 'last_update': datetime.datetime(2016, 8, 3, 13, 20, 15),
                                                 'path': '/obtenir-site-web/hebergement',
                                                 'sidebar__boxes': [{'content__start': '<ul><li><a href="http://jahia.epfl.ch">Demander un site Jahia '
-                                                                                      '(recommandé)</a></li><li><a href="130305">Demander un '
+                                                                                      '(recommandé)</a></li><li><a href="/page-130305-fr.html">Demander un '
                                                                                       'hébergement LAMP (expert)</a></li>',
                                                                     'title': 'Demandes',
                                                                     'type': 'links'},
@@ -4704,11 +4704,11 @@ class Data:
                            'data_links': 0,
                            'external_links': 384,
                            'file_links': 389,
-                           'internal_links': 113,
+                           'internal_links': 115,
                            'mailto_links': 162,
                            'num_files': 434,
                            'num_pages': 146,
-                           'unknown_links': 12},
+                           'unknown_links': 10},
                 'server_name': 'atelierweb.epfl.ch',
                 'theme': {'en': 'epfl', 'fr': 'epfl'},
                 'title': {'en': 'WEB at EPFL', 'fr': 'ATELIER WEB'}}}


### PR DESCRIPTION
**From issue**: WWP-1240

**High level changes:**

1. Si, dans une linkBox, on utilisait des `jahia:reference` pour pointer sur une autre page, l'URL générée mettait uniquement le pid de la page Jahia pointée. Le problème est qu'un PID désigne une page ainsi que toutes les traductions qu'elle contient. Il y avait donc un problème de langue pointée qui était incorrect lors de la reconstruction des liens durant l'export du site. 
Maintenant, au lieu de mettre uniquement le "pid" de la page, c'est fait comme pour le contenu de EPFL-Snippets, à savoir qu'on reconstruit une URL "Jahia like" : `/page-12345-fr.html` et du coup, on garde l'information sur la langue lorsque l'exporter est appelé et c'est la bonne URL qui est remplacée.

**Targetted version**: x.x.x
