### PR TITLE
Wwp cookie "security"

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl-multisite.php
+++ b/data/wp/wp-content/plugins/epfl/epfl-multisite.php
@@ -12,12 +12,23 @@ if (! defined( 'ABSPATH' )) {
     die( 'Access denied.' );
 }
 
-add_action('template_redirect', function() {
-    if (! class_exists('\SEED_CSP4')) return;
+function has_wordpress_cookie () {
     foreach ($_COOKIE as $cookie_name => $unused_value) {
         if (preg_match('#^wordpress_logged_in_#', $cookie_name)) {
-            remove_action('template_redirect', array(\SEED_CSP4::get_instance(), 'render_comingsoon_page'));
-            break;
+            return true;
         }
     }
-}, 8);
+    return false;
+}
+
+function get_logged_out_redirect_url () {
+    return get_option("epfl-multisite-logged-out-redirect");
+}
+
+add_action('template_redirect', function() {
+    $redirect = get_logged_out_redirect_url();
+    if ($redirect && ! has_wordpress_cookie()) {
+        header("Location: $redirect");
+        exit;
+    }
+});

--- a/data/wp/wp-content/plugins/epfl/epfl-multisite.php
+++ b/data/wp/wp-content/plugins/epfl/epfl-multisite.php
@@ -1,0 +1,23 @@
+<?php
+
+/* Copyright © 2018 École Polytechnique Fédérale de Lausanne, Switzerland */
+/* All Rights Reserved, except as stated in the LICENSE file. */
+/**
+ * Special (non-menu) provisions for EPFL-style nested-site deployments
+ */
+
+namespace EPFL\Multisite;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+add_action('template_redirect', function() {
+    if (! class_exists('\SEED_CSP4')) return;
+    foreach ($_COOKIE as $cookie_name => $unused_value) {
+        if (preg_match('#^wordpress_logged_in_#', $cookie_name)) {
+            remove_action('template_redirect', array(\SEED_CSP4::get_instance(), 'render_comingsoon_page'));
+            break;
+        }
+    }
+}, 8);

--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -6,6 +6,7 @@
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
+require_once 'epfl-multisite.php';
 require_once 'lib/utils.php';
 require_once 'shortcodes/epfl-news/epfl-news.php';
 require_once 'shortcodes/epfl-memento/epfl-memento.php';

--- a/data/wp/wp-content/plugins/epfl/preprod.php
+++ b/data/wp/wp-content/plugins/epfl/preprod.php
@@ -9,11 +9,9 @@ namespace EPFL\Preprod;
 function is_subscriber () {
     if (! is_user_logged_in()) return false;
 
-    $CHEATING = ($user->ID === 27);
-
     $user = wp_get_current_user();
     foreach ($user->roles as $role) {
-        if (($role === 'subscriber') || $CHEATING) {
+        if ($role === 'subscriber') {
             return true;
         }
     }


### PR DESCRIPTION
**From issue**: none filed

**High level changes:**

- Unauthenticated access under a sub-site of www2018.epfl.ch now redirects to the root
- No more Tequila back-and-forths on subsites (and thus no more risk of an infinite redirect loop on same)

**Low level changes:**

- Except on the root site, believe any cookie presented by the user that matches `^wordpress_logged_in_`
- New configuration option `epfl-multisite-logged-out-redirect` to configure where to 302 logged-out users to
- (Off-PR) Set that option to `https://www2018.epfl.ch/` on all sandbox sites except the root
