### PR TITLE
Convert epfl_card old to epfl_card new

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -950,7 +950,7 @@ def shortcode_list(path, out_csv=None, **kwargs):
 
 
 @dispatch.on('shortcode-fix')
-def shortcode_fix(wp_env, wp_url, shortcode_name, **kwargs):
+def shortcode_fix(wp_env, wp_url, shortcode_name=None, **kwargs):
 
     shortcodes = Shortcodes()
 

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -44,7 +44,7 @@ Usage:
   jahia2wp.py shortcode-list        <path> [--out-csv=<out_csv>]    [--debug | --quiet]
   jahia2wp.py shortcode-details     <path> <shortcode>              [--debug | --quiet]
     [--out-csv=<out_csv>]
-  jahia2wp.py shortcode-fix         <wp_env> <wp_url>               [--debug | --quiet]
+  jahia2wp.py shortcode-fix         <wp_env> <wp_url> [<shortcode_name>] [--debug | --quiet]
   jahia2wp.py shortcode-fix-many    <csv_file>                      [--debug | --quiet]
   jahia2wp.py extract-plugin-config <wp_env> <wp_url> <output_file> [--debug | --quiet]
   jahia2wp.py list-plugins          <wp_env> <wp_url>               [--debug | --quiet]
@@ -950,11 +950,11 @@ def shortcode_list(path, out_csv=None, **kwargs):
 
 
 @dispatch.on('shortcode-fix')
-def shortcode_fix(wp_env, wp_url, **kwargs):
+def shortcode_fix(wp_env, wp_url, shortcode_name, **kwargs):
 
     shortcodes = Shortcodes()
 
-    report = shortcodes.fix_site(wp_env, wp_url)
+    report = shortcodes.fix_site(wp_env, wp_url, shortcode_name)
 
     logging.info("Fix report:\n%s", str(report))
 

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -939,7 +939,7 @@ class Shortcodes():
         content = self.__rename_shortcode(content, old_shortcode, new_shortcode)
         return content
 
-    def _fix_epfl_card_2018(self, content):
+    def _fix_epfl_card_new_version(self, content):
         """
         Fix "epfl_card" shortcode
 
@@ -1015,8 +1015,8 @@ class Shortcodes():
 
                     fix_func_name = "_fix_{}".format(shortcode.replace("-", "_"))
 
-                    if shortcode_name is not None and shortcode_name.endswith("_2018"):
-                        fix_func_name += "_2018"
+                    if shortcode_name is not None and shortcode_name.endswith("_new_version"):
+                        fix_func_name += "_new_version"
 
                     try:
                         # Trying to get function to fix current shortcode

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -187,7 +187,6 @@ class Shortcodes():
         """
         Remove a shortcode attribute
 
-        FIX: this method has a bug when parameter value contains parameter name
         example: [epfl_card title="toto title" link="toto link" image="29"]toto text[/epfl_card]
 
         :param content: string in which doing replacement
@@ -199,6 +198,7 @@ class Shortcodes():
         # Transforms the following:
         # [my_shortcode attr_name="a" two="b"]  --> [my_shortcode two="b"]
         # [my_shortcode attr_name two="b"]      --> [my_shortcode two="b"]
+        # FIXME: there is a bug when parameter value contains parameter name
         matching_reg = re.compile('(?P<before> \[{}.+ ){}(=(".*?"|\S+?)|\s|\])?'.format(shortcode_name, attr_name),
                                   re.VERBOSE)
 
@@ -769,26 +769,20 @@ class Shortcodes():
         for call in calls:
 
             box_content = self.__get_content(call)
-            new_call = call
+            title = self.__get_attribute(call, 'title')
+            link = self.__get_attribute(call, 'link')
+            image = self.__get_attribute(call, 'image')
 
