### PR TITLE
Synchronize menus and respect order

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -29,6 +29,10 @@ require_once 'shortcodes/epfl-google-forms/epfl-google-forms.php';
 require_once 'menus/epfl-menus.php';
 require_once 'preprod.php';
 
+if (class_exists('\WP_CLI')) {
+    require_once 'menus/wpcli.php';
+}
+
 // load .mo file for translation
 function epfl_load_plugin_textdomain() {
     load_plugin_textdomain( 'epfl', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );

--- a/data/wp/wp-content/plugins/epfl/lib/auto-fields.php
+++ b/data/wp/wp-content/plugins/epfl/lib/auto-fields.php
@@ -207,13 +207,17 @@ class AutoFieldsController {
 jQuery(function($) {
   $('#<?php echo $button_id; ?>').click(function(e) {
     e.stopPropagation();
-    console.log('<?php echo "$key ="; ?>', JSON.parse("<?php echo preg_replace('/([\\"])/', '\\\\${1}', $value); ?>"));
+    console.log('<?php echo "$key ="; ?>', JSON.parse("<?php echo static::escape_js_doublequoted($value); ?>"));
     return false;
   });
 });
 </script>
 <?php
         }
+    }
+
+    static function escape_js_doublequoted ($value) {
+        return addslashes($value);
     }
 
     function clear ()

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -487,7 +487,7 @@ class _Subscriber extends WPDBModel
             RESTClient::POST_JSON($url, $payload);
             $this->mark_success();
         } catch (RESTClientError $e) {
-            error_log($e);
+            error_log("attempt_post failed: " . $e);
             $this->mark_failure();
         }
     }

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -420,7 +420,7 @@ class _Subscriber extends WPDBModel
     // We never drop that table, even on plugin removal.
 
     protected function __construct ($id, $details) {
-        $this->ID = $id;
+        assert(is_int($this->ID = $id));
         $details = static::_as_db_results($details);
         assert(!! ($this->subscriber_id = $details->subscriber_id));
         assert(!! ($this->publisher_url = $details->publisher_url));
@@ -465,12 +465,12 @@ class _Subscriber extends WPDBModel
         $thisclass = get_called_class();
         $objects = array();
         foreach (static::get_results(
-                "SELECT publisher_url, subscriber_id, callback_url,
-                 UNIX_TIMESTAMP(last_attempt), UNIX_TIMESTAMP(failing_since)
+                "SELECT id, publisher_url, subscriber_id, callback_url,
+                 UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since
                  FROM %T
                  WHERE publisher_url = %s",
                 $publisher_url) as $db_line) {
-            $objects[] = new $thisclass($publisher_url, $db_line);
+            $objects[] = new $thisclass($db_line->id, $db_line);
         }
         return $objects;
     }

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -382,7 +382,7 @@ class PublishController
     }
 
     public function _do_forward ($event) {
-            foreach (_Subscriber::all_by_publisher_url($this->subscribe_uri)
+        foreach (_Subscriber::all_by_publisher_url($this->subscribe_uri)
                  as $sub) {
             if ($sub->has_seen($event)) continue;
             $sub->attempt_post($sub->get_callback_url(), $event->marshall());
@@ -484,7 +484,7 @@ class _Subscriber extends WPDBModel
         // attempting to untangle it would create more coupling than
         // it would save.
         try {
-            RESTClient::POST_JSON($url, $payload);
+            RESTClient::POST_JSON_ff($url, $payload);
             $this->mark_success();
         } catch (RESTClientError $e) {
             error_log("attempt_post failed: " . $e);
@@ -522,6 +522,10 @@ class _Subscriber extends WPDBModel
                  WHERE id = %d;",
                 $this->last_attempt, $this->ID);
         }
+    }
+
+    function __toString () {
+        return sprintf('<%s %s>', get_called_class(), $this->ID);
     }
 }
 

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -398,9 +398,9 @@ class _Subscriber extends WPDBModel
     protected function __construct ($id, $details) {
         $this->ID = $id;
         $details = static::_as_db_results($details);
-        assert($this->subscriber_id = $details->subscriber_id);
-        assert($this->publisher_url = $details->publisher_url);
-        assert($this->callback_url  = $details->callback_url);
+        assert(!! ($this->subscriber_id = $details->subscriber_id));
+        assert(!! ($this->publisher_url = $details->publisher_url));
+        assert(!! ($this->callback_url  = $details->callback_url));
         if ($details->last_attempt) {
             $this->last_attempt = $details->last_attempt;
         }
@@ -441,17 +441,12 @@ class _Subscriber extends WPDBModel
         $thisclass = get_called_class();
         $objects = array();
         foreach (static::get_results(
-                "SELECT subscriber_id, callback_url,
+                "SELECT publisher_url, subscriber_id, callback_url,
                  UNIX_TIMESTAMP(last_attempt), UNIX_TIMESTAMP(failing_since)
                  FROM %T
                  WHERE publisher_url = %s",
-                $url) as $line) {
-            $objects[] = new $thisclass(
-                $publisher_url,
-                $db_line->subscriber_id,
-                $db_line->callback_url,
-                ($db_line->last_attempt or NULL),
-                ($db_line->failing_since or NULL));
+                $publisher_url) as $db_line) {
+            $objects[] = new $thisclass($publisher_url, $db_line);
         }
         return $objects;
     }

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -419,7 +419,7 @@ class _Subscriber extends WPDBModel
         foreach (static::get_results(
                 "SELECT subscriber_id, callback_url,
                  UNIX_TIMESTAMP(last_attempt), UNIX_TIMESTAMP(failing_since)
-                 FROM %t
+                 FROM %T
                  WHERE publisher_url = %s",
                 $url) as $line) {
             $objects[] = new $thisclass(

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -311,6 +311,13 @@ class _Subscription extends WPDBModel
         $this->query("DELETE FROM %T WHERE slug = %s AND nonce != %s",
                      $this->slug, $this->nonce);
     }
+
+    function __toString () {
+        return sprintf(
+            '<%s slug=%s nonce=%s confirmed=%s>',
+            get_called_class(),
+            $this->slug, $this->nonce, ($this->confirmed ? "TRUE" : "FALSE"));
+    }
 }
 
 _Subscription::hook();

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -420,7 +420,7 @@ class _Subscriber extends WPDBModel
     // We never drop that table, even on plugin removal.
 
     protected function __construct ($id, $details) {
-        assert(is_int($this->ID = $id));
+        assert(($this->ID = 0 + $id) > 0);
         $details = static::_as_db_results($details);
         assert(!! ($this->subscriber_id = $details->subscriber_id));
         assert(!! ($this->publisher_url = $details->publisher_url));

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -354,7 +354,7 @@ class PublishController
     public function initiate () {
         $event = Causality::start();
         _Events::action_initiate($this->subscribe_uri, $event);
-        $this->forward($event);
+        $this->_do_forward($event);
     }
 
     public function _do_forward ($event) {
@@ -524,7 +524,7 @@ class Causality
         $that = new $thisclass();
         $data = is_string($json) ? json_decode($json) : $json;
         $that->timestamp = $data->timestamp;
-        $that->path      = $data->path;
+        $that->path      = $data->path ? $data->path : [];
         return $that;
     }
 
@@ -542,8 +542,8 @@ class Causality
         return $that;
     }
 
