### PR TITLE
Fix YouTube redirect

### DIFF
--- a/data/wp/wp-content/plugins/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl-video/epfl-video.php
@@ -65,8 +65,6 @@ function epfl_video_process_shortcode( $atts, $content = null ) {
     return epfl_video_get_error(__("EPFL-Video: Error getting final URL", 'epfl-video'));
   }
 
-    error_log($url);
-
   /* If YouTube video - Allowed formats:
     - https://www.youtube.com/watch?v=Tit6bvRIDtI
     - https://www.youtube.com/watch?v=Tit6bvRIDtI&t=281s

--- a/data/wp/wp-content/plugins/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl-video/epfl-video.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: EPFL Video
  * Description: provides a shortcode to display video from YouTube and SwitchTube
- * @version: 1.2
+ * @version: 1.3
  * @copyright: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -54,24 +54,55 @@ function epfl_video_process_shortcode( $atts, $content = null ) {
   // sanitize parameters
   $url  = $atts['url'];
 
-  /* To handle video URL redirection*/
+  /* To handle video URL redirection
+
+    NOTE: if we have an URL like 'https://youtu.be/M4Ufs7-FpvU', it will be transformed to
+    https://youtube.com/watch?v=M4Ufs7-FpvU&feature=youtu.be
+    So, '&feature=youtu.be' will be added at the end and we will have to handle it.
+  */
   if(($url = epfl_video_get_final_video_url($url)) === false)
   {
     return epfl_video_get_error(__("EPFL-Video: Error getting final URL", 'epfl-video'));
   }
 
+    error_log($url);
 
   /* If YouTube video - Allowed formats:
     - https://www.youtube.com/watch?v=Tit6bvRIDtI
     - https://www.youtube.com/watch?v=Tit6bvRIDtI&t=281s
-    - https://youtu.be/M4Ufs7-FpvU
     - https://www.youtube.com/watch?v=M4Ufs7-FpvU&feature=youtu.be
   */
   if(preg_match('/(youtube\.com|youtu\.be)/', $url)===1 && preg_match('/\/embed\//', $url)===0)
   {
-    /* Extracting video ID from URL which is like one of the example before (we also extract rest of query string) */
-    $video_id = str_replace('watch?v=', '', substr($url, strrpos($url, '/')+1 ));
+    /* Extracting query string */
+    $query = parse_url($url, PHP_URL_QUERY);
+
+    parse_str($query, $query_args);
+
+    $video_id = $query_args['v'];
+    /* Removing video ID from query string */
+    unset($query_args['v']);
+
+    /* If we have a time at which to start video */
+    if(array_key_exists('t', $query_args))
+    {
+        /* When video is embed, the parameters is called 'start' and not 't', so we remove the incorrect one
+        and add the new one. */
+        $query_args['start'] = $query_args['t'];
+        unset($query_args['t']);
+    }
+
+    /* We remove existing query string from URL */
+    $url = str_replace('?'.$query, '', $url);
+
+    /* Updating query (without video_id if it was present) to reuse it later */
+    $query = http_build_query($query_args);
+
     $url = "https://www.youtube.com/embed/".$video_id;
+    if($query != "")
+    {
+        $url .= '?'.$query;
+    }
   }
 
   /* if Vimeo video - Allowed formats:


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Correction d'un bug qui faisait qu'une URL incorrecte était générée si on mettait une URL YouTube du style "https://youtu.be/oI2xK6zbaoI". Ce problème est apparu suite à la mise en place de la récupération de l'URL après redirection éventuelle de celle-ci. Dans le cas courant, on arrivait sur "https://www.youtube.com/watch?v=oI2xK6zbaoI&feature=youtu.be" et le paramètre "&feature=youtu.be" n'était pas géré correctement et ajouté tel quel à la suite de l'URL faisant office de `src` pour l'`iframe`, donc erreur... 
1. Ajout de la gestion du paramètre `t` (pour démarrer la vidéo à une postion donnée) car celui-ci se transforme en `start` lorsque la vidéo est inclue dans une `iframe`
