### PR TITLE
Remove widget (from Dashboard) on which there's a link to Theme manage page

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
@@ -101,4 +101,14 @@ function EPFL_remove_customize_admin_bar_render()
     $wp_admin_bar->remove_menu('customize');
 }
 
+/* Remove 'At a glance' and 'Welcome' widgets from Dashboard (because contains link to themes page)
+ *
+ */
+add_action( 'admin_init','EPFL_remove_theme_reference_widget', 100 );
+function EPFL_remove_theme_reference_widget() {
+    remove_meta_box('dashboard_right_now', 'dashboard', 'normal');
+    remove_action('welcome_panel', 'wp_welcome_panel');
+}
+
+
 ?>


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. En contrôlant un autre truc, j'ai pu voir que dans le Dashboard, on avait encore des liens sur la page de management des thèmes. Celle-ci restait donc accessible même si on avait caché l'entrée de menu sur la gauche. Du coup, masquage de 2 widgets contenant le lien.

**Targetted version**: x.x.x
