### PR TITLE
Bugfix: menu entry referenced page without parent in menu were not added to menu

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1040,8 +1040,8 @@ class WPExporter:
                         logging.error("Submenu creation: No page found for UUID %s", menu_item.points_to)
                         continue
 
-                    if lang in child.contents and child.parent.contents[lang].wp_id in self.menu_id_dict and \
-                            child.contents[lang].wp_id:  # FIXME For unknown reason, wp_id is sometimes None
+                    # FIXME For unknown reason, wp_id is sometimes None
+                    if lang in child.contents and child.contents[lang].wp_id:
 
                         # If we have a menu entry title and it is different as the page title, we take the menu title
                         menu_txt = menu_item.txt if menu_item.txt != "" else child.contents[lang].menu_title


### PR DESCRIPTION
**From issue**: WWP-319

**High level changes:**

1. Il y avait une condition de trop dans un `if` qui faisait que si une entrée de menu référençait une page (via son uuid) dont le parent n'était pas dans le menu, eh bien l'entrée de menu référençant la page n'était pas créé. Après check, la condition n'avait aucune raison d'être donc elle a été supprimée.

**Targetted version**: x.x.x
