### PR TITLE
Handle 'actu' in 'remote-content'

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -635,10 +635,19 @@ class Box:
 
             self.content = '[{} url="{}" /]'.format(self.shortcode_name, url)
         elif '://infoscience.epfl.ch/' in url:
+            self.set_box_infoscience(element)
 
-            self.shortcode_name = "epfl_infoscience"
+        elif '://actu.epfl.ch/' in url:
 
-            self.content = '[{} url="{}"]'.format(self.shortcode_name, url)
+            self.shortcode_name = "epfl_news"
+
+            # URL looks like https://actu.epfl.ch/webservice/school?channel=8&lang=en&template=3
+            parameters = self._extract_epfl_news_parameters(url)
+
+            self.content = '[{} channel="{}" lang="{}" template="{}" ]'.format(self.shortcode_name,
+                                                                               parameters[0],
+                                                                               parameters[1],
+                                                                               parameters[2])
 
         else:
 


### PR DESCRIPTION
**From issue**: WWP-1358

**High level changes:**

1. Certaines personnes ont utiliser l'option du contenu distant pour pouvoir intégrer Actu. Et comme ce contenu est maintenant hébergé sur Amazon, notre shortcode `remote_content` renvoyait une erreur car ce n'était pas une IP EPFL. Le code a donc été modifié pour détecter les URL d'Actu appelées comme "contenu distant" afin de remettre celles-ci dans le shortcode Actu prévu à cet effet.


**Targetted version**: x.x.x
