### PR TITLE
Transform french coded lang to english

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -401,6 +401,13 @@ class Box:
 
         if 'lang' in parameters:
             lang = parameters['lang'][0]
+
+            # With Jahia, it is possible to also use "french" language denomination, we change it back to english
+            if lang == 'ang':
+                lang = 'en'
+            if lang == 'fra':
+                lang = 'fr'
+
         else:
             lang = ""
             logging.warning("News Shortcode - lang is missing")


### PR DESCRIPTION
**From issue**: WWP-1720

**High level changes:**

1. Visiblement, sur Jahia, il était possible de coder l'id de langue en français aussi (fra, ang)... donc correction dans le parser pour mettre en anglais (et en plus, ça respecte les standards de codage des langues...)

**Targetted version**: x.x.x
