### PR TITLE
Menu fixup #2: AJAX mini-app for the refresh button

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/model.php
+++ b/data/wp/wp-content/plugins/epfl/lib/model.php
@@ -32,6 +32,8 @@ class ModelException extends \Exception {
     }
 }
 
+class UnicityException extends ModelException {}
+
 
 /**
  * Abstract base class for model objects based on the WPDB API.
@@ -554,6 +556,14 @@ class _WPQueryBuilder
         unset($this->query);           // ->wp_query is a one-shot pistol
         $this->_saved_query = $query;  // For ->moniker()'s use only
 
+        // Using Polylang's auto-filter-by-language feature in
+        // something called model.php, that focuses on primary keys,
+        // is a bad idea all around (e.g. think what happens when you
+        // disable the Polylang plugin?). But if caller insists we
+        // let them.
+        if (! array_key_exists('lang', $query)) {
+            $query['lang'] = '';
+        }
         return new WP_Query($query);
     }
 

--- a/data/wp/wp-content/plugins/epfl/lib/model.php
+++ b/data/wp/wp-content/plugins/epfl/lib/model.php
@@ -548,12 +548,13 @@ class _WPQueryBuilder
     function wp_query ()
     {
         if (! $this->query) {
-            throw new Exception("Can only call one of ->wp_query, ->result or ->results");
+            throw new Exception("->wp_query, ->result or ->results together may only be called once per _WPQueryBuilder object");
         }
-        $retval = new WP_Query($this->query);
-        $this->_saved_query = $this->query;
-        unset($this->query);
-        return $retval;
+        $query = $this->query;
+        unset($this->query);           // ->wp_query is a one-shot pistol
+        $this->_saved_query = $query;  // For ->moniker()'s use only
+
+        return new WP_Query($query);
     }
 
     function result ()

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.css
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.css
@@ -2,12 +2,53 @@
         background-color: yellow;
 }
 
-.ajax-spinner {
+.ajax-pending, .ajax-resolved, .ajax-rejected, .ajax-timeout {
     display: inline-block;
     height: 16px;
     width: 16px;
     margin-left: 0.3em;
+}
+
+.ajax-pending {
     background-image: url(../../../../wp-admin/images/loading.gif);
     background-repeat: no-repeat;
     background-position: right center;
+}
+
+.ajax-resolved::after {
+    color: green;
+    content: "✓";
+}
+
+.ajax-rejected::after {
+    color: red;
+    content: "⚠";
+}
+
+.ajax-timeout::after {
+    content: "🕒";
+}
+
+button p.tooltip-error {
+    color: red;
+    display: block;
+    visibility: hidden;
+
+    position: absolute;
+    right: -130%;
+    top: 0px;
+
+    border: 1px solid black;
+    border-radius: 6px;
+    padding: 0px 10px;
+    background-color: #f1f1f1;
+}
+
+button p.tooltip-error::before {
+    color: black;
+    content: "💡 ";
+}
+
+button:hover p.tooltip-error {
+    visibility: visible;
 }

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
@@ -13,15 +13,136 @@ function initExternalMenuList ($) {
     $('a.page-title-action').remove();
     $('h1.wp-heading-inline').after('<button class="page-title-action">' + wp.translations.refresh_button + '</button>');
     var $button = $('h1.wp-heading-inline').next();
-    var spinning = false;
+
     $button.click(function() {
-        if (spinning) return;
-        var $form = window.EPFLMenus.asWPAdminPostForm('refresh');
-        $form.submit();
-        var $spinner = $('<span class="ajax-spinner"></span>');
-        $button.append($spinner);
-        spinning = true;
+        onRefreshButton($, $button);
     });
+}
+
+function onRefreshButton ($, $button) {
+    if ($button.spinner) {
+        if ($button.spinner.isActive()) {
+            return;
+        } else {
+            $button.spinner.$spinner.remove();
+        }
+    }
+    $('p', $button).remove();  // Previous error messages (if any), see below
+    $button.spinner = new Spinner($);
+    $button.append($button.spinner.$spinner);
+
+    window.EPFLMenus.post('enumerate')
+        .then(function(response) {
+            var ids = response.external_menu_item_ids;
+            if (ids) {
+                return updateRowsDeferred($, ids);
+            } else {
+                console.log('AJAX ERROR:', response);
+                throw new Error(response.status);
+            }
+        })
+        .then(function() {$button.spinner.progress.resolve(); },
+              function(err) {
+                  $button.spinner.progress.reject();
+                  if (err.status === 504) {
+                      $button.spinner.$spinner.removeClass().addClass('ajax-timeout');
+                      $button.append('<p class="tooltip-error">Timeout in the server</p>');
+                  } else {
+                      $button.append('<p class="tooltip-error">Server-side error</p>');
+                  }
+              });
+}
+
+/**
+ * @param $ the jQuery framework object
+ * @param ids An array of IDs returned by the 'enumerate' AJAX call,
+ *            which may differ from what is visible on-screen (e.g.
+ *            new child site just popped up, or there are more
+ *            ExternalMenuItem's than the pagination limit)
+ */
+function updateRowsDeferred ($, ids) {
+    var d = $.Deferred();
+    var todoCount = ids.length;
+    var hasInvisibleChanges = false;
+
+    // Here, we could update the tr's in tbody#the-list to match ids,
+    // perhaps with some kind of CSS animation for
+    // appearing/disappearing rows.
+
+    for (var i = 0 ; i < ids.length; i++) {
+        var id = ids[i], $tr = $('tr#post-' + id);
+        if (! $tr.length) {
+            hasInvisibleChanges = true;
+        }
+
+        // Start all the updates in parallel at once, and let the
+        // browser's outstanding XMLHTTPRrequest limit do the
+        // throttling
+        updateOneRowDeferred($, id, $tr).always(function() {
+            if (--todoCount) return;
+
+            if (! hasInvisibleChanges) {
+                // Put a check mark in the top-most Refresh button,
+                // and allow user to click it again
+                d.resolve();
+            } else {
+                // Some rows were created/deleted (or pagination is in
+                // play), and the display might currently be
+                // incomplete or misleading. Rather than patching up
+                // the DOM (which we could, see comment above), just
+                // reload the page. This is a rare case; in
+                // steady-state, the reload button doesn't create or
+                // delete any ExternalMenuItem.
+                location.reload();
+            }
+        });
+    }
+    return d;
+}
+
+function updateOneRowDeferred ($, id, $tr) {
+    if ($tr.spinner) { $tr.spinner.$spinner.remove(); }
+    var spinner = $tr.spinner = new Spinner($);
+    $('td.column-date', $tr).empty().append(spinner.$spinner);
+
+    var allRowClasses = 'sync-inprogress sync-success sync-failed';
+    $tr.removeClass(allRowClasses).addClass('sync-inprogress');
+    spinner.progress.then(
+        function() { $tr.removeClass(allRowClasses).addClass('sync-success'); },
+        function() { $tr.removeClass(allRowClasses).addClass('sync-failed'); });
+
+    window.EPFLMenus.post('refresh_by_id', {data: {id: id}})
+        .then(
+            function (response) {
+                if (response.status !== 'OK') {
+                    spinner.progress.reject();
+                } else {
+                    spinner.progress.resolve();
+                }
+            },
+            function (error) {
+                console.log('POST refresh_by_id for ' + id + ': ', error);
+                spinner.progress.reject();
+            });
+    return spinner.progress;
+}
+
+/**
+ * @constructor
+ */
+function Spinner ($) {
+    var $spinner = this.$spinner = $('<span></span>');
+    var progress = this.progress = $.Deferred();
+
+    function updateSpinner () {
+        $spinner.removeClass().addClass('ajax-' + progress.state());
+    }
+    updateSpinner();
+    progress.always(updateSpinner);
+}
+
+Spinner.prototype.isActive = function() {
+    return this.progress.state() === 'pending';
 }
 
 jQuery(document).ready(function($) {

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1494,8 +1494,22 @@ class MenuItemController extends CustomPostTypeController
         $yellow = 'rgba(248, 247, 202, 0.45)';
         $stripesize = '20px'; $stripesize2x = '40px';
         static::add_editor_css("
-.wp-list-table tr.sync-failed {
+.wp-list-table tr.sync-failed, .wp-list-table tr.sync-inprogress {
   background-image: repeating-linear-gradient(-45deg,$yellow,$yellow $stripesize,transparent $stripesize,transparent $stripesize2x);
+}
+
+.wp-list-table tr.sync-inprogress {
+  animation: wp-epfl-sync-barber .5s linear infinite;
+}
+
+@keyframes wp-epfl-sync-barber {
+  from {
+    background-position-x: 0px;
+  }
+
+  to {
+    background-position-x: 57px;
+  }
 }
 ");
     }

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1070,7 +1070,6 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
                 $title = $menu_descr->description . "[$lang] @ $site_url_dir";
                 $that->update(array('post_title' => $title));
 
-                $that->try_refresh();
                 $instances[] = $that;
             }
         }
@@ -1098,24 +1097,17 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
             $menu_contents->get_link('subscribe'));
     }
 
