### PR TITLE
Search and remove incorrect 'Redirect 301' in all .htaccess of given path

### DIFF
--- a/src/jahia2wp-utils/fix-wrong-htaccess.sh
+++ b/src/jahia2wp-utils/fix-wrong-htaccess.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Check parameters
+
+if [ "$#" -ne 1 ]
+then
+    echo "Usage: $0 <sitesRootPath>"
+
+    exit 1
+fi
+
+
+SITES_ROOT_PATH=$1
+TMP_FILE_INVENTORY="/tmp/inventory.htaccess"
+TMP_FILE_PAGE_LIST="/tmp/pageList"
+TMP_FILE_PAGE_REDIRECT="/tmp/redirectList"
+
+echo -n "Extracting site list... "
+find ${SITES_ROOT_PATH} -name "wp-config.php" -printf '%h\n' > ${TMP_FILE_INVENTORY}
+echo "done"
+
+echo "Looping through sites"
+
+while read pathToSite
+do
+    echo -n "${pathToSite}... "
+
+    currentHtaccess="${pathToSite}/.htaccess"
+
+    # Listing site pages
+    wp post list --post_type=page --field=post_name --format=csv --path=${pathToSite} > ${TMP_FILE_PAGE_LIST}
+    # Extract redirect targets
+    cat ${currentHtaccess} | grep "Redirect 301" | awk '{print $NF}' | sort | uniq | awk -F"/" '{print $(NF-1)}' > ${TMP_FILE_PAGE_REDIRECT}
+
+    nbFix=0
+
+    while read target
+    do
+        if [ "`egrep \"^${target}$\" ${TMP_FILE_PAGE_LIST}`" == "" ]
+        then
+            # Removing error from htaccess
+            sed -i "/\/${target}\/$/d" ${currentHtaccess}
+
+            let nbFix=nbFix+1
+        fi
+
+    done < ${TMP_FILE_PAGE_REDIRECT}
+
+    rm ${TMP_FILE_PAGE_REDIRECT}
+
+    if [ ${nbFix} -eq 0 ]
+    then
+        echo "Correct"
+    else
+        echo "${nbFix} fix done for site"
+    fi
+
+
+    rm ${TMP_FILE_PAGE_LIST}
+
+done < ${TMP_FILE_INVENTORY}
+
+rm ${TMP_FILE_INVENTORY}
+


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Workaround bête au problème d'entrées "Redirect 301" incorrectes dans le fichier `.htaccess` d'un site après import de celui-ci, plus particulièrement s'il avait été importé en même temps qu'un autre...
Le script recherche tous les fichiers `wp-config.php` dans un dossier donné et pour chaque site trouvée, il supprime les entrées pointant sur des pages qui ne sont pas existantes dans le site.

**Note**
Lors du merge de la PR, informer qu'il faut exécuter cette ligne de commande après migration d'un site.

**Targetted version**: x.x.x
