### PR TITLE
Write guard in Ansible on undump (e.g. when ventilating)

### DIFF
--- a/ansible/playbooks/push-ventilated.yml
+++ b/ansible/playbooks/push-ventilated.yml
@@ -2,7 +2,7 @@
 # their new sites.
 #
 # ../src/ventilation/Makefile automatically creates the Ansible inventory
-# and runs this script; you therefore don't want to run this script
+# and runs this script; you therefore don't want to run this playbook
 # by hand.
 #
 # Expected directory layout in {{ from }}:

--- a/ansible/playbooks/wordpress-main.yml
+++ b/ansible/playbooks/wordpress-main.yml
@@ -8,8 +8,8 @@
     - name: Check Ansible version
       assert:
         that: "ansible_version.full | version_compare('2.6', '>=')"
-        msg: >
-          "You must update Ansible to at least 2.6 to use this playbook."
+        msg: |
+          You must update Ansible to at least 2.6 to use this playbook.
     - name: Ansible pre-configuration
       set_fact:
         ansible_user: www-data

--- a/ansible/roles/wordpress/tasks/undump.yml
+++ b/ansible/roles/wordpress/tasks/undump.yml
@@ -8,6 +8,13 @@
 # All .xml files uder {{ undump_local_dir }} will be undumped into
 # this Wordpress, in no particular order.
 
+- assert:
+    that:
+      - inventory_hostname in wp_destructive
+      - wp_destructive[inventory_hostname] is search("^(data|wipe)")
+    msg: |
+      Please specify a write permission for {{ inventory_hostname }} using the 'wp_destructive' command line parameter. See examples in src/ventilation/Makefile or ansible/roles/wordpress/defaults/main.yml .
+
 - include_vars: jahia2wp-vars.yml  # For jahia2wp_dir, used by dump-vars below
 - include_vars: dump-vars.yml
 

--- a/src/ventilation/Makefile
+++ b/src/ventilation/Makefile
@@ -4,9 +4,11 @@
 #
 #   make clean all push
 #
+#   make push PUSH_EXTRA_VARS='{"wp_destructive":{"ventilation":"data-only"}}'
+#
 #   make push PUSH_EXTRA_VARS='{"wp_destructive":{"vpsi":"wipe"},"wp_unit_id":"VPSI"}'
 #
-# CAVEAT EMPTOR: the latter command *WIPES OUT* the "vpsi" remote site!
+# CAVEAT EMPTOR: the latter command *WIPES OUT* the "vpsi" site!
 
 VENTILATION_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 JAHIA2WP_TOPDIR := $(shell dirname $(shell dirname $(VENTILATION_DIR)))


### PR DESCRIPTION
**From issue**: No issue

**High level changes:**

Make it so that the operator needs to indicate that they know what they are doing via command line.

**Low level changes:**

Add an "assert" with helpful message in the Ansible undump play.

