### PR TITLE
[WIP] Infoscience search 2018

### DIFF
--- a/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
@@ -21,6 +21,9 @@ require_once 'marc_converter.php';
 require_once 'group_by.php';
 require_once 'mathjax-config.php';
 
+require_once 'to_theme/publications/controller.php';
+
+
 define("INFOSCIENCE_SEARCH_URL", "https://infoscience.epfl.ch/search?");
 
  /**
@@ -266,7 +269,11 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
                 if (has_action("epfl_infoscience_search_action")) {
                     ob_start();
                     try {
-                        do_action("epfl_infoscience_search_action", $publications);
+                        do_action("epfl_infoscience_search_action", $grouped_by_publications,
+                                                                    $url,
+                                                                    $format,
+                                                                    $summary,
+                                                                    $thumbnail);
                         $page = ob_get_contents();
                     } finally {
                         ob_end_clean();

--- a/data/wp/wp-content/plugins/epfl-infoscience-search/to_theme/publications/controller.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/to_theme/publications/controller.php
@@ -1,0 +1,25 @@
+<?php
+add_action('epfl_infoscience_search_action', 'renderPublicationsSearchResult', 1, 5);
+
+function renderPublicationsSearchResult($grouped_by_publications,
+                                 $url,
+                                 $format,
+                                 $summary,
+                                 $thumbnail) {
+  ob_start();
+
+  if (is_admin()) {
+    // render placeholder for backend editor
+    set_query_var('epfl_placeholder_title', 'Infoscience search');
+    get_template_part('shortcodes/placeholder');
+
+  } else {
+    set_query_var('epfl_infoscience_search_grouped_by_publications', $grouped_by_publications);
+    set_query_var('epfl_infoscience_search_url', $url);
+    set_query_var('epfl_infoscience_search_format', $format);
+    set_query_var('epfl_infoscience_search_summary', $summary);
+    set_query_var('epfl_infoscience_search_thumbnail', $thumbnail);
+    get_template_part('shortcodes/publications/view');
+  }
+  return ob_end_flush();
+}

--- a/data/wp/wp-content/plugins/epfl-infoscience-search/to_theme/publications/view.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/to_theme/publications/view.php
@@ -1,0 +1,74 @@
+<?php
+  $publications = get_query_var('epfl_infoscience_search_grouped_by_publications');
+  $url = get_query_var('epfl_infoscience_search_url');
+  $format = get_query_var('epfl_infoscience_search_format');
+  $summary = get_query_var('epfl_infoscience_search_summary');
+  $thumbnail = get_query_var('epfl_infoscience_search_thumbnail');
+?>
+
+<div class="list-group mb-5">
+    <?php
+    # parsing all
+      foreach($publications['group_by'] as $grouped_by_publications) {
+        # do we have a groupby title ?
+        if ($grouped_by_publications['label']) {
+          echo '<h1>' . $grouped_by_publications['label'] . '</h1>';
+        }
+        # parsing groupby lvl1 data
+        foreach($grouped_by_publications['values'] as $grouped_by2_publications) {
+          if ($grouped_by2_publications['label'] && !$grouped_by_publications['label']) {
+            echo '<h1>' . $grouped_by2_publications['label'] . '</h1>';
+          } else {
+            echo '<h2>' . $grouped_by2_publications['label'] . '</h2>';
+          }
+
+          foreach($grouped_by2_publications['values'] as $index3 => $publication) {
+    ?>
+    <div class="list-group-item list-group-item-publication">
+      <div class="row">
+        <?php if ($publication['url']['icon'][0]): ?>
+          <div class="col-md-10">
+          <img src="<?php echo $publication['url']['icon'][0] ?>" class="float-left mr-3" alt="publication thumbnail">
+        <?php endif ?>
+        <div class="col-md-10">
+                    <h4 class="h5"><?php echo $publication['title'][0] ?></h4>
+          <p class="text-muted small mb-0 tex2jax_process">
+          <?php if ($summary): ?>
+            <?php echo $publication['summary'][0] ?><br>
+          <?php endif ?>
+            Author(s): 
+            <?php foreach ($publication['author'] as $author) { ?>
+              <a class="text-muted no-tex2jax_process" href="<?php echo $author['search_url'] ?>" href="_blank"><?php echo $author['initial_name'] ?></a><?php if ($author !== end($publication['author'])) echo ','; ?>
+            <?php } ?>
+          </p>
+        </div>
+        <div class="col-md-2 text-right mt-4 mt-md-0">
+          <p>
+            <a href="//infoscience.epfl.ch/record/<?php echo $publication['record_id'][0] ?>" class="btn btn-secondary btn-sm" target="_blank">Detailed record</a>
+          </p>
+          <?php if ($publication['url']['fulltext'][0]): ?>
+            <p class="text-muted small mb-0">
+            <?php if ($publication['url']['fulltext'][0]): ?>
+              <a class="text-muted" href="<?php echo $publication['url']['fulltext'][0] ?>" target="_blank">Full text</a>
+            <?php endif ?>
+            <?php if ($publication['doi'][0]): ?>
+              <?php if ($publication['url']['fulltext'][0]) echo " - "; ?>
+              <a class="text-muted" href="https://dx.doi.org/<?php echo $publication['doi'][0] ?>" target="_blank">View at publisher</a>
+            <?php endif ?>
+            </p>
+          <?php endif ?>
+        </div>
+      </div>
+    </div>
+    <?php
+          }
+        }
+      }
+    ?>
+  </div>
+</div>
+<?php if ($url): ?>
+<p class="text-center">
+  <a class="link-pretty" href="<?php echo str_replace('&of=xm', '',  $url) ?>">See all publications</a>
+</p>
+<?php endif ?>


### PR DESCRIPTION
Mise à jour du plugin Infoscience Search pour faire un rendu avec le thème 2018 -> https://epfl-idevelop.github.io/elements/#/content-types/publication

Pour l'instant, les deux renders, 2010 et 2018 sont dans le même plugin.