### PR TITLE
Shortcode migration from 2010 to 2018 (part 1)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -264,8 +264,8 @@ To look into the tree structure and list all valid/unvalid WordPress sites, with
     .../src$ python jahia2wp.py inventory $WP_ENV /srv/your-env/localhost
     INFO - your-env - inventory - Building inventory...
     path;valid;url;version;db_name;db_user;admins
-    /srv/your-env/localhost/htdocs/;ok;http://localhost/;4.8.2;wp_dvyrgdywryrcmnkjnmonfzjv9ts4d;ce8clbbqyzeqta31;admin
-    /srv/your-env/localhost/htdocs/folder;ok;http://localhost/folder;4.8;wp_snqi7wekjznhkfe1ggisr9jmqaqeo;o0ajktkeaygim7w9;admin
+    /srv/your-env/localhost/htdocs/;OK;http://localhost/;4.8.2;wp_dvyrgdywryrcmnkjnmonfzjv9ts4d;ce8clbbqyzeqta31;admin
+    /srv/your-env/localhost/htdocs/folder;OK;http://localhost/folder;4.8;wp_snqi7wekjznhkfe1ggisr9jmqaqeo;o0ajktkeaygim7w9;admin
     /srv/your-env/localhost/htdocs/unittest;KO;;;;;
     INFO - your-env - inventory - Inventory made for /srv/your-env/localhost
 

--- a/functional_tests/test_jahia2wp.py
+++ b/functional_tests/test_jahia2wp.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from settings import OPENSHIFT_ENV, SRC_DIR_PATH
+from settings import OPENSHIFT_ENV, SRC_DIR_PATH, WP_SITE_INSTALL_OK
 from utils import Utils
 from wordpress import WPUser, WPBackup
 from wordpress.generator import MockedWPGenerator
