### PR TITLE
Do not include WordPress installed in subfolders during backup

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -319,17 +319,35 @@ class Utils(object):
     @staticmethod
     def generate_tar_file(tar_file_path, tar_listed_inc_file_path, source_path):
         """
-        Generate a tar file
+        Generate a tar file from a WordPress installation.
+        Doing a simple tar file backups everything in the folder and also in subfolders. This can be a problem in case
+        of multiple WordPress installation in subfolders of folder we have to backup.
+        To avoid to backup those WordPress installations, we'll first list files/folders to backup (using "find") and
+        we take care to exclude/include exactly the files/folders we want.
+        Two commands are used :
+        - list files at root level (excluding the ones starting with "wp-")
+        - list all element (files/(sub)folders) starting (at root level) with "wp-".
+        The output of those 2 commands is concaneted and given as input to "tar" command so we have the exact list
+        of files to backup.
 
         Arguments keywords
         tar_file_path -- path of TAR file to create
         tar_listed_inc_file_path -- path to file containing incremental infos to help to create tar file
         source_path -- path to infos to put in TAR file
         """
-        command = "tar --create --no-check-device --file={} --listed-incremental={} {}".format(
+
+        # To list root FILES not starting with "wp-"
+        cmd_first_level_files = 'find {0} -maxdepth 1 -type f -print | grep -v "{0}/wp-"'.format(source_path)
+
+        # To list all files/dirs starting with "<tar_file_path>/wp-" (this will exclude non-WordPress subfolder,
+        # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
+        cmd_all_others = 'find {0} -print | grep "{0}/wp-"'.format(source_path)
+
+        command = "{{ {} ; {}; }} | tar --create --no-check-device --file={} --listed-incremental={} -T -".format(
+            cmd_first_level_files,
+            cmd_all_others,
             tar_file_path,
-            tar_listed_inc_file_path,
-            source_path
+            tar_listed_inc_file_path
         )
         return Utils.run_command(command)
 


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout du nécessaire pour ne pas prendre en compte les installations de WordPress se trouvant dans des dossiers qui sont à la racine du WordPress que l'on veut backuper.
Utilisation de `find` et `grep` pour filtrer correctement la liste des dossiers/fichiers à backuper et celle-ci est ensuite passée en entrée à la commande `tar` pour finir le job. 
La commande `tar` ne permettant que d'exclure des éléments (black list) via un "pattern", il fallait donc plutôt lui passer la liste des fichiers à prendre en compte de manière explicite.

**Targetted version**: x.x.x
