### PR TITLE
Snippets - Remove 'manage_quotes' call because useless and leads to issue

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -1095,8 +1095,7 @@ class Box:
                         # if link has a title, add it to content as ref
                         url_title = Utils.get_tag_attribute(snippet, "jahia:link", "jahia:title")
                         if url_title and not url_title == "":
-                            description += Utils.manage_quotes('<a href="' + url + '">' +
-                                                               Utils.manage_quotes(url_title) + '</a>')
+                            description += '<a href="' + url + '">' + Utils.manage_quotes(url_title) + '</a>'
 
             self.content += '[{} url="{}" title="{}" subtitle="{}" image="{}"' \
                             ' big_image="{}" enable_zoom="{}"]{}[/{}]'.format(self.shortcode_name,


### PR DESCRIPTION
**From issue**: WWP-1781, WWP-1782, WWP-1783

**High level changes:**

1. Suppression d'un appel à `manage_quotes()` qui était fait en trop et qui menait à la génération incorrecte de liens dans Snippets.

**Targetted version**: x.x.x
