### PR TITLE
Disable major updates (to avoid WP 5.0.0 install), fix bug in mu-plugins install

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_enable_updates_automatic.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_enable_updates_automatic.php
@@ -16,7 +16,7 @@
 add_filter( 'allow_minor_auto_core_updates', '__return_true' );
 
 // enable WordPress Core major updates
-add_filter( 'allow_major_auto_core_updates', '__return_true' );
+add_filter( 'allow_major_auto_core_updates', '__return_false' );
 
 // enable plugins updates
 add_filter( 'auto_update_plugin', '__return_true' );

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -424,6 +424,8 @@ class WPGenerator:
     def enable_updates_automatic_if_allowed(self):
         if self.wp_config.updates_automatic:
             WPMuPluginConfig(self.wp_site, "EPFL_enable_updates_automatic.php").install()
+            # We also uninstall the plugin which disable auto-updates otherwise we will have both...
+            WPMuPluginConfig(self.wp_site, "EPFL_disable_updates_automatic.php").uninstall()
 
     def generate_plugins(self,
                          only_one=None,

--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -120,6 +120,10 @@ class WPMuPluginConfig(WPConfig):
                       self.name, src_path,
                       self.path)
 
+    def uninstall(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
     @property
     def dir_path(self):
         dir_path = os.path.join(self.wp_site.path, self.PLUGINS_PATH)


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Désactivation des mises à jour "majeures"
1. Ajout du nécessaire pour supprimer le plugin "EPFL_disable_updates_automatic.php" après l'import d'un site. Celui-ci était en effet installé lors de la génération du site, puis, à la fin de l'export, on installait "EPFL_enable_updates_automatic.php"... sans désinstaller l'autre... donc les 2 sont actuellement en train de cohabiter sur les sites web depuis... le 1er mars 2018

**TODO**
Virer "EPFL_disable_updates_automatic.php" sur tous les sites passés en production

**Targetted version**: x.x.x
