### PR TITLE
epfl_infoscience_search - Fix some bug and sync with new theme

### DIFF
--- a/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL Infoscience search shortcode
  * Plugin URI: https://github.com/epfl-idevelop/jahia2wp
  * Description: provides a shortcode to search and dispay results from Infoscience
- * Version: 1.0
+ * Version: 1.1
  * Author: Julien Delasoie
  * Author URI: https://people.epfl.ch/julien.delasoie?lang=en
  * Contributors: 

--- a/data/wp/wp-content/plugins/epfl-infoscience-search/shortcake-config.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/shortcake-config.php
@@ -94,9 +94,6 @@ Class InfoscienceSearchShortCakeConfig
         $fields['epfl-select'] = array(
             'template' => 'epfl-shortcode-ui-field-select',
         );
-        $fields['epfl-radio'] = array(
-            'template' => 'epfl-shortcode-ui-field-radio',
-        );        
         return $fields;
     }
 
@@ -167,28 +164,6 @@ Class InfoscienceSearchShortCakeConfig
 		<# } #>
 	</div>
     </script>  
-
-    <script type="text/html" id="tmpl-epfl-shortcode-ui-field-radio">
-        <# if (data.title) { #>
-            <# if ( 'true' == data.is_toggle ){ #> 
-                <h3 class="infoscience_search_toggle_header"><a href="#">[-] {{ data.title }}</a></h3>
-            <# } else { #>
-                <h2>{{ data.title }}</h2>
-            <# } #>
-        <# } #>
-        <div class="field-block epfl-shortcode-ui-field-radio shortcode-ui-attribute-{{ data.attr }}">
-            <label>{{{ data.label }}}</label>
-            <# _.each( data.options, function( option ) { #>
-                <label>
-                    <input type="radio" name="{{ data.attr }}" value="{{ option.value }}" <# if ( option.value == data.value ) { print('checked'); } #> />
-                    {{ option.label }}
-                </label>
-            <# }); #>
-            <# if ( typeof data.description == 'string' && data.description.length ) { #>
-                <p class="description">{{{ data.description }}}</p>
-            <# } #>
-        </div>
-    </script>
         <?php
         //@formatter:on
     }
@@ -290,10 +265,9 @@ Class InfoscienceSearchShortCakeConfig
 
                     # Presentation
                     array(
-                        'title'         => esc_html__('Style', 'epfl-infoscience-search'),
                         'label'         => esc_html__('Format', 'epfl-infoscience-search'),
                         'attr'          => 'format',
-                        'type'          => 'epfl-radio',
+                        'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_format_options(),
                         'description'   => __('Detail level for a publication', 'epfl-infoscience-search'),
                         'value'         => 'short',
@@ -301,21 +275,21 @@ Class InfoscienceSearchShortCakeConfig
                     array(
                         'label'         => esc_html__('Summary', 'epfl-infoscience-search'),
                         'attr'          => 'summary',
-                        'type'          => 'epfl-radio',
+                        'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_summary_options(),
                         'value' => 'false',
                     ),                        
                     array(
                         'label'         => esc_html__('Thumbnail', 'epfl-infoscience-search'),
                         'attr'          => 'thumbnail',
-                        'type'          => 'epfl-radio',
+                        'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_thumbnail_options(),
                         'value' => 'true',
                     ),
                     array(
                         'label'         => esc_html__('Sort', 'epfl-infoscience-search'),
                         'attr'          => 'sort',
-                        'type'          => 'epfl-radio',
+                        'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_sort_options(),
                         'value'         => 'desc',
                     ),                        


### PR DESCRIPTION
- Copy and renamed epfl_infoscience_url_exists method as it was not in the same namespace
- Set a WP filter for testing if the new theme is installed, and to use it if this is the case
- Remove the custom radio input in shortcake UI, this was completly broken