@@ -95,8 +95,8 @@ class TestCommandLine:
 
         expected_lines = [
             "path;valid;url;version;db_name;db_user;admins",
-            "/srv/{0}/{1}/htdocs/{2};ok;{3};{4};wp_".format(
-                OPENSHIFT_ENV, TEST_HOST, TEST_SITE, SITE_URL_SPECIFIC, version),
+            "/srv/{0}/{1}/htdocs/{2};{3};{4};{5};wp_".format(
+                OPENSHIFT_ENV, TEST_HOST, TEST_SITE, WP_SITE_INSTALL_OK, SITE_URL_SPECIFIC, version),
         ]
 
         output = Utils.run_command(

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -480,7 +480,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     # skip_media: if True don't import the media
     # skip_pages: if True don't import the pages
     skip_base = False
-    skip_media = True
+    skip_media = False
     skip_pages = False
 
     # List of plugins to let in 'deactivated' state during import. To earn more time, they are not activated during

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -41,6 +41,7 @@ Usage:
   jahia2wp.py veritas               <csv_file>                      [--debug | --quiet]
   jahia2wp.py fan-global-sitemap    <csv_file> <wp_path>            [--debug | --quiet]
   jahia2wp.py inventory             <path>                          [--debug | --quiet]
+  jahia2wp.py shortcode-list        <path>                          [--debug | --quiet]
   jahia2wp.py extract-plugin-config <wp_env> <wp_url> <output_file> [--debug | --quiet]
   jahia2wp.py list-plugins          <wp_env> <wp_url>               [--debug | --quiet]
     [--config [--plugin=<PLUGIN_NAME>]] [--extra-config=<YAML_FILE>]
@@ -67,7 +68,6 @@ import subprocess
 from collections import OrderedDict
 from datetime import datetime, date
 from pprint import pprint
-
 import os
 import shutil
 
@@ -93,6 +93,7 @@ from veritas.casters import cast_boolean
 from veritas.veritas import VeritasValidor
 from wordpress import WPSite, WPConfig, WPGenerator, WPBackup, WPPluginConfigExtractor
 from fan.fan_global_sitemap import FanGlobalSitemap
+from migration2018.shortcodes import Shortcodes
 
 
 def _check_site(wp_env, wp_url, **kwargs):
@@ -477,7 +478,7 @@ def export(site, wp_site_url, unit_name, to_wordpress=False, clean_wordpress=Fal
     # skip_media: if True don't import the media
     # skip_pages: if True don't import the pages
     skip_base = False
-    skip_media = False
+    skip_media = True
     skip_pages = False
 
     # List of plugins to let in 'deactivated' state during import. To earn more time, they are not activated during
@@ -856,6 +857,19 @@ def rotate_backup(csv_file, dry_run=False, **kwargs):
                 include_list=[pattern]
             ).rotate_backups(path)
 
+@dispatch.on('shortcode-list')
+def shortcode_list(path, **kwargs):
+    logging.info("Listing used shortcodes...")
+
+    shortcodes = Shortcodes()
+
+    shortcodes.locate_existing(path)
+
+    print("# shortcodes found: {}".format(len(shortcodes.shortcode_list.keys())))
+
+    print(shortcodes.shortcode_list)
+
+    logging.info("Shortcodes listed for %s", path)
 
 @dispatch.on('inventory')
 def inventory(path, **kwargs):

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -42,6 +42,8 @@ Usage:
   jahia2wp.py fan-global-sitemap    <csv_file> <wp_path>            [--debug | --quiet]
   jahia2wp.py inventory             <path>                          [--debug | --quiet]
   jahia2wp.py shortcode-list        <path>                          [--debug | --quiet]
+  jahia2wp.py shortcode-fix         <wp_env> <wp_url>               [--debug | --quiet]
+  jahia2wp.py shortcode-fix-many    <csv_file>                      [--debug | --quiet]
   jahia2wp.py extract-plugin-config <wp_env> <wp_url> <output_file> [--debug | --quiet]
   jahia2wp.py list-plugins          <wp_env> <wp_url>               [--debug | --quiet]
     [--config [--plugin=<PLUGIN_NAME>]] [--extra-config=<YAML_FILE>]
@@ -870,6 +872,29 @@ def shortcode_list(path, **kwargs):
     print(shortcodes.shortcode_list)
 
     logging.info("Shortcodes listed for %s", path)
+
+@dispatch.on('shortcode-fix')
+def shortcode_fix(wp_env, wp_url, **kwargs):
+
+    shortcodes = Shortcodes()
+
+    report = shortcodes.fix_site(wp_env, wp_url)
+
+    logging.info("Fix report:\n%s", str(report))
+
+@dispatch_on('shortcode-fix-many')
+def shortcode_fix_many(csv_file, **kwargs):
+
+    rows = Utils.csv_filepath_to_dict(csv_file)
+
+    print("\nShortcode will now be fixed on websites...")
+    for index, row in enumerate(rows):
+        print("\nIndex #{}:\n---".format(index))
+
+        shortcode_fix(row['openshift_env'], row['wp_site_url'])
+
+    logging.info("All shortcodes for all sites fixed !")
+
 
 @dispatch.on('inventory')
 def inventory(path, **kwargs):

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -859,6 +859,7 @@ def rotate_backup(csv_file, dry_run=False, **kwargs):
                 include_list=[pattern]
             ).rotate_backups(path)
 
+
 @dispatch.on('shortcode-list')
 def shortcode_list(path, **kwargs):
     logging.info("Listing used shortcodes...")
@@ -873,6 +874,7 @@ def shortcode_list(path, **kwargs):
 
     logging.info("Shortcodes listed for %s", path)
 
+
 @dispatch.on('shortcode-fix')
 def shortcode_fix(wp_env, wp_url, **kwargs):
 
@@ -882,7 +884,8 @@ def shortcode_fix(wp_env, wp_url, **kwargs):
 
     logging.info("Fix report:\n%s", str(report))
 
-@dispatch_on('shortcode-fix-many')
+
+@dispatch.on('shortcode-fix-many')
 def shortcode_fix_many(csv_file, **kwargs):
 
     rows = Utils.csv_filepath_to_dict(csv_file)

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -41,7 +41,7 @@ Usage:
   jahia2wp.py veritas               <csv_file>                      [--debug | --quiet]
   jahia2wp.py fan-global-sitemap    <csv_file> <wp_path>            [--debug | --quiet]
   jahia2wp.py inventory             <path>                          [--debug | --quiet]