-    static function has_in_path ($subscriber_id) {
-        return in_array($subscriber_id, $event->path);
+    function has_in_path ($subscriber_id) {
+        return in_array($subscriber_id, $this->path);
     }
 
     /**
@@ -551,7 +551,7 @@ class Causality
      *         appended to the path
      */
     function received ($via_subscriber_id) {
-        if (array_search($via_subscriber_id, $this->path)) {
+        if ($this->has_in_path($via_subscriber_id)) {
             throw new CausalityLoopError(
                 implode(" -> ", $this->path) .
                 " loops back to us: $via_subscriber_id");

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1615,6 +1615,16 @@ class MenuEditorController
                 _MenusJSApp::load();
             }
         });
+
+        add_action('wp_update_nav_menu', function($nav_menu_selected_id, $new_menu_data = NULL) {
+            // For whatever reason, this action is called twice per click on
+            // the Save button.
+            if (! $new_menu_data) return;
+
+            if (! ($menu = Menu::by_term($nav_menu_selected_id))) return;
+
+            MenuRESTController::menu_changed($menu);
+        }, 10, 2);
     }
 }
 

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -453,8 +453,6 @@ class MenuItemBag
             throw new \Error("Duplicate ID: " . $this->_get_id($item));
         }
         $item = clone($item);
