### PR TITLE
Use empty (blank) title instead of None to avoid sorting errors

### DIFF
--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -331,7 +331,8 @@ class Site:
 
                 # If no childNode, it means <navigationPage> can be a "reference" to a menu entry of another language
                 if not nav_page.childNodes:
-                    menu_item = MenuItem(None, nav_page_uuid, False, None)
+                    # Creating a menu entry with a blank title because we don't know the "target" title.
+                    menu_item = MenuItem("", nav_page_uuid, False, None)
 
                     # If we are parsing root menu entries
                     if parent_menu is None:
@@ -342,6 +343,8 @@ class Site:
 
         # Looking for sort information. If exists, the format is the following:
         # epfl_simple_navigationList_navigationPage;asc;false;false
+        # Note: If sorting is done using 'txt' field (menu title), it will be incorrect if there are references to
+        # menu entries in other language.
         sort_infos = nav_list_list_node.getAttribute("jahia:sortHandler")
         if sort_infos:
             # FIXME: For now, root menu entries sorting is not handled because never encountered in a Jahia Website


### PR DESCRIPTION
**From issue**: -

**Low level changes:**

1. Dans le cas où on avait une entrée de menu d'une langue A qui référençait une entrée de menu d'une langue B (ou qui ne référence rien du tout...), c'était un titre de menu égal à `None` qui était initialisé. Et s'il s'avérait qu'il fallait faire un titre des entrées de menu par leur titre, cela soulevait une erreur car on ne peut pas trier du "str" sur une variable égale à `None`.

**Targetted version**: x.x.x
