### PR TITLE
Add language utility; remove map language selection

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -7,6 +7,7 @@
  */
 
 require_once 'lib/utils.php';
+require_once 'lib/language.php';
 require_once 'shortcodes/epfl-news/epfl-news.php';
 require_once 'shortcodes/epfl-memento/epfl-memento.php';
 require_once 'shortcodes/epfl-toggle/epfl-toggle.php';

--- a/data/wp/wp-content/plugins/epfl/lib/language.php
+++ b/data/wp/wp-content/plugins/epfl/lib/language.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Utilities about languages, using Polylang if installed
+*/
+
+namespace EPFL\Language;
+
+function get_current_or_default_language() {
+    $default_lang = 'en';
+    $allowed_langs = array('en', 'fr');
+    $language = $default_lang;
+    
+    /* If Polylang installed */
+    if(function_exists('pll_current_language'))
+    {
+        $current_lang = pll_current_language('slug');
+        // Check if current lang is supported. If not, use default lang
+        $language = (in_array($current_lang, $allowed_langs)) ? $current_lang : $default_lang;
+    } else {
+        $lang = get_bloginfo("language");
+
+        if ($lang === 'fr-FR') {
+            $language = 'fr';
+        }
+    }
+
+    return $language;
+}

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -236,6 +236,9 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
     # add language to cache definer if a group_by doctype is used
     if ($group_by === 'doctype' || ($group_by === 'year' && $group_by2 === 'doctype')) {
         # fetch language
+        # if you can, use the method
+        # use function EPFL\Language\get_current_or_default_language;
+        
         $default_lang = 'en';
         $allowed_langs = array('en', 'fr');
         $language = $default_lang;

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-map/epfl-map.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-map/epfl-map.php
@@ -7,6 +7,8 @@
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
+ use function EPFL\Language\get_current_or_default_language;
+
 /**
  * Check the parameters
  *
@@ -39,6 +41,11 @@ function epfl_map_process_shortcode( $attributes, string $content = null ): stri
     // sanitize parameters
     $query  = sanitize_text_field($atts['query']);
     $lang   = sanitize_text_field($atts['lang']);
+
+    if (empty($lang)) {
+        # use the current page language
+        $lang = get_current_or_default_language();
+    }
 
     // check parameters
     if ( false == epfl_map_check_parameters($query, $lang) ) {
@@ -92,13 +99,6 @@ add_action( 'register_shortcode_ui',  function() {
                     'type'          => 'text',
                     'value'         => 'INN011',
                     'description'   => esc_html__('A room for example', 'epfl'),
-                ),
-                array(
-                    'label'         => '<h3>' . esc_html__('Language', 'epfl') . '</h3>',
-                    'attr'          => 'lang',
-                    'type'          => 'select',
-                    'options'       => $lang_options,
-                    'description'   => esc_html__('Language used to render map result', 'epfl'),
                 ),
             ),
 


### PR DESCRIPTION
Homogénise la manière de récuprérer la langue en cours

Enlève la sélection de la langue dans le shortcake de epfl-map, mais respecte celle choisit dans le shortcode si il y a.