### PR TITLE
Ignore title for Infoscience boxes in sidebar

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -504,7 +504,9 @@ class Box:
         if projects:
             content += 'projects="{}" '.format(",".join(projects))
 
-        content += 'title="{}" '.format(self.title)
+        # Title is only for boxes in pages
+        if not self.is_in_sidebar():
+            content += 'title="{}" '.format(self.title)
         content += '/]'
 
         # If we have a <moreUrl> element
@@ -514,6 +516,13 @@ class Box:
             content += '[/epfl_buttons_container]'
 
         self.content = content
+
+    def is_in_sidebar(self):
+        """
+        Tells if the box belongs to the sidebar
+        :return:
+        """
+        return self.page_content.page.is_homepage()
 
     @staticmethod
     def _extract_epfl_memento_parameters(url):


### PR DESCRIPTION
**From issue**: WWP-1662

**High level changes:**

1. Ajout d'un check pour voir si la boîte infoscience était dans la sidebar. Si c'est le cas, il ne faut pas ajouter le paramètre "title" sinon celui-ci se retrouvera à double (vu qu'affiché également avec le titre de la widget)

**Low level changes:**

1. Ajout d'une fonction `is_in_sidebar()` dans `box.py` afin de savoir si une boîte faisait partie de la sidebar ou pas.

**Targetted version**: x.x.x
