### PR TITLE
Don't spin if nothing to do

### DIFF
--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
@@ -65,6 +65,14 @@ function updateRowsDeferred ($, ids) {
     var todoCount = ids.length;
     var hasInvisibleChanges = false;
 
+    if (! todoCount) {
+        // It is bad practice to resolve a promise before returning it:
+        window.setTimeout(function() {
+            d.resolve();
+        }, 0);
+        return d;
+    }
+
     // Here, we could update the tr's in tbody#the-list to match ids,
     // perhaps with some kind of CSS animation for
     // appearing/disappearing rows.


### PR DESCRIPTION
**From issue**: None filed (discovered with Luc while investigating a menu-related issue)

**High level changes:**

None visible (the bug is normally masked)

**Low level changes:**

Fast-path exit of the spinner thing if the response to the refresh button's POST query has zero ExternalMenuItem's
