### PR TITLE
Update redirect_to URL when forcing login, fix infinite loop with Tequila

### DIFF
--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     0.10
+ * Version:     0.11
  * Author:      Lucien Chaboudez
  * Author URI:  mailto:lucien.chaboudez@epfl.ch
  */

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-site.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-site.php
@@ -32,8 +32,23 @@ function epfl_intranet_force_login() {
 		return;
 	}
 
+    /* Defining URL on which we have to redirect to */
+	$http = ( empty( $_SERVER['HTTPS'] ) || ( $_SERVER['HTTPS'] == 'off' ) )?'http://':'https://';
+	$after_login_url = $http . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+
+	/* Forcing cache-control entry from headers otherwise, if we already have a Tequila token but we are not currently
+	authenticated on present WordPress website, we will redirect (below) to "wp-login.php" but this redirect will be
+	cached. This mean that access to current URL and redirect to wp-login.php is cached.
+	And when we will come back from Tequila (without any login because we already have the token), we will be redirected
+	(locally it seems) to primary asked URL and the cache will answer and tell to redirect on wp-login.php... so we will
+	be stuck in an infinite loop that could destroy the world!
+	The only way to fix this is to update the header specifying we must not cache the page.
+	And, this problem does not occurs when we primary authenticate on Tequila (if we don't have any token) because we
+	will go on Tequila website and come back on WordPress. And in this case, cache is not used. */
+	header('Cache-Control: no-cache, no-store, must-revalidate');
+
 	/*	wp_redirect( wp_login_url() ) goes to WP login URL right after exit on the line that follows. */
-	wp_redirect( wp_login_url() );
+	wp_redirect( wp_login_url($after_login_url) );
 	exit;
 }
 


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout de l'URL de redirection après login Tequila, celle-ci manquait...
1. Correction du bug de boucle infinie dans le cas où le plugin est utilisé en conjonction avec un plugin de cache.


**NOTE**: Ceci est une correction du plugin mais il n'est pas installé par défaut dans les sites WP.
