### PR TITLE
Change way to handle simple/double quotes and add brackets support

### DIFF
--- a/src/exporter/wp_exporter.py
+++ b/src/exporter/wp_exporter.py
@@ -556,7 +556,7 @@ class WPExporter:
             content = str(soup.body)
 
             # Transforming quotes to right html entities
-            content = WPUtils.manage_quotes(content, False)
+            content = WPUtils.handle_custom_chars(content, False)
 
             self.update_page_content(page_id=wp_id, content=content)
 

--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -283,7 +283,7 @@ class Box:
             title = Utils.get_tag_attribute(e, "jahia:url", "jahia:title")
 
             # Escape if necessary
-            title = Utils.manage_quotes(title)
+            title = Utils.handle_custom_chars(title)
 
             self.content += '[{} layout="{}" link="{}" title="{}" image="{}"][/{}]\n'.format(
                 shortcode_inner_name, layout, link, title, image, shortcode_inner_name)
@@ -741,7 +741,7 @@ class Box:
 
             # Get question and escape if necessary
             question = Utils.get_tag_attribute(entry, "question", "jahia:value")
-            question = Utils.manage_quotes(question)
+            question = Utils.handle_custom_chars(question)
 
             # Get answer
             answer = Utils.get_tag_attribute(entry, "answer", "jahia:value")
@@ -881,6 +881,10 @@ class Box:
         if small_button_key:
             small_button_key = 'key="{}"'.format(small_button_key)
 
+        # Replacing necessary characters to ensure everything will work correctly
+        text = Utils.handle_custom_chars(text)
+        alt_text = Utils.handle_custom_chars(alt_text)
+
         return '[epfl_buttons type="{}" url="{}" {} alt_text="{}" text="{}" {}]'.format(box_type,
                                                                                         url,
                                                                                         big_button_image_url,
@@ -1007,10 +1011,6 @@ class Box:
             if box_type == 'small' and text == "":
                 text = alt_text
 
-            # Escape if necessary
-            text = Utils.manage_quotes(text)
-            alt_text = Utils.manage_quotes(alt_text)
-
             # bigButton will have 'image' attribute and smallButton will have 'key' attribute.
             box_content = self._get_button_shortcode(box_type,
                                                      url,
@@ -1067,8 +1067,8 @@ class Box:
                 big_image = big_image[big_image.rfind("/files"):]
 
             # escape
-            title = Utils.manage_quotes(title)
-            subtitle = Utils.manage_quotes(subtitle)
+            title = Utils.handle_custom_chars(title)
+            subtitle = Utils.handle_custom_chars(subtitle)
 
             url = ""
 
@@ -1081,7 +1081,7 @@ class Box:
                 if url != "":
                     if not subtitle or subtitle == "":
                         subtitle = Utils.get_tag_attribute(snippet, "jahia:url", "jahia:title")
-                        subtitle = Utils.manage_quotes(subtitle)
+                        subtitle = Utils.handle_custom_chars(subtitle)
                 # if not we might have a <jahia:link> (internal url)
                 else:
                     uuid = Utils.get_tag_attribute(snippet, "jahia:link", "jahia:reference")
@@ -1095,7 +1095,7 @@ class Box:
                         # if link has a title, add it to content as ref
                         url_title = Utils.get_tag_attribute(snippet, "jahia:link", "jahia:title")
                         if url_title and not url_title == "":
-                            description += '<a href="' + url + '">' + Utils.manage_quotes(url_title) + '</a>'
+                            description += '<a href="' + url + '">' + Utils.handle_custom_chars(url_title) + '</a>'
 
             self.content += '[{} url="{}" title="{}" subtitle="{}" image="{}"' \
                             ' big_image="{}" enable_zoom="{}"]{}[/{}]'.format(self.shortcode_name,

--- a/src/utils.py
+++ b/src/utils.py
@@ -475,24 +475,34 @@ class Utils(object):
         return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
 
     @staticmethod
-    def manage_quotes(html, escape=True):
+    def handle_custom_chars(html, escape=True):
         """
-        Manage quotes (simples and double) to avoid BeautifulSoup to transform HTML entities back to "real" characters.
-        When escaped quotes are replaced by custom identifiers that won't be transformed by BeautifulSoup. And when
-        unescaped, quotes are set back to corresponding HTML entities
+        Manage some special characters in shortcode attributes values. We have to do this to avoid BeautifulSoup to
+        transform HTML entities back to "real" characters.
+        When escaped, special characters are replaced by custom identifiers that won't be transformed by BeautifulSoup.
+        And when unescaped, quotes are set back to corresponding HTML entities
 
         :param html: string in which (un)escape
         :param escape: To tells if we have to escape or unescape.
         :return:
         """
 
-        simple_quote = "#apos!"
-        double_quote = "#quot!"
+        # Element to replace: https://www.freeformatter.com/html-entities.html
+        # Tuple format :
+        # <originalChar>, <customHtmlEntity>, <officialHtmlEntity>
+        replace = [('[', '##91!', '&#91;'),
+                   (']', '##93!', '&#93;'),
+                   ("'", '#apos!', '&apos;'),
+                   ('"', '#quot!', '&quot;')]
 
-        if escape:
-            return html.replace('"', double_quote).replace("'", simple_quote)
-        else:
-            return html.replace(double_quote, '&quot;').replace(simple_quote, '&apos;')
+        for original, escape_to, unescape_to in replace:
+
+            if escape:
+                html = html.replace(original, escape_to)
+            else:
+                html = html.replace(escape_to, unescape_to)
+
+        return html
 
     @staticmethod
     def escape_quotes(str):

--- a/src/utils.py
+++ b/src/utils.py
@@ -482,6 +482,9 @@ class Utils(object):
         When escaped, special characters are replaced by custom identifiers that won't be transformed by BeautifulSoup.
         And when unescaped, quotes are set back to corresponding HTML entities
 
+        For now, we only encode simple/double quotes and brackets. If more special characters needs to be added in the
+        future, just do it ;-)
+
         :param html: string in which (un)escape
         :param escape: To tells if we have to escape or unescape.
         :return:


### PR DESCRIPTION
**From issue**: WWP-1815

**High level changes:**

1. Si un attribut de shortcode a, dans sa valeur, un `[` ou un `]`, l'expression régulière qui récupère la liste des valeurs des attributs du shortcode va être perdue et donc il faut faire en sorte que ces caractères sont mis sous forme de htmlentities (https://www.freeformatter.com/html-entities.html) dans la valeur de l'attribut.
Le problème est que lorsque l'on fait un appel à BeautifulSoup, ce dernier remet les "vraies" valeurs au lieu de conserver les htmlentities. Ce problème avait déjà été constaté par le passé pour les simples/doubles quotes et donc la fonction qui s'occupait de gérer ceci a simplement été adaptée afin d'être un peu plus générique.

**Targetted version**: x.x.x