-            # Delete unused attributes
-            new_call = self.__remove_attribute(new_call, old_shortcode, 'subtitle')
-            new_call = self.__remove_attribute(new_call, old_shortcode, 'big_image')
-            new_call = self.__remove_attribute(new_call, old_shortcode, 'enable_zoom')
-
-            new_call = self.__rename_shortcode(new_call, old_shortcode, new_shortcode)
-
-            # Content
-            new_call = self.__add_attribute(new_call, new_shortcode, "content1", attr_value=box_content)
-            new_call = self.__change_content(new_call, new_content="").replace("][/epfl_card]", " /]")
+            new_call = '[{0} content1="{1}" title1="{2}" link1="{3}" image1="{4}" /]'.format(
+                new_shortcode,
+                box_content,
+                title,
+                link,
+                image
+            )
 
             # Replacing in global content
             content = content.replace(call, new_call)
-
-        # Rename attributes
-        content = self.__rename_attribute(content, new_shortcode, "title", "title1")
-        content = self.__rename_attribute(content, new_shortcode, "url", "link1")
-        content = self.__rename_attribute(content, new_shortcode, "image", "image1")
 
         return content
 
@@ -941,9 +935,14 @@ class Shortcodes():
 
     def _fix_epfl_card_new_version(self, content):
         """
-        Fix "epfl_card" shortcode
+        Fix "epfl_card" shortcode in the new version.
 
-        Note: This method name is suffix by '_new_version' to prevent its use during shortcodes migration
+        The epfl_card shortcode has changed. By calling this method, you can modify the parameters of epfl_card.
+
+        To call this method:
+        python jahia2wp shortcode-fix <wp_env> <wp_url> epfl_card_new_version
+
+        Note: This method name is suffix by '_new_version' to prevent its automatic use.
 
         example:
         input: [epfl_card title="toto titre" link="toto lien" image="29"]toto text[/epfl_card]
@@ -956,15 +955,19 @@ class Shortcodes():
         for call in calls:
 
             box_content = self.__get_content(call)
+            title = self.__get_attribute(call, 'title')
+            link = self.__get_attribute(call, 'link')
+            image = self.__get_attribute(call, 'image')
 
-            new_call = self.__add_attribute(call, shortcode_name, "content1", attr_value=box_content)
-            new_call = self.__change_content(new_call, new_content="").replace("][/epfl_card]",  " /]")
+            new_call = '[{0} content1="{1}" title1="{2}" link1="{3}" image1="{4}" /]'.format(
+                shortcode_name,
+                box_content,
+                title,
+                link,
+                image
+            )
 
             content = content.replace(call, new_call)
-
-        content = self.__rename_attribute(content, shortcode_name, "title", "title1")
-        content = self.__rename_attribute(content, shortcode_name, "link", "link1")
-        content = self.__rename_attribute(content, shortcode_name, "image", "image1")
 
         return content
 

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -1,4 +1,5 @@
 """(c) All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2018"""
+from urllib.parse import quote_plus
 
 import settings
 import logging
@@ -768,9 +769,11 @@ class Shortcodes():
 
         for call in calls:
 
-            box_content = self.__get_content(call)
+            # urlencode content
+            box_content = quote_plus(self.__get_content(call))
+
             title = self.__get_attribute(call, 'title')
-            link = self.__get_attribute(call, 'link')
+            link = self.__get_attribute(call, 'url')
             image = self.__get_attribute(call, 'image')
 
             new_call = '[{0} content1="{1}" title1="{2}" link1="{3}" image1="{4}" /]'.format(
@@ -954,7 +957,9 @@ class Shortcodes():
 
         for call in calls:
 
-            box_content = self.__get_content(call)
+            # urlencode content
+            box_content = quote_plus(self.__get_content(call))
+
             title = self.__get_attribute(call, 'title')
             link = self.__get_attribute(call, 'link')
             image = self.__get_attribute(call, 'image')

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -943,7 +943,7 @@ class Shortcodes():
         """
         Fix "epfl_card" shortcode
 
-        Note: This method name is suffix by '_2018' to prevent its use during shortcodes migration
+        Note: This method name is suffix by '_new_version' to prevent its use during shortcodes migration
 
         example:
         input: [epfl_card title="toto titre" link="toto lien" image="29"]toto text[/epfl_card]

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -186,7 +186,7 @@ class Shortcodes():
     def __remove_attribute(self, content, shortcode_name, attr_name):
         """
         Remove a shortcode attribute
-        
+
         FIX: this method has a bug when parameter value contains parameter name
         example: [epfl_card title="toto title" link="toto link" image="29"]toto text[/epfl_card]
 
@@ -942,7 +942,7 @@ class Shortcodes():
     def _fix_epfl_card_2018(self, content):
         """
         Fix "epfl_card" shortcode
