### PR TITLE
Disable image ID for BigButton in exporter, allow to use ID and URL for image in plugin

### DIFF
--- a/data/wp/wp-content/plugins/epfl-buttons/epfl-buttons.php
+++ b/data/wp/wp-content/plugins/epfl-buttons/epfl-buttons.php
@@ -134,10 +134,18 @@ function epfl_buttons_process_shortcode( $attributes, string $content = null ): 
         /* If image given */
         if($image != "" && $image != "/")
         {
-            $image_url = wp_get_attachment_url( $image );
-            if (false == $image_url)
+            /* We have an image ID given*/
+            if(is_numeric($image))
             {
-                $image_url = "BAD MEDIA ID";
+                $image_url = wp_get_attachment_url( $image );
+                if (false == $image_url)
+                {
+                    $image_url = "BAD MEDIA ID";
+                }
+            }
+            else /* We may have an URL for the image */
+            {
+                $image_url = $image;
             }
         }
         else /* No image given */

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -554,7 +554,7 @@ class WPExporter:
             new_attribute = '{}="{}"'.format(attribute, new_url)
 
             # To use shortcake for snippet plugin we must define url="23" with 23 as media id.
-            if box.type == Box.TYPE_SNIPPETS or box.type == Box.TYPE_BUTTONS:
+            if box.type == Box.TYPE_SNIPPETS:
 
                 if 'guid' in wp_media and 'rendered' in wp_media['guid'] and wp_media['guid']['rendered'] == new_url:
                     new_attribute = '{}="{}"'.format(attribute, wp_media['id'])


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Il a été constaté que le shortcode BigButtons se voyait mettre des ID d'images (comme pour snippets) au lieu d'utiliser l'URL vers l'image. Ceci a été fait pour une raison qui s'est aujourd'hui perdue dans les méandres des daily et des changements de direction de nos valeureux codeurs dans leur quête du St-WordPress. Bref, étant donné que l'on ne peut pas utiliser shortcake pour BigButton (vu que imbriqué dans un autre shortcode), il était complètement inutile de continuer à utiliser des ID. La recherche et l'utilisation de ceux-ci dans l'exporter a donc été supprimée. En parallèle, le plugin `epfl_buttons` a été modifié pour accepter à la fois les URL d'images ainsi que les ID, ceci pour assurer une "backward compatibility" avec ce que l'on a fait jusqu'à présent. 

