### PR TITLE
Skip pages if not valid anymore (because of 'validTo' attribute)

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -19,6 +19,7 @@ from parser.banner import Banner
 from parser.box_sorted_group import BoxSortedGroup
 from utils import Utils
 from collections import OrderedDict
+from datetime import datetime
 
 """
 This file is named jahia_site to avoid a conflict with Site [https://docs.python.org/3/library/site.html]
@@ -520,6 +521,7 @@ class Site:
         Parse the PageContent. This is the content that is specific
         for each language.
         """
+        today = datetime.now().strftime("%Y-%m-%d")
 
         for language, dom_path in self.export_files.items():
             dom = Utils.get_dom(dom_path)
@@ -533,6 +535,19 @@ class Site:
                 # we don't parse the sitemap as it's not a real page
                 if template == "sitemap":
                     continue
+
+                # looking for end of validation date
+                valid_to = xml_page.getAttribute("jahia:validTo")
+
+                # If we have a validity date
+                if valid_to:
+                    # if format like "2017-10-06T11:03:00", we extract only the date.
+                    if "T" in valid_to:
+                        valid_to = valid_to.split("T")[0]
+
+                    # if page is not valid anymore, we skip it
+                    if valid_to < today:
+                        continue
 
                 # retrieve the Page definition that we already parsed
                 page = self.pages_by_pid[pid]


### PR DESCRIPTION
**From issue**: WWP-1738

**High level changes:**

1. Les pages Jahia peuvent avoir un attribut `jahia:validTo` qui dit jusqu'à quand la page est valable. Ajout d'un check pour savoir si les pages sont encore valables avant d'importer celles-ci.

**Targetted version**: x.x.x