-        
+
         Note: This method name is suffix by '_2018' to prevent its use during shortcodes migration
 
         example:

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -768,6 +768,7 @@ class Shortcodes():
 
         for call in calls:
 
+            box_content = self.__get_content(call)
             new_call = call
 
             # Delete unused attributes
@@ -776,6 +777,10 @@ class Shortcodes():
             new_call = self.__remove_attribute(new_call, old_shortcode, 'enable_zoom')
 
             new_call = self.__rename_shortcode(new_call, old_shortcode, new_shortcode)
+
+            # Content
+            new_call = self.__add_attribute(new_call, new_shortcode, "content1", attr_value=box_content)
+            new_call = self.__change_content(new_call, new_content="").replace("][/epfl_card]", " /]")
 
             # Replacing in global content
             content = content.replace(call, new_call)
@@ -1010,7 +1015,7 @@ class Shortcodes():
 
                     fix_func_name = "_fix_{}".format(shortcode.replace("-", "_"))
 
-                    if shortcode_name.endswith("_2018"):
+                    if shortcode_name is not None and shortcode_name.endswith("_2018"):
                         fix_func_name += "_2018"
 
                     try:

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -926,6 +926,45 @@ class Shortcodes():
         content = self.__rename_shortcode(content, old_shortcode, new_shortcode)
         return content
 
+    def _fix_epfl_card(self, content):
+        """
+        Fix "epfl_card" shortcode
+        
+        example:
+        input: [epfl_card title="toto titre" link="toto lien" image="29"]toto text[/epfl_card]
+        output [epfl_card title1="toto titre" link1="toto lien" image1="29" content1="%3Cp%3Etoto%20text%3C%2Fp%3E" /]
+        
+        :param 
+        :return: 
+        """
+        shortcode_name = "epfl_card"
+
+        # title1
+        title1_value = self.__get_attribute(content, "title")
+        content = self.__add_attribute(content, shortcode_name, "title1", attr_value=title1_value)
+        content = self.__remove_attribute(content, shortcode_name, "title")
+
+        # link1
+
+        # FIX: le remove_attribut merdouille si on met link à l'intérieur de la valeur de link=""
+        # [epfl_card title="toto titre" link="toto link" image="29"]toto text[/epfl_card]
+        link1_value = self.__get_attribute(content, "link")
+        content = self.__add_attribute(content, shortcode_name, "link1", attr_value=link1_value)
+        content = self.__remove_attribute(content, shortcode_name, "link")
+
+        #image1
+        image1_value = self.__get_attribute(content, "image")
+        content = self.__add_attribute(content, shortcode_name, "image1", attr_value=image1_value)
+        content = self.__remove_attribute(content, shortcode_name, "image")
+
+        # FIX: comment ça peut marcher sans préciser le nom du shortcode ? ou si plusieurs shortcodes avec content ?
+        content1_value = self.__get_content(content)
+        content = self.__add_attribute(content, shortcode_name, "content1", attr_value=content1_value)
+        content = self.__change_content(content, new_content="").replace("][/epfl_card]",  " /]")
+
+        return content
+
+
     def fix_site(self, openshift_env, wp_site_url):
         """
         Fix shortocdes in WP site


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Migration de epfl_card dans sa nouvelle version. 
Pour cela le nom de la méthode est  'fix_epfl_card_new_version' permettant de distinguer les shortcodes à migrer de 2010 à 2018 (sans sufffixe '_new_version') et ceux à passer dans la nouvelle version (avec sufixe '_new_version'). 

1. Mise à jour de la migration de su_box et epfl_snippets qui migre vers epfl_card

**Low level changes:**

1. Ajout d'un paramètre optionnel <shortcode_name> pour ne migrer qu'un shortcode qui aurait connu une nouvelle version nécessitant une mise à jour des appels



**Targetted version**: x.x.x
