### PR TITLE
Handle multilang in custom header

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -918,7 +918,7 @@ class WPExporter:
                     logging.warning("Banner is empty")
                     continue
 
-                cmd = 'widget add text header-widgets --text="{}"'.format(
+                cmd = 'widget add custom_html header-widgets --content="{}"'.format(
                     banner.content.replace('"', '\\"'))
 
                 self.run_wp_cli(cmd)


### PR DESCRIPTION
**From issue**: WWP-1676

**High level changes:**

1. Changement du type de widget qui est mis comme "Custom header" pour passer de "text" à "custom_html". L'utilisation de "custom_html" permet de faire en sorte que la langue pour laquelle le widget doit être affiché soit correctement reprise et initialisée.


**Targetted version**: x.x.x
