### PR TITLE
Use 'id' instead of 'name' dumbass...

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -923,7 +923,7 @@ class WPExporter:
         :param sidebar_name: Name of the sidebar we want to know if it exists.
         :return:
         """
-        cmd = "sidebar list --fields=name --format=csv"
+        cmd = "sidebar list --fields=id --format=csv"
         sidebar_list = self.run_wp_cli(cmd)
 
         return sidebar_name in sidebar_list


### PR DESCRIPTION
**From issue**: -

**Low level changes:**

1. Utilisation du champ `id` au lieu de `name` pour la recherche des sidebar existantes... ça marche mieux comme ça...
Ce bug a été introduit dans https://github.com/epfl-idevelop/jahia2wp/pull/613

**Targetted version**: x.x.x
