### PR TITLE
Change etx char fix func to be more generic and clean also vertical tabs

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -368,7 +368,7 @@ def parse(site, output_dir=None, use_cache=False, **kwargs):
             site = pickle_site
         else:
             logging.info("Cache not used, parsing the Site")
-            site = Site(site_dir, site, fix_etx_chars=True)
+            site = Site(site_dir, site, fix_problematic_chars=True)
 
         print(site.report)
 
@@ -408,7 +408,6 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     :param updates_automatic: boolean
     :param openshift_env: openshift_env environment (prod, int, gcharmier ...)
     :param keep_extracted_files: command to keep files extracted from jahia zip
-    :param fix_etx_chars: Tell to remove ETX chars from XML files containing site pages.
     :param features_flags: Tell to clean page content or not
     """
 

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -28,16 +28,18 @@ This file is named jahia_site to avoid a conflict with Site [https://docs.python
 class Site:
     """A Jahia Site. Have 1 to N Pages"""
 
-    def __init__(self, base_path, name, root_path="", fix_etx_chars=False):
+    def __init__(self, base_path, name, root_path="", fix_problematic_chars=False):
         """
         Create an instance of object
 
         :param base_path: Base path to dir containing extracted Jahia ZIP files
         :param name: Site name
         :param root_path: (optional) ?
-        :param fix_etx_chars: (optional) to tell if we have to fix x03 chars that may be in export_<lang>.xml files.
-                              If this character (=ETX -> End Of Text) is present in a value read by DOM utils, the
-                              string is truncated at x03 position and the following characters are ignored.
+        :param fix_problematic_chars: (optional) to tell if we have to fix problematic characters. Those includes :
+                - x03 chars that may be in export_<lang>.xml files. If this character (=ETX -> End Of Text) is present
+                  in a value read by DOM utils, the string is truncated at x03 position and the following characters
+                  are ignored.
+                - same problem with x0B chars... (vertical tabs)
         """
         # FIXME: base_path should not depend on output-dir
         self.base_path = base_path
@@ -83,9 +85,9 @@ class Site:
                 self.export_files[language] = path
                 self.languages.append(language)
 
-        # If we have to fix ETX char in XML file,
-        if fix_etx_chars:
-            self.fix_etx_chars()
+        # If we have to fix problematic char in XML file,
+        if fix_problematic_chars:
+            self.fix_problematic_chars()
 
         # site params that are parsed later. There are dicts because
         # we have a value for each language. The dict key is the language,
@@ -156,10 +158,10 @@ class Site:
         # generate the report
         self.generate_report()
 
-    def fix_etx_chars(self):
+    def fix_problematic_chars(self):
         """
-        Remove ETX (End of Text) characters from XML files. If this character is present in a value read by DOM utils,
-        the string is truncated at ETX position and the following characters are ignored.
+        Remove problematic chars (End of Text, vertical tabs) characters from XML files. If this character is present
+        in a value read by DOM utils, the string is truncated at ETX position and the following characters are ignored.
         :return:
         """
 
@@ -174,8 +176,8 @@ class Site:
 
             in_file = open(old_export_file, 'rb')
             out_file = open(dom_path, 'wb')
-            # Reading file content, replacing ETX char and writing back to output file
-            out_file.write(in_file.read().replace(b'\x03', b''))
+            # Reading file content, replacing ETX char and Vertical Tabs and writing back to output file
+            out_file.write(in_file.read().replace(b'\x03', b'').replace(b'\x0b', b''))
 
             in_file.close()
             out_file.close()


### PR DESCRIPTION
**From issue**: WWP-1278

**High level changes:**

1. En plus des caractères ETX (End-of-text) qui pouvaient être présents dans l'export ZIP, il peut aussi y avoir des "Vertical Tabs" (ouais, moi aussi je me demande pourquoi..). Bref, ça fait que le texte est tronqué à l'import. Donc modification de la fonction de nettoyages des ETX pour la rendre plus générique et y ajouter le caractère "vertical tab" `x0B`


**Targetted version**: x.x.x
