### PR TITLE
Allow PPD filees upload for myprint

### DIFF
--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -123,6 +123,16 @@ add_filter('wp_get_attachment_link', 'oikos_get_attachment_link_filter', 10, 4);
 
 
 
+/*--------------------------------------------------------------
+
+ # File upload extension whitelist
+
+--------------------------------------------------------------*/
+function epfl_mimetypes($mime_types){
+    $mime_types['ppd'] = 'application/vnd.cups-ppd'; //Adding ppd extension
+    return $mime_types;
+}
+add_filter('upload_mimes', 'epfl_mimetypes', 1, 1);
 
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Catherine ayant besoin d'uploader des fichiers *.ppd pour myPrint (car utilisés à distance depuis des script), après discussion avec Luc, une whitelist a été ajoutée pour autoriser ceci (car bloqué par défaut sur WP).


**Targetted version**: x.x.x
