### PR TITLE
EPFL-News: Use 'isset' to check var

### DIFF
--- a/data/wp/wp-content/plugins/epfl-news/render.php
+++ b/data/wp/wp-content/plugins/epfl-news/render.php
@@ -194,7 +194,7 @@ Class Render
             $html .= '    </a>';
             $html .= '  </figure>';
 
-            if ($category_label) {
+            if (isset($category_label)) {
                 $html .= '  <p class="category-label">' . $category_label . ' </p>';
             }
 


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Utilisation de `isset` pour contrôler qu'une variable existe au lieu de check simplement avec `if($var)`. Ceci n'est pas grand chose mais ça remontait un "notice"


**Targetted version**: x.x.x
