### PR TITLE
Display hidden errors (only saved in tracer file)

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -664,6 +664,7 @@ def export_many(csv_file, output_dir=None, admin_password=None, use_cache=None,
                 features_flags=features_flags
             )
         except (Exception, subprocess.CalledProcessError) as e:
+            logging.error(str(e))
             Tracer.write_row(site=row['Jahia_zip'], step=e, status="KO")
 
 

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -576,6 +576,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
             else:
                 logging.info("Site %s already exported to WordPress", site.name)
         except (Exception, subprocess.CalledProcessError) as e:
+            logging.error(str(e))
             Tracer.write_row(site=site.name, step=e, status="KO")
             if not settings.DEBUG:
                 wp_generator.clean()


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Lors de l'export-many, des sites étaient uniquement parsés mais après le script sortait sans aucun message d'erreur affiché...  Après recherche, il y avait bel et bien une exception qui était levée mais celle-ci était juste notée dans le "tracer" mais pas dans la console. Donc un peu vicieux pour investiguer... bref, ajout de l'affichage de l'erreur dans la console.

**Targetted version**: x.x.x
