### PR TITLE
2018 Theme - Remove <div class='textBox'> but keep content

### DIFF
--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -8,6 +8,7 @@ import re
 import os
 from wordpress import WPConfig, WPSite
 from utils import Utils
+from bs4 import BeautifulSoup
 
 
 class Shortcodes():
@@ -1016,6 +1017,7 @@ class Shortcodes():
                                            "--field=post_content".format(post_id))
             original_content = content
 
+            # Step 1 - Fixing shortcodes
             # Looking for all shortcodes in current post
             for shortcode in list(set(re.findall(self.regex, content))):
 
@@ -1044,6 +1046,17 @@ class Shortcodes():
                         report[shortcode] += 1
 
                     content = fixed_content
+
+            # Step 2: Removing <div class="textbox"> to avoid display issues on 2018 theme
+            soup = BeautifulSoup(content, 'html5lib')
+            soup.body.hidden = True
+
+            # Looking for all DIVs with "textBox" as class
+            for div in soup.find_all('div', {'class': 'textBox'}):
+                # Remove DIV but keep its content
+                div.unwrap()
+
+            content = str(soup.body)
 
             # If content changed for current page,
             if content != original_content:


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Afin de corriger le problème de DOM qui fait que les vidéos ne peuvent pas prendre la totalité de la largeur, Antistatique avait conseillé ceci : https://github.com/epfl-idevelop/elements/issues/319
Cependant, leur truc fait que la totalité des enfants sous "big-children" prennent 100% de la largeur (selon mes tests du moins) et ce n'est pas ce qu'on veut... d'autres tests ont amené à voir que si on supprimait les `<div class="textBox">` tout en gardant leur contenu, cela réglait le problème. Du code pour faire ce nettoyage a donc été ajouté dans le code qui "fixe" les shortcodes pour passer de 2010 à 2018.


**Targetted version**: x.x.x
