### PR TITLE
Add date to CSV generated line

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -264,7 +264,7 @@ def _generate_csv_line(wp_generator):
     csv_columns['updates_automatic'] = wp_generator._site_params['updates_automatic']  # from csv (bool)
     csv_columns['langs'] = wp_generator._site_params['langs']  # from parser
     csv_columns['unit_name'] = wp_generator._site_params['unit_name']  # from csv
-    csv_columns['comment'] = 'Migrated from Jahia to WP'
+    csv_columns['comment'] = 'Migrated from Jahia to WP {}'.format(datetime.date.today())
 
     # Formatting values depending on their type/content
     for col in csv_columns:

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -264,7 +264,7 @@ def _generate_csv_line(wp_generator):
     csv_columns['updates_automatic'] = wp_generator._site_params['updates_automatic']  # from csv (bool)
     csv_columns['langs'] = wp_generator._site_params['langs']  # from parser
     csv_columns['unit_name'] = wp_generator._site_params['unit_name']  # from csv
-    csv_columns['comment'] = 'Migrated from Jahia to WP {}'.format(datetime.date.today())
+    csv_columns['comment'] = 'Migrated from Jahia to WP {}'.format(date.today())
 
     # Formatting values depending on their type/content
     for col in csv_columns:

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -65,7 +65,7 @@ import logging
 import pickle
 import subprocess
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, date
 from pprint import pprint
 
 import os


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Cosmétique mais en voyant les données entrées dans la source de vérité pour les sites migrés depuis Jahia, j'ai pu voir que le commentaire avait la date de migration. Et dans la ligne à mettre dans le fichier CSV qui est générée lors de l'export d'un site, y'avait pas cette date. Donc simple ajout de celle-ci.

**Targetted version**: x.x.x
