### PR TITLE
Handle double quotes in wp_tagline

### DIFF
--- a/src/exporter/utils.py
+++ b/src/exporter/utils.py
@@ -4,10 +4,6 @@
 class Utils:
 
     @staticmethod
-    def escape_quotes(str):
-        return str.replace('"', '\\"')
-
-    @staticmethod
     def get_menu_id(str):
         return str.replace('\n', '')
 

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -894,7 +894,7 @@ class WPExporter:
         and doing everything in one place is more simple.
         """
         def prepare_html(html):
-            return Utils.escape_quotes(html.replace(u'\xa0', u' '))
+            return WPUtils.escape_quotes(html.replace(u'\xa0', u' '))
 
         widget_pos = 1
         widget_pos_to_lang = {}

--- a/src/utils.py
+++ b/src/utils.py
@@ -491,3 +491,7 @@ class Utils(object):
             return html.replace('"', double_quote).replace("'", simple_quote)
         else:
             return html.replace(double_quote, '&quot;').replace(simple_quote, '&apos;')
+
+    @staticmethod
+    def escape_quotes(str):
+        return str.replace('"', '\\"')

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -293,7 +293,7 @@ class WPGenerator:
             # Command is in simple quotes and tagline between double quotes to avoid problems in case of simple quote
             # in tagline text. We initialize blogdescription with default language
             if not self.run_wp_cli('option update blogdescription "{}"'.format(
-                    self._site_params['wp_tagline'][self.default_lang()]),
+                    Utils.escape_quotes(self._site_params['wp_tagline'][self.default_lang()])),
                     encoding="utf-8"):
                 logging.error("%s - could not configure blog description", repr(self))
                 return False


### PR DESCRIPTION
**From issue**: WWP-1619

**High level changes:**

1. Gestion des " dans la tagline

**Low level changes:**

1. Déplacement de la fonction `escape_quotes` du fichier "Utils" de l'exporter vers celui plus générique car la fonction doit être utilisée dans le Generator aussi.

**Targetted version**: x.x.x