-  jahia2wp.py shortcode-list        <path>                          [--debug | --quiet]
+  jahia2wp.py shortcode-list        <path> [--out-csv=<out_csv>]    [--debug | --quiet]
   jahia2wp.py shortcode-fix         <wp_env> <wp_url>               [--debug | --quiet]
   jahia2wp.py shortcode-fix-many    <csv_file>                      [--debug | --quiet]
   jahia2wp.py extract-plugin-config <wp_env> <wp_url> <output_file> [--debug | --quiet]
@@ -861,18 +861,34 @@ def rotate_backup(csv_file, dry_run=False, **kwargs):
 
 
 @dispatch.on('shortcode-list')
-def shortcode_list(path, **kwargs):
-    logging.info("Listing used shortcodes...")
+def shortcode_list(path, out_csv=None, **kwargs):
+    """
+    Go through websites present in 'path' and list all used shortcodes
+    :param path: Path where to look for WP installs
+    :param out_csv: CSV file to save result
+    :param kwargs:
+    :return:
+    """
+    logging.info("Listing used shortcodes in path %s...", path)
 
     shortcodes = Shortcodes()
 
     shortcodes.locate_existing(path)
 
-    print("# shortcodes found: {}".format(len(shortcodes.shortcode_list.keys())))
+    print("# shortcodes found: {}".format(len(shortcodes.list.keys())))
 
-    print(shortcodes.shortcode_list)
+    # If CSV output is requested
+    if out_csv:
+        with open(out_csv, 'w') as out:
+            # Adding one line for each couple "shortcode", "website"
+            for shortcode, url_list in shortcodes.list.items():
+                for url in url_list:
+                    out.write("{},{}\n".format(shortcode, url))
+    else:
 
-    logging.info("Shortcodes listed for %s", path)
+        print(shortcodes.list)
+
+    logging.info("Shortcodes list done!")
 
 
 @dispatch.on('shortcode-fix')

--- a/src/migration2018/__init__.py
+++ b/src/migration2018/__init__.py
@@ -1,0 +1,1 @@
+"""(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""

--- a/src/migration2018/data/shortcodes.yml
+++ b/src/migration2018/data/shortcodes.yml
@@ -1,5 +1,0 @@
-shorcodes:
-  - name: su_youtube
-    new_name: epfl_video
-    attributes:
-  - name:

--- a/src/migration2018/data/shortcodes.yml
+++ b/src/migration2018/data/shortcodes.yml
@@ -1,0 +1,5 @@
+shorcodes:
+  - name: su_youtube
+    new_name: epfl_video
+    attributes:
+  - name:

--- a/src/migration2018/list-registered-shortcodes.php
+++ b/src/migration2018/list-registered-shortcodes.php
@@ -1,0 +1,5 @@
+<?PHP
+    /* Lists WordPress registerd shortcodes, all separated with a coma (CSV like)*/
+    global $shortcode_tags;
+    echo implode(",", array_keys($shortcode_tags));
+?>

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -163,9 +163,10 @@ class Shortcodes():
 
     def fix_site(self, openshift_env, wp_site_url):
         """
-
-        :param path_to_site:
-        :return:
+        Fix shortocdes in WP site
+        :param openshift_env: openshift environment name
+        :param wp_site_url: URL to website to fix.
+        :return: dictionnary with report.
         """
 
         report = {}

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -50,7 +50,6 @@ class Shortcodes():
                             self.shortcode_list[shortcode] = []
 
                         self.shortcode_list[shortcode].append(site_details.path)
-                break
 
     def __rename_shortcode(self, content, old_name, new_name):
         """

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -185,6 +185,9 @@ class Shortcodes():
         old_shortcode = 'su_youtube'
         new_shortcode = 'epfl_video'
 
+        # height and width are useless because display is now responsive and use 100% of width
+        content = self.__remove_attribute(content, old_shortcode, 'height')
+        content = self.__remove_attribute(content, old_shortcode, 'width')
         content = self.__rename_shortcode(content, old_shortcode, new_shortcode)
         return content
 

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -60,7 +60,7 @@ class Shortcodes():
                 # Looping through posts
                 for post_id in post_ids:
                     content = Utils.run_command("wp post get {} --field=post_content --skip-plugins --skip-themes "
-                                                "--path={}".format(post_id,site_details.path))
+                                                "--path={}".format(post_id, site_details.path))
 
                     # Looking for all shortcodes in current post
                     for shortcode in re.findall(self.regex, content):
