### PR TITLE
Remove (not installed) 'enlighter' plugin for now (2018)

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -27,8 +27,8 @@ plugins:
     config: !include svg-support/v1/config-plugin.yml
   - name: feedzy-rss-feeds
     config: !include feedzy-rss-feeds/v1/config-plugin.yml
-  - name: enlighter
-    config: !include enlighter/v1/config-plugin.yml
+#  - name: enlighter
+#    config: !include enlighter/v1/config-plugin.yml
   - name: remote-content-shortcode
     config: !include remote-content-shortcode/v1/config-plugin.yml
   - name: shortcode-ui


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Demande de Luc de ne plus installer le plugin "enlighter" sur 2018 car il prend pas mal de ressources (nb requêtes dans la DB). Je l'ai uniquement mis en commentaire dans le fichier `config-lot-1.yml` afin qu'il ne soit plus installé mais que l'on puisse revenir en arrière facilement au besoin.
