### PR TITLE
Disable avatars, fix error when applying strict plugin list

### DIFF
--- a/src/jahia2wp-utils/README.md
+++ b/src/jahia2wp-utils/README.md
@@ -5,6 +5,10 @@ This set of Bash files are used to give "shortcuts" to use `jahia2wp.py` command
 ## Scripts configuration
 Copy file `config.sample.sh` to `config.sh` and edit it to set correct values for your environment.
 
+## exec-wpcli-on-all-sites.sh
+Takes a root path where to find existing WordPress website and then execute given WPCLI command by automatically adding `--path=` parameter.
+> ./exec-wpcli-on-all-sites.sh <sitesRootPath> <wpCliToExec>
+
 ## clean.sh
 This script is used to clean a site by its name. 
 > ./clean.sh \<siteName>

--- a/src/jahia2wp-utils/exec-wpcli-on-all-sites.sh
+++ b/src/jahia2wp-utils/exec-wpcli-on-all-sites.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check parameters
+
+if [ "$#" -ne 2 ]
+then
+    echo "Usage: $0 <sitesRootPath> <wpCliToExec>"
+
+    exit 1
+fi
+
+
+SITES_ROOT_PATH=$1
+CMD_TO_EXEC=$2
+TMP_FILE="/tmp/inventory"
+
+
+
+echo -n "Extracting site list... "
+find ${SITES_ROOT_PATH} -name "wp-config.php" -printf '%h\n' > ${TMP_FILE}
+echo "done"
+
+echo "Executing command on each site..."
+
+while read s
+do
+  echo "${s}..."
+  eval "${CMD_TO_EXEC} --path=$s"
+
+done < ${TMP_FILE}

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -331,6 +331,11 @@ class WPGenerator:
         command = 'cap remove administrator unfiltered_upload'
         self.run_wp_cli(command)
 
+        # Disable avatars for security reason. Because a call to gravatar.com is done when user is logged and
+        # hash with email address associated to account is given
+        command = "option update show_avatars ''"
+        self.run_wp_cli(command)
+
         # flag success by returning True
         return True
 
@@ -522,7 +527,7 @@ class WPGenerator:
 
             for plugin_name in installed_plugins:
 
-                if plugin_name not in define_plugin_name_list:
+                if plugin_name != "" and plugin_name in define_plugin_name_list:
                     logging.info("%s - Plugins - %s: Don't have to be here, uninstalling!", repr(self), plugin_name)
                     self.run_wp_cli("plugin uninstall --deactivate {}".format(plugin_name))
 

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -523,11 +523,11 @@ class WPGenerator:
                 installed_plugins += inactive_plugins.split("\n")
 
             # List coming from YAML file
-            define_plugin_name_list = list(plugin_list.plugins(self.wp_site.name).keys())
+            defined_plugin_name_list = list(plugin_list.plugins(self.wp_site.name).keys())
 
             for plugin_name in installed_plugins:
 
-                if plugin_name != "" and plugin_name in define_plugin_name_list:
+                if plugin_name != "" and plugin_name not in defined_plugin_name_list:
                     logging.info("%s - Plugins - %s: Don't have to be here, uninstalling!", repr(self), plugin_name)
                     self.run_wp_cli("plugin uninstall --deactivate {}".format(plugin_name))
 
@@ -551,6 +551,8 @@ class WPGenerator:
                               - Only new options will be added to plugin(s)
                            - if True
                               - New plugin options will be added and existing ones will be overwritten
+        :param strict_plugin_list: True|False
+                            - if True, all plugin not present in YAML file will be uninstalled
         """
         # check we have a clean place first
         if not self.wp_config.is_installed:


### PR DESCRIPTION
**From issue**: WWP-1405

**High level changes:**

1. Demande de Patrick Saladino pour désactiver les avatars car "gravatar.com" peut suivre les URLs du site visitées par les utilisateurs connectés.
1. Ajout d'un script dans `jahia2wp-utils` pour pouvoir exécuter une commande WPCLI sur tous les sites d'une arborescence donnée. Ceci permettra d'appliquer l'option de configuration qui désactive le tracking "gravatar.com" sur les sites déjà déployés (prod et QA) de manière rapide.

**Low level changes:**

1. Correction d'un mini-bug dans la remise d'équerre des plugins installés lors de la création d'un site vide (ou de la mise à jour des plugins `update-plugins` avec l'option `--strict-list` donnée).

**Note**
Une fois cette PR mergée, il faudra exécuter une commande du style sur la prod et QA:
`jahia2wp-utils/exec-on-all-site.sh <rootPathWP> "wp option update show_avatars ''"`
