### PR TITLE
Handle 'jahia:hideFromNavigationMenu' also for jahia:url tags

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -300,6 +300,7 @@ class Site:
                     # If URL
                     elif jahia_type.nodeName == "jahia:url":
                         txt = jahia_type.getAttribute("jahia:title")
+                        hidden = jahia_type.getAttribute("jahia:hideFromNavigationMenu") != ""
                         points_to = jahia_type.getAttribute("jahia:value")
 
                         self.num_url_menu += 1


### PR DESCRIPTION
**From issue**: WWP-1730

**High level changes:**

1. Ajout de la gestion de l'attribut `jahia:hideFromNavigationMenu` également pour les entrées de menu de type `jahia:url` en plus des `jahia:page`


**Targetted version**: x.x.x
