### PR TITLE
Parse twitter timelines from Jahia exports

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -1,6 +1,5 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017"""
 import logging
-import re
 from datetime import datetime
 from urllib import parse
 from urllib.parse import urlencode
@@ -296,7 +295,7 @@ class Box:
             # for Twitter
             if 'twitter-timeline' in box_content:
                 soup = BeautifulSoup(box_content, 'html5lib')
-                links = soup.findAll("a", {"class":"twitter-timeline"})
+                links = soup.findAll("a", {"class": "twitter-timeline"})
 
                 twitter_accounts = []
 

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from xml.dom import minidom
 from parser.box_sorted_group import BoxSortedGroup
 from bs4 import BeautifulSoup
-import re
+
 from utils import Utils
 
 

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -1,5 +1,6 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017"""
 import logging
+import re
 from datetime import datetime
 from urllib import parse
 from urllib.parse import urlencode
@@ -290,8 +291,32 @@ class Box:
             FIXME: filesList and linksList are processed in a given order. It may correspond to export but they also
             may be switched. So maybe we will have to correct it in the future.
         """
+        def filter_and_transform(box_content):
+            """ Sometimes we don't want to crawl the data as it is given"""
+            # for Twitter
+            if 'twitter-timeline' in box_content:
+                soup = BeautifulSoup(box_content, 'html5lib')
+                links = soup.findAll("a", {"class":"twitter-timeline"})
+
+                twitter_accounts = []
+
+                for link in links:
+                    if link.get('href') and link['href']:
+                        twitter_accounts.append(link['href'])
+
+                if twitter_accounts:
+                    # remove everything, we only need the twitter timelines here
+                    new_content = ''
+                    for account in twitter_accounts:
+                        new_content += '[epfl_twitter url="{}"]\n'.format(account)
+
+                    return new_content
+
+            return box_content
+
         if not multibox:
             content = Utils.get_tag_attribute(element, "text", "jahia:value")
+            content = filter_and_transform(content)
 
             files_list = element.getElementsByTagName("filesList")
             if files_list:
@@ -346,7 +371,7 @@ class Box:
             content = ""
 
             for box_key, box_content in box_list:
-                content += box_content
+                content += filter_and_transform(box_content)
 
             # scheduler shortcode
             if Utils.get_tag_attribute(element, "comboList", "jahia:ruleType") == "START_AND_END_DATE":


### PR DESCRIPTION
**From issue**: WWP-1292

**High level changes:**

1. Lors de la migration, chaque boite Jahia où il y a un timeline Twitter est maintenant remplacée par le shortcode epfl_twitter. Le script suivant qui concerne l'ajout de twitter est également effacé.