-        $this->_MUTATE_set_id       ($item, (int) $this->_get_id       ($item));
-        $this->_MUTATE_set_parent_id($item, (int) $this->_get_parent_id($item));
         $this->items[$this->_get_id($item)] = $item;
     }
 

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -735,7 +735,8 @@ class Menu
 
         if (! $grafted_count) {
             error_log(sprintf(
-                'Cannot find graft point - Unable to stitch up\n%s',
+                'Cannot find graft point - Unable to stitch up (in %s)\n%s',
+                get_site_url(),
                 var_export($root_menu, true)));
         }
 

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -211,7 +211,7 @@ class MenuItemBag
                 $safe[] = $id;
             } elseif (! array_key_exists($parent_id, $this->items)) {
                 throw new TreeError("Parent of $id ($parent_id) unknown");
-            } elseif (! $children[$parent_id]) {
+            } elseif (! array_key_exists($parent_id, $children)) {
                 $children[$parent_id] = array($id);
             } else {
                 $children[$parent_id][] = $id;
@@ -226,7 +226,7 @@ class MenuItemBag
             // at the right place at the end of the topological sort.
             $sorted[] = $n;
 
-            if ($children[$n]) {
+            if (array_key_exists($n, $children)) {
                 // All children of a safe node are safe
                 $safe = array_merge($safe, $children[$n]);
                 // Discard the corresponding edges from the adjacency list
@@ -449,7 +449,7 @@ class MenuItemBag
     }
 
     private function _MUTATE_add_item ($item) {
-        if ($this->items[$this->_get_id($item)]) {
+        if (array_key_exists($this->_get_id($item), $this->items)) {
             throw new \Error("Duplicate ID: " . $this->_get_id($item));
         }
         $item = clone($item);

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1346,6 +1346,7 @@ class MenuItemController extends CustomPostTypeController
         $thisclass = get_called_class();
         static::_get_subscribe_controller($emi)->add_listener(
             function($event) use ($thisclass, $emi) {
+                set_time_limit(0);
                 foreach (Menu::all_mapped() as $menu) {
                     if ($menu->update($emi)) {
                         MenuRESTController::menu_changed($menu, $event);

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1373,8 +1373,7 @@ class MenuItemController extends CustomPostTypeController
         // Using the post ID is perhaps a bit difficult to
         // read out of error logs, but certainly the easiest
         // and most future-proof way of going about it.
-        $cache_key = "menu/" . $emi->ID;
-        return SubscribeController::by_slug($cache_key);
+        return SubscribeController::by_namespace_and_slug("menu", $emi->ID);
     }
 
     /**

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1505,7 +1505,7 @@ class MenuItemController extends CustomPostTypeController
             return array(
                 'status' => 'ERROR',
                 'exception' => get_class($e),
-                'message' => sprintf(___('Sync failed: %s', $e))
+                'message' => sprintf(___('Sync failed: %s'), $e)
             );
         }
     }

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -788,11 +788,16 @@ class Menu
      * @param $emi The instance of ExternalMenuItem whose menu received
      *             an update event
      *
-     * @return true iff this menu changed
+     * @return false if this menu cannot possibly have changed,
+               true if it did or if we are not sure.
      */
     function update ($emi) {
-        // XXX Lazy but correct implementation (for low values of correct):
-        // do nothing
+        foreach ($this->_get_local_tree()->as_list() as $item) {
+            if ($emi->equals($item)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function __toString () {
@@ -1013,6 +1018,12 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
         } else {
             return parent::get($what);
         }
+    }
+
+    function equals ($what) {
+        $thisclass = get_called_class();
+        $what = $thisclass::get($what);
+        return ($what && $what->ID == $this->ID);
     }
 
     /**

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -270,14 +270,14 @@ class MenuItemBag
 
     function graft ($at_item, $bag) {
         return static::_MUTATE_graft(
-            $this->_get_parent_id($at_item),
+            $this->_get_id($at_item),
             $this->copy(), $this->_renumber(static::coerce($bag)));
     }
 
     function reverse_graft ($at_item, $into) {
-        $parent_id = $this->_get_parent_id($at_item);
-        $into_renumbered = $this->_renumber($into, /*&*/$parent_id);
-        return static::_MUTATE_graft($parent_id, $into_renumbered, $this);
+        $id = $this->_get_id($at_item);
+        $into_renumbered = $this->_renumber($into, /*&*/$id);
+        return static::_MUTATE_graft($id, $into_renumbered, $this);
     }
 
     /**
@@ -458,7 +458,8 @@ class MenuItemBag
         $this->items[$this->_get_id($item)] = $item;
     }
 
-    function _MUTATE_graft ($new_parent_id, $mutated_outer, $inner) {
+    function _MUTATE_graft ($at_id, $mutated_outer, $inner) {
+        $new_parent_id = $mutated_outer->_get_parent_id($at_id);
         foreach ($inner->copy()->as_list() as $item) {
             if (! $mutated_outer->_get_parent_id($item)) {
                 // $item is new, thanks to ->copy() being

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1367,19 +1367,14 @@ class MenuItemController extends CustomPostTypeController
         return new \EPFL\AdminAPI\Endpoint('EPFLMenus');
     }
 
-    static private $subs = array();
     static private function _get_subscribe_controller ($emi) {
-        $cache_key = $emi->ID;
-        if (! static::$subs[$cache_key]) {
-            static::$subs[$cache_key] = new SubscribeController(
-                // The subscribe slug will be embedded in webhook
-                // URLs, so it must not change inbetween queries.
-                // Using the post ID is perhaps a bit difficult to
-                // read out of error logs, but certainly the easiest
-                // and most future-proof way of going about it.
-                "menu/" . $emi->ID);
-        }
-        return static::$subs[$cache_key];
+        // The subscribe slug will be embedded in webhook
+        // URLs, so it must not change inbetween queries.
+        // Using the post ID is perhaps a bit difficult to
+        // read out of error logs, but certainly the easiest
+        // and most future-proof way of going about it.
+        $cache_key = "menu/" . $emi->ID;
+        return SubscribeController::by_slug($cache_key);
     }
 
     /**

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -773,7 +773,7 @@ class Menu
         // MenuRESTController
         $matched = array();
         if (! preg_match(
-            '#/wp-json/(.*)/menus/(.*?)(?:\?lang=(.*))?$#',
+            '#^/wp-json/(.*)/menus/(.*?)(?:\?lang=(.*))?$#',
             $url, $matched)) {
             return false;
         }

--- a/data/wp/wp-content/plugins/epfl/menus/wpcli.php
+++ b/data/wp/wp-content/plugins/epfl/menus/wpcli.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EPFL\Menus\CLI;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+use \WP_CLI;
+use \WP_CLI_Command;
+
+require_once(dirname(__DIR__) . '/lib/i18n.php');
+use function EPFL\I18N\___;
+
+require_once(__DIR__ . '/epfl-menus.php');
+use \EPFL\Menus\ExternalMenuItem;
+
+class EPFLMenusCLICommand extends WP_CLI_Command
+{
+    public static function hook () {
+        WP_CLI::add_command('epfl-menus', get_called_class());
+    }
+
+    public function refresh () {
+        WP_CLI::log(___('Enumerating menus on filesystem...'));
+        $local = ExternalMenuItem::load_from_filesystem();
+        WP_CLI::log(sprintf(___('... Success, found %d local menus'),
+                            count($local)));
+
+        $all = ExternalMenuItem::all();
+        WP_CLI::log(sprintf(___('Refreshing %d instances...'),
+                            count($all)));
+        foreach ($all as $emi) {
+            try {
+                $emi->refresh();
+                WP_CLI::log(sprintf(___('✓ %s', $emi)));
+            } catch (\Throwable $t) {
+                WP_CLI::log(sprintf(___('\u001b[31m✗ %s\u001b[0m', $emi)));
+            }
+        }
+        
+    }
+}
+
+EPFLMenusCLICommand::hook();


### PR DESCRIPTION
**From issue**: WWP-1873

**High level changes:**

- When saving a menu, the change propagates promptly to all WordPress instances in the same pod (or not)
- Menu order is honored when "stitching" up or down with menus from other sites

**Low level changes:**

- De-mock ->update()
- Be much more defensive in constructing MenuItemBag instances; use a proper topological sort that preserves order
