### PR TITLE
Only zip files older than 7 days

### DIFF
--- a/build/logrotate/rotate.sh
+++ b/build/logrotate/rotate.sh
@@ -3,11 +3,12 @@
 set -e
 
 TODAY=$(date +%Y%m%d)
+NOZIPDAYS=7
 
 # Delete the file older than DAYS
-find /srv/*/logs \( -name access_log.* -o -name error_log.* \) -mtime +${DAYS} -delete || echo "Failed to purge log files"
+find /srv/*/logs \( -name access_log.* -o -name error_log.* \) -mtime +${KEEPDAYS} -delete || echo "Failed to purge log files"
 
 # Compress the files
-find /srv/*/logs \( -name access_log.* -o -name error_log.* \) ! -name *.${TODAY} ! -name *.gz -exec gzip {} \; || echo "Failed to compress log files"
+find /srv/*/logs \( -name access_log.* -o -name error_log.* \) ! -name *.${TODAY} ! -name *.gz -mtime +${NOZIPDAYS} -exec gzip {} \; || echo "Failed to compress log files"
 
 exit 0


### PR DESCRIPTION
This is a replay (`git rebase`) of PR #493, so that it doesn't conflict anymore

Recent  log files are not zipped immediately. Keep them unzipped for 7 days.  This let us process them again by KELK in case of a failure. Change the DAYS variable name to KEEPDAYS.


