### PR TITLE
.htaccess "Redirect 301" order

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1427,10 +1427,7 @@ class WPExporter:
             folder = ""
         else:
             folder = "/{}".format(self.wp_generator.wp_site.folder)
-
-        # We use an ordered dict to store redirections so we will later be able to sort (descending) by source
-        # so we will avoid to have "short" rules matching before "long" rules.
-        redirect_dict = OrderedDict()
+        redirect_list = []
 
         # Add all rewrite jahia URI to WordPress URI
         for element in self.urls_mapping:
@@ -1447,18 +1444,10 @@ class WPExporter:
                     target_url = "{}{}".format(folder, wp_url)
                     # To avoid Infinite loop
                     if source_url != target_url[:-1]:
-                        redirect_dict[source_url] = target_url
+                        redirect_list.append("Redirect 301 {} {}".format(source_url,  target_url))
 
-        # If we have redirections
-        if redirect_dict:
-
-            # Sorting DESC to be sure longer source URL will be taken before shorter ones
-            desc_redirect_dict = OrderedDict(sorted(redirect_dict.items(), key=lambda kv: kv, reverse=True))
-
-            redirect_list = []
-            for source_url, target_url in desc_redirect_dict.items():
-                redirect_list.append("Redirect 301 {} {}".format(source_url, target_url))
-
+        if redirect_list:
+            redirect_list.reverse()
             # Updating .htaccess file
             WPUtils.insert_in_htaccess(self.wp_generator.wp_site.path,
                                        "Jahia-Page-Redirect",

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1427,7 +1427,7 @@ class WPExporter:
             folder = ""
         else:
             folder = "/{}".format(self.wp_generator.wp_site.folder)
-        redirect_list = []
+        redirect_dict = OrderedDict()
 
         # Add all rewrite jahia URI to WordPress URI
         for element in self.urls_mapping:
@@ -1444,9 +1444,18 @@ class WPExporter:
                     target_url = "{}{}".format(folder, wp_url)
                     # To avoid Infinite loop
                     if source_url != target_url[:-1]:
-                        redirect_list.append("Redirect 301 {} {}".format(source_url,  target_url))
+                        redirect_dict[source_url] = target_url
 
-        if redirect_list:
+
+        if redirect_dict:
+
+            # Sorting DESC to be sure longer source URL will be taken before shorter ones
+            redirect_dict = OrderedDict(sorted(redirect_dict.items(), key=lambda kv: kv, reverse=True))
+
+            redirect_list = []
+            for source_url, target_url in redirect_dict:
+                redirect_list.append("Redirect 301 {} {}".format(source_url, target_url))
+
             # Updating .htaccess file
             WPUtils.insert_in_htaccess(self.wp_generator.wp_site.path,
                                        "Jahia-Page-Redirect",

--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -1427,6 +1427,9 @@ class WPExporter:
             folder = ""
         else:
             folder = "/{}".format(self.wp_generator.wp_site.folder)
+
+        # We use an ordered dict to store redirections so we will later be able to sort (descending) by source
+        # so we will avoid to have "short" rules matching before "long" rules.
         redirect_dict = OrderedDict()
 
         # Add all rewrite jahia URI to WordPress URI
@@ -1446,14 +1449,14 @@ class WPExporter:
                     if source_url != target_url[:-1]:
                         redirect_dict[source_url] = target_url
 
-
+        # If we have redirections
         if redirect_dict:
 
             # Sorting DESC to be sure longer source URL will be taken before shorter ones
-            redirect_dict = OrderedDict(sorted(redirect_dict.items(), key=lambda kv: kv, reverse=True))
+            desc_redirect_dict = OrderedDict(sorted(redirect_dict.items(), key=lambda kv: kv, reverse=True))
 
             redirect_list = []
-            for source_url, target_url in redirect_dict:
+            for source_url, target_url in desc_redirect_dict.items():
                 redirect_list.append("Redirect 301 {} {}".format(source_url, target_url))
 
             # Updating .htaccess file


### PR DESCRIPTION
**From issue**: WWP-1734

**High level changes:**

1. Changement de l'ordre de la liste des "Redirect" dans le `.htaccess` pour faire en sorte que les pages enfants soient traitées avant leur parent. Il n'y a pas de "full-match" sur les URL sources dans les "Redirect 301" donc il ne faut pas qu'on tombe sur une redirection qui ne match pas toute l'URL en premier, d'où l'inversion de la liste. Vu que les redirections sont créées dans l'ordre d'ajout des pages (et qu'on a d'abord ajouté les parents puis les enfants), un simple "reverse" de la liste suffisait pour corriger le problème.


**Targetted version**: x.x.x
