### PR TITLE
Add 'id' to h3 title

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from xml.dom import minidom
 from parser.box_sorted_group import BoxSortedGroup
 from bs4 import BeautifulSoup
+from django.utils.text import slugify
 
 from utils import Utils
 
@@ -198,6 +199,8 @@ class Box:
             self.set_box_unknown(element)
 
         self.fix_video_iframes()
+
+        self.add_id_to_h3()
 
         self.fix_img_align_left()
 
@@ -1326,6 +1329,25 @@ class Box:
                 shortcode = '[epfl_video url="{}"]'.format(src)
                 # Replacing the iframe with shortcode text
                 iframe.replaceWith(shortcode)
+
+        self.content = str(soup.body)
+
+    def add_id_to_h3(self):
+        """
+        Take title of <h3> elements, slugify it and add it as "id" attribute
+        :return:
+        """
+
+        soup = BeautifulSoup(self.content, 'html5lib')
+        soup.body.hidden = True
+
+        h3s = soup.find_all('<h3>')
+
+        for h3 in h3s:
+
+            if h3.text != "" and h3.get('id') is None:
+                slug = slugify(h3.text)
+                h3['id'] = slug
 
         self.content = str(soup.body)
 


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Ajout du nécessaire pour avoir le même comportement que Jahia, à savoir ajouter un attribut `id` aux éléments `h3` en reprenant le texte de ceux-ci et en le "slugifiant". Jahia fait ceci à la volée lors de l'affichage de la page et nous, on le fait lors du parsing, ce n'est pas la même chose mais au moins, ça fait fonctionner directement un site migrer dans le cas où des liens avec anchors (`#mylink`) seraient utilisés.


**Targetted version**: x.x.x
