### PR TITLE
Improve 'find' perf for .htaccess fix

### DIFF
--- a/src/jahia2wp-utils/fix-wrong-htaccess.sh
+++ b/src/jahia2wp-utils/fix-wrong-htaccess.sh
@@ -16,7 +16,7 @@ TMP_FILE_PAGE_LIST="/tmp/pageList"
 TMP_FILE_PAGE_REDIRECT="/tmp/redirectList"
 
 echo -n "Extracting site list... "
-find ${SITES_ROOT_PATH} -name "wp-config.php" -printf '%h\n' > ${TMP_FILE_INVENTORY}
+find ${SITES_ROOT_PATH} -name "wp-config.php" -maxdepth 3 -printf '%h\n' > ${TMP_FILE_INVENTORY}
 echo "done"
 
 echo "Looping through sites"


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout d'un paramètre `-maxdepth 3` pour éviter que le `find` qui cherche les fichiers `wp-config.php` aille trop bas et scanne aussi les potentiels milliers de médias...
La recherche des sites existants dans une arborescence devrait maintenant être plus rapide.

**Targetted version**: x.x.x
