### PR TITLE
Use 'content' to store content instead of an attribute

### DIFF
--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-card/epfl-card.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-card/epfl-card.php
@@ -21,7 +21,6 @@ function epfl_card_process_shortcode($atts = [], $content = '', $tag = '') {
     // shortcode parameters
     $atts = shortcode_atts(array(
             'title' => '',
-            'text'  => '',
             'link'  => '',
             'image' => '',
     ), $atts, $tag);
@@ -29,7 +28,7 @@ function epfl_card_process_shortcode($atts = [], $content = '', $tag = '') {
     // sanitize parameters
     $link  = esc_url($atts['link']);
     $title = sanitize_text_field( $atts['title'] );
-    $text  = wp_kses_post($atts['text']);
+    $text  = wp_kses_post($content);
     $image = sanitize_text_field( $atts['image'] );
     $image_url = wp_get_attachment_url( $image );
 

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-card/shortcake-config.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-card/shortcake-config.php
@@ -18,11 +18,6 @@ Class ShortCakeCardConfig
                             'type'  => 'text',
                         ),
                         array(
-                            'label' => '<h3>' . esc_html__('Card text', 'epfl') . '</h3>',
-                            'attr'  => 'text',
-                            'type'  => 'textarea',
-                        ),
-                        array(
                             'label' => '<h3>' . esc_html__('Card link', 'epfl') . '</h3>',
                             'attr'  => 'link',
                             'type'  => 'url',
@@ -34,6 +29,9 @@ Class ShortCakeCardConfig
                             'libraryType' => array( 'image' ),
                         ),
                     ),
+                'inner_content' => array(
+                    'label'        => '<h3>' . esc_html__('Card text', 'epfl') . '</h3>',
+                ),
                 'post_type'     => array( 'post', 'page' ),
             )
         );


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Utilisation de `$content` plutôt que d'un attribut pour stocker le texte à afficher.
1. Mise à jour du shortcake pour s'adapter au truc.


