### PR TITLE
Add check during menu entries sorting to handle KeyError exceptions

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1028,9 +1028,15 @@ class WPExporter:
 
         # If the sub-entries are sorted
         if parent_menu_item.children_sort_way is not None:
-            # Sorting information in the other structure storing the menu information
-            parent_page.children.sort(key=lambda x: x.contents[lang].title,
-                                      reverse=(parent_menu_item.children_sort_way == 'desc'))
+            try:
+
+                # Sorting information in the other structure storing the menu information
+                parent_page.children.sort(key=lambda x: x.contents[lang].title,
+                                          reverse=(parent_menu_item.children_sort_way == 'desc'))
+            except KeyError:
+                logging.error("Sorting menu failed! A page is probably missing in asked language (%s), ignoring it.",
+                              lang)
+                pass
 
         for sub_entry_index, menu_item in enumerate(parent_menu_item.children):
 


### PR DESCRIPTION
**From issue**: WWP-1343

**High level changes:**

1. S'il faut trier le menu ET qu'une page n'est pas traduite dans une des langues, cela provoque une erreur `KeyError` car le contenu dans la langue donnée n'est pas trouvé.

**Low level changes:**

1. Ajout d'une gestion d'exception pour ignorer ce type d'erreur et continer le script.

**Targetted version**: x.x.x