@@ -205,11 +205,11 @@ class Shortcodes():
             logging.info("No WP site found at given URL (%s)", wp_site_url)
             return report
 
-        logging.info("Fixing %s...", wp_site.folder)
+        logging.info("Fixing %s...", wp_site.path)
 
         # Getting list of registered shortcodes to be sure to list only registered and not all strings
         # written between [ ]
-        registered_shortcodes = self._get_site_registered_shortcodes(site_details.path)
+        registered_shortcodes = self._get_site_registered_shortcodes(wp_site.path)
 
         # Getting site posts
         post_ids = wp_config.run_wp_cli("post list --post_type=page --skip-plugins --skip-themes "

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -176,6 +176,35 @@ class Shortcodes():
 
         return matching_reg.sub(r'\g<before> {} \g<after>'.format(attr), content)
 
+    def __remove_shortcode(self, content, shortcode_name, remove_content=False):
+        """
+        Completely remove a shortcode (begin and end tag) and even its content if needed
+
+        :param content: string in which doing replacement
+        :param shortcode_name: Shortcode name to remove
+        :param remove_content: True|False to tell if we also have to remove content or not.
+        :return:
+        """
+
+        reg_list = []
+
+        if remove_content:
+            # To remove [shortcode_name param="2" ...]...[/shortcode_name]
+            reg_list.append(re.compile('\[{0} .*?\].*?\[\/{0}\]'.format(shortcode_name), re.VERBOSE))
+
+        else:  # We have to remove only surrounding elements
+
+            # To remove [shortcode_name param="2" ...]
+            reg_list.append(re.compile('\[{} .*?\]'.format(shortcode_name), re.VERBOSE))
+
+            # To remove [/shortcode_name]
+            reg_list.append(re.compile('\[\/{}]'.format(shortcode_name), re.VERBOSE))
+
+        for reg in reg_list:
+            content = reg.sub('', content)
+
+        return content
+
     def _fix_su_youtube(self, content):
         """
         Fix "su_youtube" from Shortcode ultimate plugin

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -12,8 +12,8 @@ class Shortcodes():
     """ Shortcodes helpers """
 
     def __init__(self):
-        self.shortcode_list = {}
-        self.shortcode_regex = r'\[([a-z_-]+)'
+        self.list = {}
+        self.regex = r'\[([a-z_-]+)'
 
     def locate_existing(self, path):
         """
@@ -44,12 +44,13 @@ class Shortcodes():
                         site_details.path))
 
                     # Looking for all shortcodes in current post
-                    for shortcode in re.findall(self.shortcode_regex, content):
+                    for shortcode in re.findall(self.regex, content):
 
-                        if shortcode not in self.shortcode_list:
-                            self.shortcode_list[shortcode] = []
+                        if shortcode not in self.list:
+                            self.list[shortcode] = []
 
