### PR TITLE
Add google analytics connector as MU plugin

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_google_analytics_hook.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_google_analytics_hook.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Plugin Name: EPFL Google Analytics connector
+ * Plugin URI:
+ * Description: Must-use plugin for the EPFL website.
+ * Version: 1.0
+ * Author: wwp-admin@epfl.ch
+ * */
+
+/* Hook that add the Google Analytics header to all pages
+ *
+ * https://premium.wpmudev.org/blog/create-google-analytics-plugin/
+ */
+
+function google_analytics_connector_render() {
+?>
+
+<!-- Global Site Tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-20398423-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag("js", new Date());
+    gtag("config", "UA-4833294-1", { "anonymize_ip": true });
+</script>
+
+<?php
+}
+add_action('wp_head', 'google_analytics_connector_render', 10);
+?>

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -414,6 +414,7 @@ class WPGenerator:
         WPMuPluginConfig(self.wp_site, "epfl-functions.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_custom_editor_menu.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_jahia_redirect.php").install()
+        WPMuPluginConfig(self.wp_site, "EPFL_google_analytics_hook.php").install()
 
         if self.wp_config.installs_locked:
             WPMuPluginConfig(self.wp_site, "EPFL_installs_locked.php").install()


### PR DESCRIPTION
High level changes:

Ajoute le connecteur vers Google Analytics pour chaque page. Toutes les pages auront le même identifiants Google ID.

Nouvelle PR à partir de https://github.com/epfl-idevelop/jahia2wp/pull/648, car changement de parent