### PR TITLE
Tagline not updated for other language if "white space" at the end

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -883,7 +883,8 @@ def veritas(csv_file, **kwargs):
 @dispatch.on('extract-plugin-config')
 def extract_plugin_config(wp_env, wp_url, output_file, **kwargs):
 
-    ext = WPPluginConfigExtractor(wp_env, wp_url)
+    wp_site = WPSite(wp_env, wp_url)
+    ext = WPPluginConfigExtractor(wp_site)
 
     ext.extract_config(output_file)
 

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -382,7 +382,7 @@ class Site:
         for language, dom_path in self.export_files.items():
             dom = Utils.get_dom(dom_path)
 
-            self.title[language] = Utils.get_tag_attribute(dom, "siteName", "jahia:value")
+            self.title[language] = Utils.get_tag_attribute(dom, "siteName", "jahia:value").strip()
             self.theme[language] = Utils.get_tag_attribute(dom, "theme", "jahia:value")
             if self.theme[language] == 'associations':
                 self.theme[language] = 'assoc'

--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -66,7 +66,7 @@ class WPPluginConfig(WPConfig):
         force -- True|False if option exists, tells if it will be overrided with new value or not
         """
         # Creating object to do plugin configuration restore and lauch restore right after !
-        WPPluginConfigRestore(self.wp_site.openshift_env, self.wp_site.url).restore_config(self.config, force=force)
+        WPPluginConfigRestore(self.wp_site).restore_config(self.config, force=force)
 
     def set_state(self, forced_state=None):
         """

--- a/src/wordpress/plugins/manager.py
+++ b/src/wordpress/plugins/manager.py
@@ -6,7 +6,6 @@ import pymysql
 import warnings
 
 from settings import WP_PLUGIN_TABLES_RELATIONS, WP_PLUGIN_CONFIG_TABLES
-from wordpress import WPSite
 
 
 class WPPluginConfigManager:

--- a/src/wordpress/plugins/manager.py
+++ b/src/wordpress/plugins/manager.py
@@ -13,17 +13,16 @@ class WPPluginConfigManager:
     """ Give necessary tools to manage (import/export) configuration parameters for a plugin which are stored
         in the database. Information to access database are recovered from WordPress config file (wp-config.php)
     """
-    def __init__(self, wp_env, wp_url):
+    def __init__(self, wp_site):
         """ Constructor
 
         Arguments keyword:
-        wp_env - OpenShift env
-        wp_url - webSite URL
+        :param wp_site: Instance of WPSite class
         """
         # List of "defined" value to look for in "wp-config.php" file.
         WP_CONFIG_DEFINE_NAMES = ['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'DB_CHARSET']
 
-        self.wp_site = WPSite(wp_env, wp_url)
+        self.wp_site = wp_site
 
         wp_config_file = os.path.join(self.wp_site.path, "wp-config.php")
 
@@ -149,14 +148,13 @@ class WPPluginConfigExtractor(WPPluginConfigManager):
         the procedure.
     """
 
-    def __init__(self, wp_env, wp_url):
+    def __init__(self, wp_site):
         """ Constructor
 
         Arguments keyword:
-        wp_env - OpenShift env
-        wp_url - webSite URL
+        :param wp_site: Instance of WPSite class
         """
-        WPPluginConfigManager.__init__(self, wp_env, wp_url)
+        WPPluginConfigManager.__init__(self, wp_site)
 
     def extract_config(self, output_file):
         """ Extract plugin configuration an store it in file specified by 'output_file'
@@ -271,14 +269,13 @@ class WPPluginConfigExtractor(WPPluginConfigManager):
 class WPPluginConfigRestore(WPPluginConfigManager):
     """ Allow to restore a given plugin configuration in WordPress database """
 
-    def __init__(self, wp_env, wp_url):
+    def __init__(self, wp_site):
         """ Constructor
 
         Arguments keyword:
-        wp_env - OpenShift env
-        wp_url - webSite URL
+        :param wp_site: Instance of class WPSite
         """
-        WPPluginConfigManager.__init__(self, wp_env, wp_url)
+        WPPluginConfigManager.__init__(self, wp_site)
 
     def restore_config(self, config_infos, force):
         """ Restore a plugin configuration. Configuration information are stored in parameter.


### PR DESCRIPTION
**From issue**: WWP-1319

**High level changes:**

1. S'il y avait un espace à la fin de la tagline, celui-ci était enregistré correctement mais lorsque l'on récupérait celle-ci via WP-CLI, forcément, on perdait l'info de l'espace blanc à la fin... Donc ajout d'un trim pour ça lors du parsing.

**Low level changes:**

1. Pour plusieurs fonctions, on passait les 2 paramètres nécessaires à créer une instance de `WPSite`. Mais les paramètres optionnels n'étant pas passés, on n'avait pas toutes les informations nécessaires suivant l'utilisation qui était ensuite faite de l'instance. Changement donc pour passer l'instance en question (vu qu'elle existe déjà) au lieu des 2 paramètres.

**Targetted version**: x.x.x
