### PR TITLE
epfl-faq + fix memento bug

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -18,6 +18,7 @@ require_once 'shortcodes/epfl-map/epfl-map.php';
 require_once 'shortcodes/epfl-infoscience-search/epfl-infoscience-search.php';
 require_once 'shortcodes/epfl-scheduler/epfl-scheduler.php';
 require_once 'shortcodes/epfl-xml/epfl-xml.php';
+require_once 'shortcodes/epfl-faq/epfl-faq.php';
 
 // load .mo file for translation
 function epfl_load_plugin_textdomain() {

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-faq/epfl-faq.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-faq/epfl-faq.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Plugin Name: EPFL FAQ shortcode
+ * Description: provides 2 shortcodes to dispay a faq with boxes
+ * Version: 1.1
+ * License: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
+ */
+
+/* We have to use this global var to build FAQ references links. */
+$faq_ref_table = "";
+
+/*
+    GOAL : Extract question from shortcode attributes. We use this function as workaround to WordPress
+           parsing that cannot handle escape double quotes correctly.
+
+           WARNING! for now, this function works because 'attributes' only contains 'question' attribute. If in
+                    the future another attributes is added, a modification will be needed to handle this correctly
+                    (only take array items with numeric index as 'question').
+*/
+function extract_question($attributes)
+{
+    if(array_key_exists('question', $attributes)) return $attributes['question'];
+
+    if(preg_match('/question=[.]*+/i', $attributes[0])===1)
+    {
+
+        return preg_replace('/^question=\"|\"$/i', '', implode(" ", $attributes));
+    }
+    return "";
+}
+
+function epfl_faqboxitem_process_shortcode($attributes, $content = null)
+{
+    global $faq_ref_table;
+
+    /* We have to extract question using a dedicated method outside of WordPress because if the question contains
+    escaped double quotes, it's not parsed correctly. Param $attributes won't be an associative array with 'question'
+    as key (and the question content as value), it will be an array (not associative) with the question exploded using
+    whitspaces... and in this case, WordPress will return an empty string for "question""*/
+    $question = extract_question($attributes);
+
+    /* Generating uniq anchor id*/
+    $anchor = "faq-".md5($content);
+
+    $faq_ref_table .= '<li><a href="#'.$anchor.'">'.$question.'</a></li>';
+
+    return '<div class="faq-item" style="border-top: 1px solid #c1c1c1; padding-top: 10px; padding-bottom: 10px;" id="'.esc_attr($anchor).'">'.
+           '<h4 style="font-weight: bold;">'.$question.'</h4>'.
+           do_shortcode($content).
+           '</div>';
+}
+
+/**
+ * Main function of shortcode
+ *
+ * @param $atts: attributes of the shortcode
+ * @param $content: the content of the shortcode.
+ */
+function epfl_faqbox_process_shortcode($attributes, $content = null)
+{
+    global $faq_ref_table;
+
+    $atts = shortcode_atts(array(
+            'title' => '',   // for the future
+        ), $attributes);
+
+    $faq_ref_table = '<ul class="link-list">';
+
+    $faq_items_html = do_shortcode($content);
+
+    $faq_ref_table .= '</ul>';
+
+    return '<div class="faqBox">'.
+           $faq_ref_table.
+           $faq_items_html.
+           '</div>';
+}
+
+add_shortcode('epfl_faq', 'epfl_faqbox_process_shortcode');
+add_shortcode('epfl_faqItem', 'epfl_faqboxitem_process_shortcode');
+
+?>

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-memento/epfl-memento.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-memento/epfl-memento.php
@@ -161,7 +161,7 @@ function epfl_memento_2018_process_shortcode($atts = [], $content = '', $tag = '
         $template,
         $category,
         $keyword,
-        $period,
+        $period
     );
     $events = Utils::get_items($url);
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Mettre le shortcode epfl-faq dans le plugin epfl. Ce shortcode n'est pas shortcaké car shortcodes imbriqués.

**Low level changes:**

1. Mettre le shortcode epfl-faq dans le plugin epfl.
1. corrige une erreur de syntaxe pour le shortcode epfl-memento

**A quoi cela ressemble ?**
![screenshot from 2018-09-21 14-00-38](https://user-images.githubusercontent.com/4997224/45880022-de80bd80-bda6-11e8-8283-bdf6cfd2b4f6.png)


**Targetted version**: x.x.x
