### PR TITLE
Hide wp-media-folder config menu

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
@@ -90,6 +90,8 @@ function EPFL_remove_admin_submenus() {
    remove_submenu_page( 'options-general.php', 'epfl_tequila' );
    // Jonradio private site
    remove_submenu_page( 'options-general.php', 'jr_ps_settings' );
+   // WP Media folder
+   remove_submenu_page( 'options-general.php', 'option-folder' );
 }
 
 


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Cacher le menu de config de WP-Media-Folder. Oubli lorsque celui-ci a été déplacé de la branche "release" vers "release2018"...


**Targetted version**: x.x.x
