### PR TITLE
Whitelist a rule when the probe hit "/ready/' URL.

### DIFF
--- a/build/httpd/modsecurity-whitelist.conf
+++ b/build/httpd/modsecurity-whitelist.conf
@@ -25,3 +25,7 @@
 <LocationMatch ".*/wp-admin/admin-ajax.php$">
     SecRuleRemoveById 941100 941160 949110 980130
 </LocationMatch>
+
+<LocationMatch ".*/ready/$">
+    SecRuleRemoveById 920350
+</LocationMatch>


### PR DESCRIPTION
The mod_security fill its logs with garbage because of this alart. 
This url is a genuine openshift probe used to check the service health.
