### PR TITLE
Improve 'update-plugins' command

### DIFF
--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -45,12 +45,13 @@ class WPPluginConfig(WPConfig):
         command_output = self.run_wp_cli(command)
         return False if command_output is True else self.name in command_output
 
-    def install(self):
+    def install(self, force_reinstall=False):
         if self.config.zip_path is not None:
             param = self.config.zip_path
         else:
             param = self.name
-        command = "plugin install {0} ".format(param)
+        force_option = "--force" if force_reinstall else ""
+        command = "plugin install {} {} ".format(force_option, param)
         self.run_wp_cli(command)
 
     def uninstall(self):


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Amélioration de la commande de mise à jour des plugins (`update-plugins`) afin de séparer les options de mise à jour. Au lieu d'avoir un "force" générique qui écrase plugin et config, il y a maintenant une option pour les plugins et une autre pour la config. Ceci permet de mettre à jour tous les plugins sans toucher à leur configuration
1. Ajout d'une autre option permettant de dire si la liste des plugins installés sur un site doit correspondre exactement à celle qui est donnée dans le fichier YAML. Si activée et qu'il y a des plugins en plus, ceux-ci sont désinstallés.



**Targetted version**: x.x.x
