### PR TITLE
Skip unwanted sidebar boxes

### DIFF
--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -100,7 +100,13 @@ class PageContent:
                 for extra in child.childNodes:
                     if extra.ELEMENT_NODE != extra.nodeType:
                         continue
+
+                    # If we have to skip this box,
+                    if extra.getAttribute("jahia:acl") == "break":
+                        continue
+
                     multibox = extra.getElementsByTagName("text").length > 1
+
                     box = Box(site=self.site, page_content=self, element=extra, multibox=multibox)
                     self.sidebar.boxes.append(box)
 


### PR DESCRIPTION
**From issue**: WWP-1635

**High level changes:**

1. Il peut y avoir des boxes dans la sidebar qui ne doivent pas être prises en compte pour l'affichage. Et d'après ce qui a pu être constaté, celles-ci on un attribut `jahia:acl` qui a la valeur `break`. Donc, ajout d'un check pour savoir si la box doit être prise en compte ou pas.

**Targetted version**: x.x.x
