### PR TITLE
New way to define if box is in sidebar

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -62,7 +62,7 @@ class Box:
 
     UPDATE_LANG = "UPDATE_LANG_BY_EXPORTER"
 
-    def __init__(self, site, page_content, element, multibox=False):
+    def __init__(self, site, page_content, element, multibox=False, is_in_sidebar=False):
         """
 
         :param site: instance of Site class
@@ -79,6 +79,7 @@ class Box:
         self.title = Utils.get_tag_attribute(element, "boxTitle", "jahia:value")
         self.content = ""
         self.sort_group = None
+        self.is_in_sidebar = False
 
         # the shortcode attributes with URLs that must be fixed by the wp_exporter
         self.shortcode_attributes_to_fix = []
@@ -543,7 +544,7 @@ class Box:
         content = ""
 
         # Title is only for boxes in pages
-        if not self.is_in_sidebar():
+        if not self.is_in_sidebar:
             content += '<h3>{}</h3>'.format(self.title)
 
         content += '[{} channel="{}" lang="{}" template="{}" '.format(
@@ -584,13 +585,6 @@ class Box:
             content += '[/epfl_buttons_container]'
 
         self.content = content
-
-    def is_in_sidebar(self):
-        """
-        Tells if the box belongs to the sidebar
-        :return:
-        """
-        return self.page_content.page.is_homepage()
 
     @staticmethod
     def _extract_epfl_memento_parameters(url):

--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -107,7 +107,7 @@ class PageContent:
 
                     multibox = extra.getElementsByTagName("text").length > 1
 
-                    box = Box(site=self.site, page_content=self, element=extra, multibox=multibox)
+                    box = Box(site=self.site, page_content=self, element=extra, multibox=multibox, is_in_sidebar=True)
                     self.sidebar.boxes.append(box)
 
         nb_boxes = len(self.sidebar.boxes)


### PR DESCRIPTION
**From issue**: WWP-1813

**High level changes:**

1. Autre manière de définir si une Box est dans la sidebar ou pas. Avant on regardait si elle était simplement sur la homepage (vu que la sidebar est sur la homepage uniquement) mais si la boîte était sur la homepage (dans son contenu), la fonction définissant si elle était dans la sidebar répondait par l'affirmative... changement de ceci pour simplement passer un attribut à la boîte lors du parsing comme ça elle sait où elle est.


**Targetted version**: x.x.x
