### PR TITLE
Video plugin - Add CSS classes to fit 2018 Stylguide

### DIFF
--- a/data/wp/wp-content/plugins/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl-video/epfl-video.php
@@ -45,7 +45,7 @@ function epfl_video_process_shortcode( $atts, $content = null ) {
     $url = "https://tube.switch.ch/embed/".$video_id;
   }
 
-  return '<div class="container>'.
+  return '<div class="container">'.
          '<div class="epfl-video epfl-video-responsive embed-responsive embed-responsive-16by9">'.
          '<iframe src="'.$url.'" width="'.$width.'" height="'.$height.'" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>'.
          '</div>'.

--- a/data/wp/wp-content/plugins/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl-video/epfl-video.php
@@ -45,8 +45,10 @@ function epfl_video_process_shortcode( $atts, $content = null ) {
     $url = "https://tube.switch.ch/embed/".$video_id;
   }
 
-  return '<div class="epfl-video epfl-video-responsive embed-responsive embed-responsive-16by9">'.
+  return '<div class="container>'.
+         '<div class="epfl-video epfl-video-responsive embed-responsive embed-responsive-16by9">'.
          '<iframe src="'.$url.'" width="'.$width.'" height="'.$height.'" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>'.
+         '</div>'.
          '</div>';
 
 }

--- a/data/wp/wp-content/plugins/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl-video/epfl-video.php
@@ -45,9 +45,8 @@ function epfl_video_process_shortcode( $atts, $content = null ) {
     $url = "https://tube.switch.ch/embed/".$video_id;
   }
 
-
-  return '<div class="epfl-video epfl-video-responsive">'.
-         '<iframe src="'.$url.'" width="'.$width.'" height="'.$height.'" webkitallowfullscreen mozallowfullscreen allowfullscreen frameborder="0"></iframe>'.
+  return '<div class="epfl-video epfl-video-responsive embed-responsive embed-responsive-16by9">'.
+         '<iframe src="'.$url.'" width="'.$width.'" height="'.$height.'" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>'.
          '</div>';
 
 }


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout du nécessaire dans le HTML renvoyé par le plugin pour que ça suive le styleguide 2018 (https://epfl-idevelop.github.io/elements/#/atoms/video)


**Targetted version**: x.x.x
