### PR TITLE
/!\ TO_MIGRATE : Fix backup strategy

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -37,7 +37,9 @@ Usage:
     [--output-dir=<OUTPUT_DIR> --admin-password=<PASSWORD>] [--use-cache]
     [--keep-extracted-files]
   jahia2wp.py backup-many           <csv_file>                      [--debug | --quiet]
+  jahia2wp.py backup-inventory      <path>                          [--debug | --quiet]
   jahia2wp.py rotate-backup         <csv_file>          [--dry-run] [--debug | --quiet]
+  jahia2wp.py rotate-backup-inventory   <path>          [--dry-run] [--debug | --quiet]
   jahia2wp.py veritas               <csv_file>                      [--debug | --quiet]
   jahia2wp.py fan-global-sitemap    <csv_file> <wp_path>            [--debug | --quiet]
   jahia2wp.py inventory             <path>                          [--debug | --quiet]
@@ -859,6 +861,50 @@ def backup_many(csv_file, **kwargs):
             row["wp_site_url"]
         ).backup()
 
+@dispatch.on('backup-inventory')
+def backup_inventory(path, **kwargs):
+
+    logging.info("Backup from inventory...")
+
+    for site_details in WPConfig.inventory(path):
+
+        if site_details.valid == settings.WP_SITE_INSTALL_OK:
+            logging.info("Running backup for %s", site_details.url)
+
+            WPBackup(
+                WPSite.openshift_env_from_path(site_details.path),
+                site_details.url
+            ).backup()
+
+    logging.info("All backups done for path: %s", path)
+
+
+@dispatch.on('rotate-backup-inventory')
+def rotate_backup_inventory(path, dry_run=False, **kwargs):
+
+    for site_details in WPConfig.inventory(path):
+
+        if site_details.valid == settings.WP_SITE_INSTALL_OK:
+
+            path = WPBackup(
+                WPSite.openshift_env_from_path(site_details.path),
+                site_details.url
+            ).path
+
+            # rotate full backups first
+            for pattern in ["*full.sql", "*full.tar"]:
+                RotateBackups(
+                    FULL_BACKUP_RETENTION_THEME,
+                    dry_run=dry_run,
+                    include_list=[pattern]
+                ).rotate_backups(path)
+            # rotate incremental backups
+            for pattern in ["*.list", "*inc.sql", "*inc.tar"]:
+                RotateBackups(
+                    INCREMENTAL_BACKUP_RETENTION_THEME,
+                    dry_run=dry_run,
+                    include_list=[pattern]
+                ).rotate_backups(path)
 
 @dispatch.on('rotate-backup')
 def rotate_backup(csv_file, dry_run=False, **kwargs):

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -861,6 +861,7 @@ def backup_many(csv_file, **kwargs):
             row["wp_site_url"]
         ).backup()
 
+
 @dispatch.on('backup-inventory')
 def backup_inventory(path, **kwargs):
 
@@ -905,6 +906,7 @@ def rotate_backup_inventory(path, dry_run=False, **kwargs):
                     dry_run=dry_run,
                     include_list=[pattern]
                 ).rotate_backups(path)
+
 
 @dispatch.on('rotate-backup')
 def rotate_backup(csv_file, dry_run=False, **kwargs):

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -89,7 +89,7 @@ class WPBackup:
         # build regex for filenames with found dates
         matches = "|".join([valid_date.strftime("%Y%m%d")
                             for valid_date in valid_dates])
-        file_regex = re.compile("({})\d+.list".format(matches))
+        file_regex = re.compile("\d+.list".format(matches))
 
         # list directory, filtering out files with appropriate dates
         logging.debug("%s - Seeking backups with regex: %s", repr(self.wp_site), file_regex)

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -64,7 +64,7 @@ class WPBackup:
             self.backup_pattern = self.FULL_PATTERN
             self.listfile = os.path.join(
                 self.path,
-                "_".join((self.timestamp)) + ".list")
+                self.timestamp + ".list")
         else:
             self.backup_pattern = self.INCREMENTAL_PATTERN
             self.listfile = os.path.join(self.path, listfile)

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -89,7 +89,7 @@ class WPBackup:
         # build regex for filenames with found dates
         matches = "|".join([valid_date.strftime("%Y%m%d")
                             for valid_date in valid_dates])
-        file_regex = re.compile("{}\d+.list".format(matches))
+        file_regex = re.compile("({})\d+.list".format(matches))
 
         # list directory, filtering out files with appropriate dates
         logging.debug("%s - Seeking backups with regex: %s", repr(self.wp_site), file_regex)

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -57,15 +57,14 @@ class WPBackup:
         # set backup attributes
         self.datetime = datetime.datetime.now()
         self.timestamp = self.datetime.strftime(self.TIMESTAMP_FORMAT)
-        self.path = os.path.join(self.BACKUP_PATH, self.wp_site.name)
-
+        self.path = os.path.join(self.BACKUP_PATH, self.wp_site.path.replace('/', '_'))
         # set backup type, and name for list file
         listfile = self.get_daily_list()
         if listfile is None or full:
             self.backup_pattern = self.FULL_PATTERN
             self.listfile = os.path.join(
                 self.path,
-                "_".join((self.wp_site.name, self.timestamp)) + ".list")
+                "_".join((self.timestamp)) + ".list")
         else:
             self.backup_pattern = self.INCREMENTAL_PATTERN
             self.listfile = os.path.join(self.path, listfile)