-                        self.shortcode_list[shortcode].append(site_details.path)
+                        if site_details.path not in self.list[shortcode]:
+                            self.list[shortcode].append(site_details.path)
 
     def __rename_shortcode(self, content, old_name, new_name):
         """
@@ -195,7 +196,7 @@ class Shortcodes():
             content = wp_config.run_wp_cli("post get {} --field=post_content".format(post_id))
 
             # Looking for all shortcodes in current post
-            for shortcode in re.findall(self.shortcode_regex, content):
+            for shortcode in re.findall(self.regex, content):
 
                 fix_func_name = "_fix_{}".format(shortcode.replace("-", "_"))
 

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -1,0 +1,52 @@
+"""(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
+
+import settings
+import re
+from wordpress import WPConfig
+from utils import Utils
+
+
+class Shortcodes():
+    """ Shortcodes helpers """
+
+    def __init__(self):
+        self.shortcode_list = {}
+
+    def _locate_in_pages(self, path_to_site):
+        return ""
+
+    def locate_existing(self, path):
+        """
+        Locate all existing shortcodes in a given path. Go through all WordPress installs and parse pages to extract
+        shortcode list.
+        :param path:
+        :return:
+        """
+        for site_details in WPConfig.inventory(path):
+
+            if site_details.valid == settings.WP_SITE_INSTALL_OK:
+
+                print("Checking {}...".format(site_details.url))
+
+                # Getting site posts
+                post_ids = Utils.run_command("wp post list --post_type=page --format=csv --fields=ID --path={}".format(
+                    site_details.path))
+
+                if not post_ids:
+                    continue
+
+                post_ids = post_ids.split('\n')[1:]
+
+                # Looping through posts
+                for post_id in post_ids:
+                    content = Utils.run_command("wp post get {} --field=post_content --path={}".format(
+                        post_id,
+                        site_details.path))
+
+                    # Looking for all shortcodes in current post
+                    for shortcode in re.findall(r'\[([a-z_]+)', content):
+
+                        if shortcode not in self.shortcode_list:
+                            self.shortcode_list[shortcode] = []
+
+                            self.shortcode_list[shortcode].append(site_details.path)

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -1,8 +1,10 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
 
 import settings
+import logging
+import time
 import re
-from wordpress import WPConfig
+from wordpress import WPConfig, WPSite
 from utils import Utils
 
 
@@ -11,22 +13,20 @@ class Shortcodes():
 
     def __init__(self):
         self.shortcode_list = {}
-
-    def _locate_in_pages(self, path_to_site):
-        return ""
+        self.shortcode_regex = r'\[([a-z_-]+)'
 
     def locate_existing(self, path):
         """
         Locate all existing shortcodes in a given path. Go through all WordPress installs and parse pages to extract
         shortcode list.
-        :param path:
+        :param path: path where to start search
         :return:
         """
         for site_details in WPConfig.inventory(path):
 
             if site_details.valid == settings.WP_SITE_INSTALL_OK:
 
-                print("Checking {}...".format(site_details.url))
+                logging.info("Checking %s...", site_details.url)
 
                 # Getting site posts
                 post_ids = Utils.run_command("wp post list --post_type=page --format=csv --fields=ID --path={}".format(
@@ -44,9 +44,191 @@ class Shortcodes():
                         site_details.path))
 
                     # Looking for all shortcodes in current post
-                    for shortcode in re.findall(r'\[([a-z_]+)', content):
+                    for shortcode in re.findall(self.shortcode_regex, content):
 
                         if shortcode not in self.shortcode_list:
                             self.shortcode_list[shortcode] = []
 
-                            self.shortcode_list[shortcode].append(site_details.path)
+                        self.shortcode_list[shortcode].append(site_details.path)
+                break
+
+    def __rename_shortcode(self, content, old_name, new_name):
+        """
+        Rename one shortcode in a given string
+
+        :param content: string in which doing replacement
+        :param old_name: shortcode name to look for
+        :param new_name: new shortcode name
+        :return:
+        """
+
+        # Transforms the following
+        # [old_name]Content[/old_name]  --> [new_name]Content[/new_name]
+        # [old_name attr="a"]           --> [new_name attr="a"]
+        # [old_name]                    --> [new_name]
+        #
+        # <before> and <after> are used to store string before and after shortcode name and reuse it during
+        # replacement with new name
+        matching_reg = re.compile('(?P<before>\[(\/)?){}(?P<after> (\]|\s) )'.format(old_name), re.VERBOSE)
+
+        return matching_reg.sub(r'\g<before>{}\g<after>'.format(new_name), content)
+
+    def __rename_attribute(self, content, shortcode_name, attr_old_name, attr_new_name):
+        """
+        Rename a shortcode's attribute.
+
+        :param content: string in which doing replacement
+        :param shortcode_name: shortcode name
+        :param attr_old_name: current attribute name
+        :param attr_new_name: new attribute name
+        :return:
+        """
+
+        # Transforms the following:
+        # [my_shortcode attr_old_name="a" two="b"]  --> [my_shortcode attr_new_name="a" two="b"]
+        # [my_shortcode attr_old_name=a two="b"]    --> [my_shortcode attr_new_name=a two="b"]
+        # [my_shortcode attr_old_name two="b"]      --> [my_shortcode attr_new_name two="b"]
+        matching_reg = re.compile('(?P<before> \[{}.+ ){}(?P<after> (=|\s|\])? )'.format(shortcode_name, attr_old_name),
+                                  re.VERBOSE)
+
+        return matching_reg.sub(r'\g<before>{}\g<after>'.format(attr_new_name), content)
+
+    def __remove_attribute(self, content, shortcode_name, attr_name):
+        """
+        Remove a shortcode attribute
+
+        :param content: string in which doing replacement
+        :param shortcode_name: Shortcode name for which we have to remove attribute
+        :param attr_name: Attribute name to remove
+        :return:
+        """
+
+        # Transforms the following:
+        # [my_shortcode attr_name="a" two="b"]  --> [my_shortcode two="b"]
+        # [my_shortcode attr_name two="b"]      --> [my_shortcode two="b"]
+        matching_reg = re.compile('(?P<before> \[{}.+ ){}(=(".+?"|\S+?)|\s|\])?'.format(shortcode_name, attr_name),
+                                  re.VERBOSE)
+
+        return matching_reg.sub(r'\g<before>', content)
+
+    def __change_attribute_value(self, content, shortcode_name, attr_name, new_value):
+        """
+        Change a shortcode attribute value
+
+        :param content: string in which doing replacement
+        :param shortcode_name: shortcode for which we want to change an attribute value
+        :param attr_name: attribute to which we want to change value
+        :param new_value: new value to set for attribute
+        :return:
+        """
+
+        # Transforms the following:
+        # [my_shortcode attr_name="a" two="b"]  --> [my_shortcode attr_name="b" two="b"]
+        # [my_shortcode attr_name=a two="b"]  --> [my_shortcode attr_name="b" two="b"]
+        matching_reg = re.compile('(?P<before> \[{}.+{}= )(".+?"|\S+?)'.format(shortcode_name, attr_name),
+                                  re.VERBOSE)
+
+        return matching_reg.sub(r'\g<before>"{}"'.format(new_value), content)
+
+    def __add_attribute(self, content, shortcode_name, attr_name, attr_value=""):
+        """
+        Adds an attribute to a shortcode
+        :param content: string in which doing replacement
+        :param shortcode_name: Shortcode name for which we want to add the attribute
+        :param attr_name: Attribute name
+        :param attr_value: Attribute value
+        :return:
+        """
+
+        # Transforms the following
+        # [my_shortcode]            --> [my_shortcode attr_name="b" ]
+        # [my_shortcode two="b"]    --> [my_shortcode attr_name="b" two="b"]
+        # [my_shortcode two="b"]    --> [my_shortcode attr_name two="b"]
+        matching_reg = re.compile('(?P<before> \[{}.*? )(?P<after> \S+? )'.format(shortcode_name),
+                                  re.VERBOSE)
+
+        attr = attr_name
+        if attr_value:
+            attr += '="{}"'.format(attr_value)
+
+        return matching_reg.sub(r'\g<before> {} \g<after>'.format(attr), content)
+
+    def _fix_simple_sitemap(self, content):
+
+        shortcode = 'simple-sitemap'
+        content = self.__rename_attribute(content, shortcode, 'show_labels', 'tagada')
+        content = self.__add_attribute(content, shortcode, 'new', 'attribute')
+        content = self.__rename_shortcode(content, shortcode, 'simple-sitemap-lulu')
+        return content
+
+    def fix_site(self, openshift_env, wp_site_url):
+        """
+
+        :param path_to_site:
+        :return:
+        """
+
+        report = {}
+
+        wp_site = WPSite(openshift_env, wp_site_url)
+        wp_config = WPConfig(wp_site)
+
+        if not wp_config.is_installed:
+            logging.info("No WP site found at given URL (%s)", wp_site_url)
+            return report
+
+        logging.info("Fixing %s...", wp_site.folder)
+
+        # Getting site posts
+        post_ids = wp_config.run_wp_cli("post list --post_type=page --format=csv --fields=ID")
+
+        # Nothing to fix
+        if not post_ids:
+            logging.info("No page found, nothing to do!")
+            return
+
+        post_ids = post_ids.split('\n')[1:]
+
+        # Looping through posts
+        for post_id in post_ids:
+            logging.info("Fixing page ID %s...", post_id)
+            content = wp_config.run_wp_cli("post get {} --field=post_content".format(post_id))
+
+            # Looking for all shortcodes in current post
+            for shortcode in re.findall(self.shortcode_regex, content):
+
+                fix_func_name = "_fix_{}".format(shortcode.replace("-", "_"))
+
+                try:
+                    # Trying to get function to fix current shortcode
+                    fix_func = getattr(self, fix_func_name)
+                except Exception as e:
+                    # "Fix" function not found, skipping to next shortcode
+                    continue
+
+                logging.debug("Fixing shortcode %s...", shortcode)
+                fixed_content = fix_func(content)
+
+                if fixed_content != content:
+
+                    # Building report
+                    if shortcode not in report:
+                        report[shortcode] = 0
+
+                    report[shortcode] += 1
+
+                    logging.debug("Shortcode fixed, updating page...")
+
+                    for try_no in range(settings.WP_CLI_AND_API_NB_TRIES):
+                        try:
+                            wp_config.run_wp_cli("post update {} - ".format(post_id), pipe_input=fixed_content)
+
+                        except Exception as e:
+                            if try_no < settings.WP_CLI_AND_API_NB_TRIES - 1:
+                                logging.error("fix_site() error. Retry %s in %s sec...",
+                                              try_no + 1,
+                                              settings.WP_CLI_AND_API_NB_SEC_BETWEEN_TRIES)
+                                time.sleep(settings.WP_CLI_AND_API_NB_SEC_BETWEEN_TRIES)
+                                pass
+
+        return report

--- a/src/settings.py
+++ b/src/settings.py
@@ -247,3 +247,7 @@ FEATURES_FLAGS_ATTRIBUTES_TO_CLEAN = ['style']
 # Retries settings for WPCLI and WordPress API calls
 WP_CLI_AND_API_NB_TRIES = 3
 WP_CLI_AND_API_NB_SEC_BETWEEN_TRIES = 5
+
+# Status for WordPress site installs
+WP_SITE_INSTALL_OK = 'OK'
+WP_SITE_INSTALL_KO = 'KO'

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -86,7 +86,7 @@ class WPConfig:
                 if wp_config.is_config_valid:
                     yield WPResult(
                         wp_config.wp_site.path,
-                        "ok",
+                        settings.WP_SITE_INSTALL_OK,
                         wp_config.wp_site.url,
                         wp_config.wp_version,
                         wp_config.db_name,
@@ -94,7 +94,7 @@ class WPConfig:
                         ",".join([wp_user.username for wp_user in wp_config.admins]),
                     )
                 else:
-                    yield WPResult(wp_config.wp_site.path, "KO", "", "", "", "", "")
+                    yield WPResult(wp_config.wp_site.path, settings.WP_SITE_INSTALL_KO, "", "", "", "", "")
 
     def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout du nécessaire pour pouvoir:
- Renommer un Shortcode
- Renommer un attribut d'un shortcode donné
- Changer la valeur d'un attribut donné pour un shortcode donné
- Ajouter un attribut (avec ou sans valeur) pour un shortcode donné
- Supprimer un attribut pour un shortcode donné.
- Supprimer un shortcode (et potentiellement son contenu). Ceci peut être utile pour supprimer des "surrounding shortcodes", typiquement utilisés dans les shortcodes imbriqués.
2. Ajout d'options de fonctionnement à `jahia2wp.py` pour:
- Lister tous les shortcodes utilisés par les sites se trouvant dans un dossier donné (utilisation de l'inventaire) - `shortcode-list`
- Mettre à jour les shortcodes d'un site donné - `shortcode-fix`
- Mettre à jour les shortcodes de plusieurs sites depuis une source de vérité - `shortcode-fix-many`
3. Gestion du premier shortcode, "su_youtube"

**Low level changes:**
1. Remplacement des chaînes hard-codées "ok" et "KO" pour l'inventaire par des constantes dans `settings.py`
1. Adaptation des tests suite au changement précédent.

**Targetted version**: x.x.x
