### PR TITLE
Remove 'Todo' for RSS box in sidebar and remove meta

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -887,7 +887,8 @@ class WPExporter:
                         continue
 
                     if box.type in [Box.TYPE_TOGGLE, Box.TYPE_TEXT, Box.TYPE_CONTACT, Box.TYPE_LINKS, Box.TYPE_FILES,
-                                    Box.TYPE_INCLUDE, Box.TYPE_MEMENTO, Box.TYPE_ACTU, Box.TYPE_SNIPPETS]:
+                                    Box.TYPE_INCLUDE, Box.TYPE_MEMENTO, Box.TYPE_ACTU, Box.TYPE_SNIPPETS,
+                                    Box.TYPE_RSS]:
                         widget_type = 'custom_html'
                         title = prepare_html(box.title)
                         content = prepare_html(box.content)

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -659,15 +659,17 @@ class Box:
         max = nb_items
         feed_title = "yes"
         summary = "yes"
+        meta = "yes"
 
         if hide_title == "true":
             feed_title = "no"
 
         if detail_items != "true":
             summary = "no"
+            meta = "no"
 
-        self.content = "[feedzy-rss feeds=\"{}\" max=\"{}\" feed_title=\"{}\" summary=\"{}\" refresh=\"12_hours\"]" \
-            .format(feeds, max, feed_title, summary)
+        self.content = '[feedzy-rss feeds="{}" max="{}" feed_title="{}" summary="{}" refresh="12_hours" meta="{}"]' \
+            .format(feeds, max, feed_title, summary, meta)
 
     def set_box_links(self, element):
         """set the attributes of a links box"""


### PR DESCRIPTION
**From issue**: WWP-1251

**High level changes:**

1. Il reste encore le texte "TODO" avant le titre de la boîte "RSS" dans la Sidebar. Ajout de la boîte à la liste des boîtes supportées.
1. En plus du titre de l'entrée RSS, il y a aussi le nom de l'auteur et la date du post. Suppression de ces infos s'ils ne faut pas afficher les détails

**Low level changes:**

1. Ajout du paramètre `meta` pour le shortcode de RSS pour contrôler l'affichage de l'auteur et de la date.

**Targetted version**: x.x.x
