### PR TITLE
Set title to buttons boxes

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -732,7 +732,11 @@ class Box:
         self.site.register_shortcode(self.shortcode_name, ["image", "url"], self)
 
         box_type = element.getAttribute("jcr:primaryType")
-        content = ""
+
+        if self.title != "":
+            content = "<h3>{}</h3>".format(self.title)
+        else:
+            content = ""
 
         if 'small' in box_type:
             elements = element.getElementsByTagName("smallButtonList")


### PR DESCRIPTION
From issue: https://siexop-jirat.epfl.ch/browse/WWP-1494

High level changes:
1. Lors d'une migration, ajoute un titre h3 devant les boites Buttons si la boite Jahia à une boxTitle non vide.