### PR TITLE
Fix moniker and sandbox

### DIFF
--- a/src/ops.py
+++ b/src/ops.py
@@ -54,10 +54,14 @@ class SshRemoteHost:
             assert self is SshRemoteHost.test
             wp_env = 'int'
             wp_hostname = 'migration-wp.epfl.ch'
+        elif hostname == 'www2018.epfl.ch':
+            assert self is SshRemoteHost.prod
+            wp_env = 'sandbox'
+            wp_hostname = hostname
         else:
             # TODO: there certainly is more to it than this.
             assert self is SshRemoteHost.prod
-            wp_env = 'sandbox'
+            wp_env = 'subdomains'
             wp_hostname = hostname
 
         retval = {

--- a/src/ventilation/Makefile
+++ b/src/ventilation/Makefile
@@ -26,7 +26,7 @@ $(SOURCES_INVENTORY) hosts/group_vars/ventilation-source-wordpresses \
 $(TARGETS_INVENTORY) hosts/group_vars/ventilation-target-wordpresses: \
   $(VENTILATION_CSV)
 	@mkdir hosts 2>/dev/null || true
-	python3 ./wordpress-inventories.py --sources=$(SOURCES_INVENTORY) --targets=$(TARGETS_INVENTORY) $<
+	python3 ./wordpress_inventories.py --sources=$(SOURCES_INVENTORY) --targets=$(TARGETS_INVENTORY) $<
 
 wxr-src: $(SOURCES_INVENTORY)
 	@mkdir "$@" 2>/dev/null || true

--- a/src/ventilation/ventilate.py
+++ b/src/ventilation/ventilate.py
@@ -25,7 +25,8 @@ import logging
 dirname = os.path.dirname
 sys.path.append(dirname(dirname(os.path.realpath(__file__))))
 
-from utils import Utils  # noqa: E402
+from utils import Utils                         # noqa: E402
+from wordpress_inventories import site_moniker  # noqa: E402
 
 
 class SourceWXR:
@@ -55,16 +56,6 @@ class SourceWXR:
 
     def __repr__(self):
         return '<%s "%s">' % (self.__class__.__name__, self.path)
-
-
-# This is quite unfortunately coupled with the _moniker method
-# in wordpress-inventories.py
-def site_moniker(url):
-    parsed = urlparse(url)
-    hostname = parsed.netloc.split('.')[0]
-    if hostname != 'migration-wp':
-        return hostname
-    return re.search('^/([^/]*)/', parsed.path).group(1)
 
 
 class DestinationWXR:

--- a/src/ventilation/ventilate.py
+++ b/src/ventilation/ventilate.py
@@ -13,7 +13,6 @@ Options:
 """
 
 import os
-import re
 import sys
 import subprocess
 import lxml.etree

--- a/src/ventilation/wordpress_inventories.py
+++ b/src/ventilation/wordpress_inventories.py
@@ -61,6 +61,7 @@ class AnsibleGroup:
     def __repr__(self):
         return '<%s %s>' % (self.__class__, self.name)
 
+
 def site_moniker(url):
     """
     Return

--- a/src/ventilation/wordpress_inventories.py
+++ b/src/ventilation/wordpress_inventories.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8; -*-
 # All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2017
 
-"""wordpress-inventories.py: Find where source Wordpresses reside from a CSV file.
+"""wordpress_inventories.py: Find where source Wordpresses reside from a CSV file.
 
 The CSV file must have a 'source' column with URLs in it.  Other columns are
 ignored.
 
 Usage:
-  wordpress-inventories.py --sources=<sources_inventory_file> --targets=<targets_inventory_file> <ventilation_csv_file>
+  wordpress_inventories.py --sources=<sources_inventory_file> --targets=<targets_inventory_file> <ventilation_csv_file>
 
 """
 
@@ -35,25 +35,9 @@ class AnsibleGroup:
     def has_wordpress(self, designated_name):
         return designated_name in self.hosts
 
-    def _moniker(self, url):
-        """
-        Return
-        A short name that identifies this URL either in a file path (under wxr-ventilated/),
-        or in an Ansible hosts file.
-        
-        Example:
-        url = "https://migration-wp.epfl.ch/help-actu/*"
-        return "help-actu"
-        """
-        parsed = urlparse(url)
-        hostname = parsed.netloc.split('.')[0]
-        if hostname != 'migration-wp':
-            return hostname
-        return re.search('^/([^/]*)/', parsed.path).group(1)
-
     def add_wordpress_by_url(self, url):
         ssh = SshRemoteHost.for_url(url)
-        moniker = self._moniker(url)
+        moniker = site_moniker(url)
         ansible_params = copy.copy(ssh.as_ansible_params(url))
         self.hosts[moniker] = ansible_params
 
@@ -76,6 +60,22 @@ class AnsibleGroup:
 
     def __repr__(self):
         return '<%s %s>' % (self.__class__, self.name)
+
+def site_moniker(url):
+    """
+    Return
+    A short name that identifies this URL either in a file path (under wxr-ventilated/),
+    or in an Ansible hosts file.
+
+    Example:
+    url = "https://migration-wp.epfl.ch/help-actu/*"
+    return "help-actu"
+    """
+    parsed = urlparse(url)
+    hostname = parsed.netloc.split('.')[0]
+    if hostname not in ('migration-wp', 'www2018'):
+        return hostname
+    return re.search('^/([^/]*)/', parsed.path).group(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**From issue**: No issue

**High level changes:**

Sites under www2018.epfl.ch are now correctly treated as "staging" (under directory "sandbox"; and their host name is not authoritative w.r.t. the Ansible short names)

**Low level changes:**

* SshRemoteHost().as_ansible_params(): fix guesswork again
* Single, repaired implementation of site_moniker


