### PR TITLE
Change parameter order to avoid 'warning' from 'find' command

### DIFF
--- a/src/jahia2wp-utils/fix-wrong-htaccess.sh
+++ b/src/jahia2wp-utils/fix-wrong-htaccess.sh
@@ -16,7 +16,7 @@ TMP_FILE_PAGE_LIST="/tmp/pageList"
 TMP_FILE_PAGE_REDIRECT="/tmp/redirectList"
 
 echo -n "Extracting site list... "
-find ${SITES_ROOT_PATH} -name "wp-config.php" -maxdepth 3 -printf '%h\n' > ${TMP_FILE_INVENTORY}
+find ${SITES_ROOT_PATH} -maxdepth 3 -name "wp-config.php" -printf '%h\n' > ${TMP_FILE_INVENTORY}
 echo "done"
 
 echo "Looping through sites"


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Bug bête... faut passer le paramètre `-maxdepth` à la fonction `find` avant tout autre paramètre sinon ça affiche un warning.


**Targetted version**: x.x.x
