### PR TITLE
Handle box group sorting

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -411,7 +411,7 @@ class WPExporter:
 
     def fix_page_links_in_pages(self, wp_pages, site_folder):
         """
-        Fix all the links once we know all the WordPress pages urls
+        Fix all the links once we know all the WordPress pages urls and then update page in WordPress
         :param wp_pages: list of pages to fix
         :param site_folder: path to folder containing website files
         :return:
@@ -661,40 +661,58 @@ class WPExporter:
             contents = OrderedDict()
             info_page = OrderedDict()
 
+            # To save processed boxes. When we find a box that needs to be sort with other boxes, we directly will
+            # process all boxes to sort and we will add them to this list. This will avoid to process sorted boxes twice
+            done_boxes = []
+
             for lang in page.contents.keys():
                 contents[lang] = ""
 
                 # create the page content
                 for box in page.contents[lang].boxes:
 
-                    # We skip empty boxes
-                    if box.is_empty():
+                    # We skip empty boxes and the ones already processed
+                    if box.is_empty() or box in done_boxes:
                         continue
 
-                    if not box.is_shortcode():
-                        contents[lang] += '<div class="{}">'.format(box.type + "Box")
+                    # If box have to be sort
+                    if box.sort_group:
+                        # We recover all boxes belonging to the "sort group".
+                        sorted_boxes = box.sort_group.get_sorted_boxes()
+                    else:
+                        # There's only one box to "sort"
+                        sorted_boxes = [box]
 
-                        if box.title:
-                            if WPUtils.is_html(box.title):
-                                contents[lang] += '<h3>{}</h3>'.format(box.title)
-                            else:
-                                slug = slugify(box.title)
-                                contents[lang] += '<h3 id="{}">{}</h3>'.format(slug, box.title)
+                    # Looping through boxes to sort (in correct order)
+                    for box_to_sort in sorted_boxes:
 
-                        # If cleaning required
-                        if features_flags:
-                            box.content = self.apply_features_flags(box.content)
+                        if not box_to_sort.is_shortcode():
+                            contents[lang] += '<div class="{}">'.format(box_to_sort.type + "Box")
 
-                    # in the parser we can't know the current language.
-                    # we assign a string that we replace with the current language
-                    if box.type in (Box.TYPE_PEOPLE_LIST, Box.TYPE_MAP):
-                        if Box.UPDATE_LANG in box.content:
-                            box.content = box.content.replace(Box.UPDATE_LANG, lang)
+                            if box_to_sort.title:
+                                if WPUtils.is_html(box_to_sort.title):
+                                    contents[lang] += '<h3>{}</h3>'.format(box_to_sort.title)
+                                else:
+                                    slug = slugify(box_to_sort.title)
+                                    contents[lang] += '<h3 id="{}">{}</h3>'.format(slug, box_to_sort.title)
 
-                    contents[lang] += box.content
+                            # If cleaning required
+                            if features_flags:
+                                box_to_sort.content = self.apply_features_flags(box_to_sort.content)
 
-                    if not box.is_shortcode():
-                        contents[lang] += "</div>"
+                        # in the parser we can't know the current language.
+                        # we assign a string that we replace with the current language
+                        if box_to_sort.type in (Box.TYPE_PEOPLE_LIST, Box.TYPE_MAP):
+                            if Box.UPDATE_LANG in box_to_sort.content:
+                                box_to_sort.content = box_to_sort.content.replace(Box.UPDATE_LANG, lang)
+
+                        contents[lang] += box_to_sort.content
+
+                        if not box_to_sort.is_shortcode():
+                            contents[lang] += "</div>"
+
+                        # To remember that box was processed
+                        done_boxes.append(box_to_sort)
 
                 info_page[lang] = {
                     'post_name': page.contents[lang].path,

--- a/src/parser/box_sorted_group.py
+++ b/src/parser/box_sorted_group.py
@@ -1,0 +1,43 @@
+"""(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
+
+from collections import OrderedDict
+
+
+class BoxSortedGroup:
+    """ To group boxes that have to be sort using on of their property field """
+
+    def __init__(self, uuid, sort_field, sort_way):
+        """
+        Class constructor
+
+        :param uuid: uuid of sort handler
+        :param sort_field: field used to sort
+        :param sort_way: sort way ('asc', 'desc')
+        """
+        self.uuid = uuid
+        self.sort_field = sort_field
+        self.sort_way = sort_way.lower()
+        self.boxes = OrderedDict()
+
+    def add_box_to_sort(self, box, sort_field_value):
+        """
+        Add a box to the sort group.
+        :param box: Instance of Box class
+        :param sort_field_value: value to use to sort the group
+        :return:
+        """
+        self.boxes[sort_field_value] = box
+
+    def get_sorted_boxes(self):
+        """
+        Returns a list with sorted boxes
+        Sort and returns this way is the only working way I found. Maybe it's possible to do better with less code lines
+        :return:
+        """
+        ordered_keys = sorted(self.boxes, reverse=(self.sort_way == 'desc'))
+
+        box_list = []
+        for key in ordered_keys:
+            box_list.append(self.boxes[key])
+
+        return box_list

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -15,6 +15,7 @@ from parser.page_content import PageContent
 from parser.sitemap_node import SitemapNode
 from parser.menu_item import MenuItem
 from parser.banner import Banner
+from parser.box_sorted_group import BoxSortedGroup
 from utils import Utils
 from collections import OrderedDict
 
@@ -64,6 +65,9 @@ class Site:
 
         # the site languages
         self.languages = []
+
+        # List of sort groups used to sort groups of boxes
+        self.box_sort_groups = {}
 
         # the WordPress shortcodes used in the site. The key is the shortcode name,
         # and the value is the shortcode attributes containing URLs that must be
@@ -176,6 +180,25 @@ class Site:
             out_file.close()
             # Remove temp file
             os.remove(old_export_file)
+
+    def get_box_sort_group(self, uuid, sort_params):
+        """
+        Generate (if not exists) a Box sort group associated to given uuid.
+        Sort handlers are managed here
+        :param uuid: ID of sortHandler
+        :param sort_params: String containing sort parameters
+        :return: SortHandler object
+        """
+
+        if uuid not in self.box_sort_groups:
+
+            # Sort handler for uuid doesn't exists so we have to create it
+            # First, we extract params from sort_params: ex => "lastModified;desc;true;true"
+            params = sort_params.split(";")
+
+            self.box_sort_groups[uuid] = BoxSortedGroup(uuid, params[0], params[1])
+
+        return self.box_sort_groups[uuid]
 
     def full_path(self, path):
         """
@@ -570,7 +593,8 @@ class Site:
 
     def register_shortcode(self, name, attributes, box):
         """
-        Register the given shortcode.
+        Register the given shortcode with specified attributes. Content of those attributes (usually links) will be
+        fixed during export in WordPress.
 
         :param name: the shortcode name
         :param attributes: a list with the shortcode attributes that must be fixed by WPExporter


### PR DESCRIPTION
**From issue**: WWP-1057

**High level changes:**

1. Jahia permet de trier un groupe de boîte via un champ donné et dans un sens donné. Ajout du nécessaire pour effectuer ce tri.

**Low level changes:**

1. Ajout d'une classe `BoxSortedGroup` pour enregistrer les informations de tri d'un groupe de boîte. 
1. Durant le parsing, lorsque l'on tombe sur une boîte qui doit être triée avec d'autres, on créé (si n'existe pas encore) une instance de `BoxSortedGroup` qui a un uuid unique (venant de l'export Jahia) et qui permettra de regrouper les boîtes à trier dedans. 
1. Durant l'export, dès qu'on tombe sur une boîte avec des infos de tri, on récupère toutes celles avec lesquelles elle doit être triée, dans l'ordre, et on les affiche dans le bon ordre, tout en enregistrant au passage qu'on les a traitées afin de ne pas les retraiter une 2e fois.
1. Petit ajout de double quotes autour de l'URL infoscience dans son shortcode

**Targetted version**: x.x.x
