### PR TITLE
Définir une liste de host qui ne sont pas restreint par IP à /wp-admin

### DIFF
--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,7 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
+    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dcsl.epfl.ch', 'courtine-lab.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,7 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <If "req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
+    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -16,7 +16,7 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <If "req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
+    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,35 +2,35 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
+    <RequireAll>
+        Require all granted
+        Require not host charte-wp.epfl.ch
 
-    Require all granted
-    Require not host charte-wp.epfl.ch
+        # docker private network
+        Require ip 172.16.0.0/12
 
-    # docker private network
-    Require ip 172.16.0.0/12
+        # EPFL IPv4 & IPv6
+        Require ip 128.178.0.0/15
+        Require ip 2001:620:618::/48
 
-    # EPFL IPv4 & IPv6
-    Require ip 128.178.0.0/15
-    Require ip 2001:620:618::/48
-
-    # OpenShift cluster
-    Require ip 10.180.21.0/24
-
+        # OpenShift cluster
+        Require ip 10.180.21.0/24
+    </RequireAll>
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
+    <RequireAll>
+        Require all granted
+        Require not host charte-wp.epfl.ch
 
-    Require all granted
-    Require not host charte-wp.epfl.ch
+        # docker private network
+        Require ip 172.16.0.0/12
 
-    # docker private network
-    Require ip 172.16.0.0/12
+        # EPFL IPv4 & IPv6
+        Require ip 128.178.0.0/15
+        Require ip 2001:620:618::/48
 
-    # EPFL IPv4 & IPv6
-    Require ip 128.178.0.0/15
-    Require ip 2001:620:618::/48
-
-    # OpenShift cluster
-    Require ip 10.180.21.0/24
-
+        # OpenShift cluster
+        Require ip 10.180.21.0/24
+    </RequireAll>
 </LocationMatch>

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,7 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <If "req('HOST') != 'charte-wp.epfl.ch'">
+    <If "req('HOST') != 'charte-wp2.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -16,7 +16,7 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <If "req('HOST') != 'charte-wp.epfl.ch'">
+    <If "req('HOST') != 'charte-wp2.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,7 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <If "req('HOST') != 'charte-wp2.epfl.ch'">
+    <If "req('HOST') != 'charte-wp.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -16,7 +16,7 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <If "req('HOST') != 'charte-wp2.epfl.ch'">
+    <If "req('HOST') != 'charte-wp.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -3,6 +3,8 @@
 
 <LocationMatch ".*/wp-login.php.*">
 
+    Require not host charte-wp.epfl.ch
+
     # docker private network
     Require ip 172.16.0.0/12
 
@@ -16,6 +18,8 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
+
+    Require not host charte-wp.epfl.ch
 
     # docker private network
     Require ip 172.16.0.0/12

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -16,7 +16,7 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
+    <If "!req('HOST') in {'charte-wp.epfl.ch', 'dcsl.epfl.ch', 'courtine-lab.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -3,6 +3,7 @@
 
 <LocationMatch ".*/wp-login.php.*">
 
+    Require all granted
     Require not host charte-wp.epfl.ch
 
     # docker private network
@@ -19,6 +20,7 @@
 
 <LocationMatch ".*/wp-admin.*">
 
+    Require all granted
     Require not host charte-wp.epfl.ch
 
     # docker private network

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,7 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <If "req('HOST') != 'charte-wp.epfl.ch'">
+    <If "req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -16,7 +16,7 @@
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <If "req('HOST') != 'charte-wp.epfl.ch'">
+    <If "req('HOST') in {'charte-wp.epfl.ch', 'dream-team.epfl.ch'}">
         # docker private network
         Require ip 172.16.0.0/12
 

--- a/build/httpd/restrict-wp-admin.conf
+++ b/build/httpd/restrict-wp-admin.conf
@@ -2,10 +2,7 @@
 # docker and OpenShift.
 
 <LocationMatch ".*/wp-login.php.*">
-    <RequireAll>
-        Require all granted
-        Require not host charte-wp.epfl.ch
-
+    <If "req('HOST') != 'charte-wp.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -15,14 +12,11 @@
 
         # OpenShift cluster
         Require ip 10.180.21.0/24
-    </RequireAll>
+    </If>
 </LocationMatch>
 
 <LocationMatch ".*/wp-admin.*">
-    <RequireAll>
-        Require all granted
-        Require not host charte-wp.epfl.ch
-
+    <If "req('HOST') != 'charte-wp.epfl.ch'">
         # docker private network
         Require ip 172.16.0.0/12
 
@@ -32,5 +26,5 @@
 
         # OpenShift cluster
         Require ip 10.180.21.0/24
-    </RequireAll>
+    </If>
 </LocationMatch>


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Avec @LuluTchab on a fait en sorte que l'on puisse définir une liste des sites à exclure de la restriction 'restrict-wp-admin.conf' de l'image httpd.

Pour tester : https://charte-wp.epfl.ch/
Site déployé sur le POD de Luc dans lequel le conteneur HTTPD a été redéployé.

**Low level changes:**

1. None

**Targetted version**: x.x.x