@@ -73,10 +72,10 @@ class WPBackup:
         # set filenames
         self.tarfile = os.path.join(
                 self.path,
-                "_".join((self.wp_site.name, self.timestamp, self.backup_pattern)) + ".tar")
+                "_".join((self.timestamp, self.backup_pattern)) + ".tar")
         self.sqlfile = os.path.join(
                 self.path,
-                "_".join((self.wp_site.name, self.timestamp, self.backup_pattern)) + ".sql")
+                "_".join((self.timestamp, self.backup_pattern)) + ".sql")
 
     def get_daily_list(self):
         # shortcut if directory does not exist yet

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -89,7 +89,7 @@ class WPBackup:
         # build regex for filenames with found dates
         matches = "|".join([valid_date.strftime("%Y%m%d")
                             for valid_date in valid_dates])
-        file_regex = re.compile("\d+.list".format(matches))
+        file_regex = re.compile("{}\d+.list".format(matches))
 
         # list directory, filtering out files with appropriate dates
         logging.debug("%s - Seeking backups with regex: %s", repr(self.wp_site), file_regex)

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -22,13 +22,13 @@ class WPBackup:
     - inc : Incremental backup (for files only, not the DB), when full backup found (in NB_DAYS_BEFORE_NEW_FULL)
 
     A full backup generates 3 files :
-    - "<wp_site_name>_<timestamp>.list": reference for incremental backup
-    - "<wp_site_name>_<timestamp>_full.tar": to save of files
-    - "<wp_site_name>_<timestamp>_full.sql": the db dump
+    - "<BACKUP_PATH>/<wp_site.path>/<timestamp>.list": reference for incremental backup
+    - "<BACKUP_PATH>/<wp_site.path>/<timestamp>_full.tar": to save of files
+    - "<BACKUP_PATH>/<wp_site.path>/<timestamp>_full.sql": the db dump
 
     A incremental backup generates 2 files :
-    - "<wp_site_name>_<timestamp>_inc.tar": to save files
-    - "<wp_site_name>_<timestamp>_inc.sql": the db dump
+    - "<BACKUP_PATH>/<wp_site.path>/<timestamp>_inc.tar": to save files
+    - "<BACKUP_PATH>/<wp_site.path>/<timestamp>_inc.sql": the db dump
     """
 
     FULL_PATTERN = "full"

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -90,15 +90,25 @@ class WPSite:
         # returns last folder if site as a folder defined
         return self.folder.split('/')[-1]
 
+    @staticmethod
+    def openshift_env_from_path(path):
+        """
+        Extract OpenShift environment from given path
+
+        :param path:
+        :return:
+        """
+        # extract openshift env
+        env_match = re.match("/srv/([^/]+)", path)
+        if env_match is None or not env_match.groups():
+            raise ValueError("given path '{}' should be included in a valid openshift_env".format(path))
+        return env_match.groups()[0]
+
     @classmethod
     def from_path(cls, path):
         given_path = os.path.abspath(path).rstrip('/')
 
-        # extract openshift env
-        env_match = re.match("/srv/([^/]+)", given_path)
-        if env_match is None or not env_match.groups():
-            raise ValueError("given path '{}' should be included in a valid openshift_env".format(given_path))
-        openshift_env = env_match.groups()[0]
+        openshift_env = WPSite.openshift_env_from_path(given_path)
 
         # validate given path
         if not os.path.isdir(given_path):


### PR DESCRIPTION
Attention, cette PR est un fix pour release et release2018. De plus, il y a peut-être une opération de migration (par renommage ou par recréation) à effectuer sur les backup existants, sous peine de refaire les backups incrémentaux en full. Edit : nous avons décidé de ne pousser que dans release pour l'instant, et que nous n'effectuerons pas d'opération de migration.

Actuellement, les noms des backups n'ont pas leur provenance. Ce qui créé un clash de nom quand on sauve depuis wp-migration et depuis la prod.

Cette PR tente de corriger ceci en insérant dans le nom le path complet.

Exemple de nom de backup avant PR:
`/backups/{mon_site}/{mon_site}_20181011153126_full.sql`
Avec cette PR:
`/backups/_srv_{wp_env}_jahia2wp-httpd_htdocs_{mon_site}/20181011153303_full.sql`

**LuluTchab**

_High level changes:_
1. Ajout de 2 commandes dans `jahia2wp.py` :
- backup-inventory
- rotate-backup-inventory
Les 2 commandes utilisent la fonctionnalité d'inventaire pour effectuer le backup des sites (ainsi que leur rotation). ça signifie qu'on a donc un backup de tout ce qui est existant.
J'ai laissé les commandes `backup-many` et `rotate-backup` afin que ça puisse continuer à fonctionner "comme avant".

_Low level changes:_

1. Création d'une méthode static dans `WPSite` (déplacement de code) pour pouvoir récupérer l'environnement OpenShift depuis un path donné.

**Mise en production de la partie "inventory"**
Afin de pouvoir mettre en production correctement les backups depuis l'inventaire, il faudra modifier le cron job qui s'occupe de lancer actuellement le backup.
Plusieures entrées pourront être créées, une par environnement ("subdomains", "www2018", ...). 
Pour ce qui est du backup des "unmanaged", comme ils sont tous directement sous `/srv/`, ça impliquerait de parcourir énormément de dossiers avec l'inventaire pour pouvoir trouver les sites. Donc, après discussion, la source de vérité va continuer à être utilisée pour le backup des sites "unmanaged".