### PR TITLE
Add parsing for /op/edit/.../ref/<ref> links used in pages

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -794,6 +794,12 @@ class Site:
 
         tags = soup.find_all(tag_name)
 
+        # Regex to parse internal Jahia links. Here are type of links that can exists: 
+        # /cms/op/edit/lang/fr/ref/6a37c1e5-b935-409b-8c51-b0fe8834aef1
+        # http://jahia-prod.epfl.ch/cms/op/edit/lang/fr/ref/6a37c1e5-b935-409b-8c51-b0fe8834aef1
+        # ###page:/lang/fr/ref/be42d070-0578-4278-89f3-f3f48e261814
+        internal_link_reg = re.compile("(^###page|[\w:/.-]+/op/edit/(\w+/)+ref/[\w-]+)")
+
         for tag in tags:
             link = tag.get(attribute)
 
@@ -805,7 +811,7 @@ class Site:
                     return
 
             # internal Jahia links
-            if link.startswith("###page"):
+            if internal_link_reg.match(link):
                 uuid = link[link.rfind('/') + 1:]
 
                 # check if we have a Page with this uuid

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -794,7 +794,7 @@ class Site:
 
         tags = soup.find_all(tag_name)
 
-        # Regex to parse internal Jahia links. Here are type of links that can exists: 
+        # Regex to parse internal Jahia links. Here are type of links that can exists
         # /cms/op/edit/lang/fr/ref/6a37c1e5-b935-409b-8c51-b0fe8834aef1
         # http://jahia-prod.epfl.ch/cms/op/edit/lang/fr/ref/6a37c1e5-b935-409b-8c51-b0fe8834aef1
         # ###page:/lang/fr/ref/be42d070-0578-4278-89f3-f3f48e261814


### PR DESCRIPTION
**From issue**: WWP-1690

**High level changes:**

1. Les liens du style "/op/edit/lang/fr/ref/6a37c1e5-b935-409b-8c51-b0fe8834aef1" et c'est quelque chose qu'on ne gère pas dans le code... A priori, c'est un peu sale d'utiliser un lien pareil mais bon, il faut le traiter. Et comme il s'agit d'un lien interne à Jahia et utilisant une référence (comme les liens commençant par "###page"), on peut le traiter de la même manière, il faut juste adapter la condition de recherche.

**Targetted version**: x.x.x
