### PR TITLE
Remove unit name validation for CSV file

### DIFF
--- a/src/veritas/veritas.py
+++ b/src/veritas/veritas.py
@@ -5,7 +5,7 @@ from django.core.validators import URLValidator, ValidationError
 from utils import Utils
 from .validators import validate_string, validate_yes_or_no, validate_integer, \
     validate_openshift_env, validate_site_type, validate_theme, validate_theme_faculty, validate_languages, \
-    validate_unit, mock_validate_unit
+    mock_validate_unit
 
 BASE_COLUMNS = [
     ("wp_site_url", URLValidator(schemes=['https']), True),
@@ -29,11 +29,6 @@ if Utils.get_optional_env('TRAVIS', False):
     JAHIA2WP_COLUMNS = BASE_COLUMNS + [
         ("unit_name", mock_validate_unit, False),
     ]
-else:
-    JAHIA2WP_COLUMNS = BASE_COLUMNS + [
-        ("unit_name", validate_unit, False),
-    ]
-
 
 MOCK_JAHIA2WP_COLUMNS = BASE_COLUMNS + [
     ("unit_name", mock_validate_unit, False),

--- a/src/veritas/veritas.py
+++ b/src/veritas/veritas.py
@@ -29,6 +29,8 @@ if Utils.get_optional_env('TRAVIS', False):
     JAHIA2WP_COLUMNS = BASE_COLUMNS + [
         ("unit_name", mock_validate_unit, False),
     ]
+else:
+    JAHIA2WP_COLUMNS = BASE_COLUMNS
 
 MOCK_JAHIA2WP_COLUMNS = BASE_COLUMNS + [
     ("unit_name", mock_validate_unit, False),


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Suppression de la validation du nom d'unité qui se trouve dans le fichier CSV. Maintenant, on passe dans tous les cas par le "unit id" dans le code. La validation du nom est donc superflue.


**Targetted version**: x.x.x
