### PR TITLE
Remove epfl-infoscience-search from list of desactivated plugin, as i…

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -492,7 +492,8 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
                            'epfl-faq',
                            'epfl-grid',
                            'epfl-infoscience',
-                           'epfl-infoscience-search',
+                           # waiting for a validation
+                           # 'epfl-infoscience-search',
                            'epfl-map',
                            'epfl-memento',
                            'epfl-news',


### PR DESCRIPTION
Remove epfl-infoscience-search from list of desactivated plugin, as it is not installed
This is not critic, only time consuming  (~4 seconds) when doing a migration.