### PR TITLE
Remove duplicate footer, handle custom Jahia footer

### DIFF
--- a/data/wp/wp-content/themes/epfl-master/footer.php
+++ b/data/wp/wp-content/themes/epfl-master/footer.php
@@ -39,18 +39,18 @@
 
 
         			if( $epfl_cur_lang == "fr" ) {
-          			$linkLegal = "https://mediacom.epfl.ch/disclaimer-fr";
-                $linkAccess = "https://www.epfl.ch/accessibility.fr.shtml";
+          			    $legal_link  = "https://mediacom.epfl.ch/disclaimer-fr";
+          			    $access_link = "https://www.epfl.ch/accessibility.fr.shtml";
         			} else {
-          			$linkLegal = "https://mediacom.epfl.ch/disclaimer-en";
-                $linkAccess = "https://www.epfl.ch/accessibility.en.shtml";
+          			    $legal_link  = "https://mediacom.epfl.ch/disclaimer-en";
+                        $access_link = "https://www.epfl.ch/accessibility.en.shtml";
         			}
         			
         		?>
       			
       			<ul class="nav footer-nav">
-        			<li class="legal-notice"><a href="<?php echo $linkLegal; ?>"><?php _e("Legal notice", "epfl"); ?></a></li>
-        			<li class="access"><a href="<?php echo $linkAccess; ?>"><?php _e("Accessibility", "epfl"); ?></a></li>
+        			<li class="legal-notice"><a href="<?php echo $legal_link; ?>"><?php _e("Legal notice", "epfl"); ?></a></li>
+        			<li class="access"><a href="<?php echo $access_link; ?>"><?php _e("Accessibility", "epfl"); ?></a></li>
       			</ul>
       			<?php if ( has_nav_menu( 'footer_nav' ) ) :
   							wp_nav_menu( array(

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -819,7 +819,7 @@ class WPExporter:
         # Update page links in sidebar boxes
         self.fix_page_links_in_sidebar(site_folder)
 
-        self.create_sitemaps()
+        self.create_sitemaps_and_footer()
 
         self.update_parent_ids()
 
@@ -853,7 +853,7 @@ class WPExporter:
                                 time.sleep(settings.WP_CLI_AND_API_NB_SEC_BETWEEN_TRIES)
                                 pass
 
-    def create_sitemaps(self):
+    def create_sitemaps_and_footer(self):
 
         logging.info("Creating sitemap...")
 
@@ -863,7 +863,7 @@ class WPExporter:
             # create sitemap page
 
             info_page[lang] = {
-                'post_name': 'sitemap',
+                'post_name': 'Sitemap',
                 'post_status': 'publish',
             }
 
@@ -875,10 +875,10 @@ class WPExporter:
         for sitemap_wp_id, lang in zip(sitemap_ids, info_page.keys()):
             wp_page = self.update_page(
                 page_id=sitemap_wp_id,
-                title='sitemap',
+                title='Sitemap',
                 content='[simple-sitemap show_label="false" types="page" orderby="menu_order"]'
             )
-            self.create_footer_menu_for_sitemap(sitemap_wp_id=wp_page['id'], lang=lang)
+            self.create_footer_menu(sitemap_wp_id=wp_page['id'], lang=lang)
 
     def import_sidebars(self):
         """
@@ -985,9 +985,9 @@ class WPExporter:
             self.report['failed_widgets'] += 1
             raise e
 
-    def create_footer_menu_for_sitemap(self, sitemap_wp_id, lang):
+    def create_footer_menu(self, sitemap_wp_id, lang):
         """
-        Create footer menu for sitemap page
+        Create footer menu
         """
 
         def clean_menu_html(cmd):
@@ -1000,17 +1000,21 @@ class WPExporter:
         else:
             footer_name = "{}-{}".format(settings.FOOTER_MENU, lang)
 
+        # Defining lang to use for EPFL links
+        link_lang = lang if lang in ['en', 'fr'] else 'en'
+
+        # Add sitemap entry
         self.run_wp_cli('menu item add-post {} {} --porcelain'.format(footer_name, sitemap_wp_id))
 
-        # Create footer menu
-        cmd = "menu item add-custom {} Accessibility http://www.epfl.ch/accessibility.en.shtml​".format(footer_name)
-        cmd = clean_menu_html(cmd)
-        self.run_wp_cli(cmd)
+        # Adding footer entries, if any, for lang
+        for footer_link in self.site.footer[lang]:
+            cmd = "menu item add-custom {} '{}' '{}'".format(footer_name,
+                                                             footer_link.title.replace("'", "\\'"),
+                                                             footer_link.url)
 
-        # legal notice
-        cmd = "menu item add-custom {} 'Legal Notice' http://mediacom.epfl.ch/disclaimer-en".format(footer_name)
-        cmd = clean_menu_html(cmd)
-        self.run_wp_cli(cmd)
+            cmd = clean_menu_html(cmd)
+            self.run_wp_cli(cmd)
+
 
         # Report
         self.report['menus'] += 2

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1000,9 +1000,6 @@ class WPExporter:
         else:
             footer_name = "{}-{}".format(settings.FOOTER_MENU, lang)
 
-        # Defining lang to use for EPFL links
-        link_lang = lang if lang in ['en', 'fr'] else 'en'
-
         # Add sitemap entry
         self.run_wp_cli('menu item add-post {} {} --porcelain'.format(footer_name, sitemap_wp_id))
 
@@ -1014,7 +1011,6 @@ class WPExporter:
 
             cmd = clean_menu_html(cmd)
             self.run_wp_cli(cmd)
-
 
         # Report
         self.report['menus'] += 2

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -491,7 +491,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
                            'epfl-snippet',
                            'epfl-toggle',
                            'epfl-xml',
-                           'epfl-scienceqa'
+                           'epfl-scienceqa',
                            'feedzy-rss-feeds',
                            'remote-content-shortcode',
                            'shortcode-ui',


### PR DESCRIPTION
**From issue**: WWP-1324

**High level changes:**

1. Les entrées "Accessibility" et "Legal notice" étaient (à nouveau) doublées dans le pied de page. Suppression de l'ajout de celles-ci dans l'exporter.
1. Ajout de la gestion des entrées "custom" du pied de page. Celles-ci étaient bien parsées mais jamais utilisées dans l'exporter. Ceci a été ajouté dans la fonction de création du footer qui est appelée par la création du sitemap. Et comme il y a toujours un sitemap, on passe toujours dans cette partie de code.

**Low level changes:**

1. Renommage de fonctions pour que ça soit plus "clair" et "logique"
1. Renommage de variables dans le `footer.php` pour ne plus avoir du camelCase.
1. Correction d'un bug introduit dans https://github.com/epfl-idevelop/jahia2wp/pull/501 et qui n'avait pas été décelé lors de la review... il manquait une virgule à la fin d'une ligne donc 2 chaines de caractères (qui auraient dû être séparées par la virgule) était concaténées et ça affichait une erreur dans la console. Ceci est peut-être passé au travers des mailles du filets lors du check avant soumission de la PR. Conséquence: 2 plugins n'étaient pas réactivés, "sciences-qa" et "feedzy rss".

**Targetted version**: x.x.x