-    function try_refresh () {
-        if ($this->_refreshed !== NULL) {
-            // Do not attempt twice in same query cycle
-            return $this->_refreshed;
-        }
+    function refresh () {
         try {
             $this->_do_refresh();
-            $this->_refreshed = true;
             $this->meta()->set_last_synced(time());
             $this->meta()->del_sync_started_failing();
-            return true;
         } catch (RESTClientError $e) {
             $this->error_log("unable to refresh: $e");
             if (! $this->meta()->get_sync_started_failing()) {
                 $this->meta()->set_sync_started_failing(time());
             }
-            $this->_refreshed = false;
-            return false;
+            throw $e;
         }
     }
 
@@ -1404,56 +1396,53 @@ class MenuItemController extends CustomPostTypeController
     }
 
     /**
-     * Invoked through form POST by the wp-admin refresh button
+     * Invoked first by the wp-admin refresh button
      */
-    static function admin_post_refresh () {
-        $emis = array();
+    static function ajax_enumerate () {
+        $transient_name = 'epfl-menus-all-external-item-ids';
+        if (false !== ($cached = get_transient($transient_name))) {
+            return $cached;
+        }
+
+        // The Varnish-side limit is 30 seconds, however the
+        // client-side AJAX app is prepared to deal with 504's
+        set_time_limit(120);
+
+        ExternalMenuItem::load_from_filesystem();
+        $value = array(
+            'status' => 'OK',
+            'external_menu_item_ids' => array_map(function($emi) {
+                return (int) $emi->ID;
+            }, ExternalMenuItem::all()));
+        set_transient($transient_name, $value, 300);
+        return $value;
+    }
+
+    /**
+     * Invoked by the wp-admin refresh button once for each
+     * ExternalMenuItemID that @link ajax_refresh_local previously
+     * returned
+     */
+    static function ajax_refresh_by_id ($data) {
+        if (! ($emi = ExternalMenuItem::get($data['id']))) {
+            error_log('Unknown ID or malformed ajax_refresh_by_id: ' . var_export($data, true));
+            return array(
+                'status' => 'ERROR',
+                'message' => "$data->id not found"
+            );
+        }
         try {
-            $emis = ExternalMenuItem::load_from_filesystem();
-        } catch (\Throwable $t) {
-            error_log("ExternalMenuItem::load_from_filesystem(): $t");
-            static::admin_error(___('Unable to load menus of sites in the same pod'));
-            // Continue
+            $emi->refresh();
+            return array(
+                'status' => 'OK'
+            );
+        } catch (RESTClientError $e) {
+            return array(
+                'status' => 'ERROR',
+                'exception' => get_class($e),
+                'message' => sprintf(___('Sync failed: %s', $e))
+            );
         }
-
-        $errors = 0;
-        foreach (array_merge($emis,
-                             // Optimization: keep the
-                             // ExternalMenuItem's obtained above,
-                             // along with their state, so as to avoid
-                             // ->try_refresh()ing them twice.
-                             ExternalMenuItem::all_except($emis))
-                 as $emi)
-        {
-            if (! $emi->try_refresh()) {
-                $errors++;
-                continue;
-            }
-
-            $subscribe_url = $emi->get_subscribe_url();
-            if (! $subscribe_url) {
-                $emi->error_log("has no subscribe URL");
-                continue;
-            }
-            try {
-                static::_get_subscribe_controller($emi)->
-                    subscribe($subscribe_url);
-            } catch (RESTClientError | TestWebhookFlowException $e) {
-                $emi->error_log(
-                    "Unable to subscribe at $subscribe_url: $e");
-                $errors++;
-            }
-        }
-
-        if (! $errors) {
-            static::admin_notice(___('Refresh successful'));
-        } else {
-            static::admin_error(sprintf(
-                ___('Refresh failed (%d failed out of %d)'),
-                $errors, count($all)));
-        }
-
-        return "edit.php?post_type=" . static::get_post_type();
     }
 
     /**


### PR DESCRIPTION
**From issue**: (None filed)

**High level changes:**

1. The Refresh button now displays the progress of refresh operations in a whole-page animation
![Technicolor updates](https://user-images.githubusercontent.com/1629585/47507175-f8b02e80-d871-11e8-8397-9fc98cfdc3d0.gif)
1. There is now a white-screen-free recovery path in case of timeout (which still do happen): just wait a short while and hit the Refresh button again

**Low level changes:**

- Server-side, split the part where we detect new menus from the
  filesystem (one POST XHR) from the part where we update each of
  them (one POST XHR per ExternalMenuItem, whether it be visible
  in the page or not)
- Signal errors in the first POST with (somewhat crude)
  position: absolute tooltips
- Use jQuery's .Deferred class to craft a Spinner widget that updates
  visually as the Deferred's .status() changes. Put one Spinner in the
  refresh button, and one per line being updated
- Also use hatched / barber-bar background styling in individual <tr>s
  to indicate update progress / result
- If any changes are not visible through these animations (typically
  upon the first attempt when there are no ExternalMenuItems at all),
  end the refresh action by reloading the page, so that they become
  visible.
- Deal properly with 504's client-side, as they still happen in
  practice; on the server side, do our level best to finish the
  request and encache it in a WordPress transient, so that the next
  hit on the refresh button has a shot at obtaining the info
