### PR TITLE
Bugfix: 'open' tag not just has to be present, it also has to have a …

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -601,7 +601,7 @@ class Box:
 
         self.shortcode_name = 'epfl_toggle'
 
-        if Utils.get_tag_attribute(element, "opened", "jahia:value"):
+        if Utils.get_tag_attribute(element, "opened", "jahia:value") == 'true':
             state = 'open'
         else:
             state = 'close'


### PR DESCRIPTION
**From issue**: WWP-411

**High level changes:**

1. La manière de contrôler si une ToggleBox était ouverte ou fermée n'était pas optimale... la simple présence du tag `<opened` n'était pas suffisante pour déterminer l'état.

**Targetted version**: x.x.x
