### PR TITLE
Do 303 instead of 302 for local redirection (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -190,4 +190,23 @@ function colored_box( $atts, $content = null ) {
 }
 add_shortcode('colored-box', 'colored_box');
 
+
+/*--------------------------------------------------------------
+
+ # CloudFlare
+
+--------------------------------------------------------------*/
+
+/*
+    If we have 302 redirection on local address, we transform them to 303 to avoid CloudFlare to cache
+    them. If we don't do this, we have issues to switch from one language to another (Polylang) because the
+    first time we visit the homepage, it does a 302 to default lang homepage and this request is cached in cloudflare
+    so it's impossible to switch to the other language
+*/
+function http_status_change_to_non_cacheable($status, $location) {
+   /* We only do 303 redirect if redirection are local to website. */
+   return (strpos($location, $_SERVER['SERVER_NAME'])!==false)? 303: $status;
+}
+add_filter( 'wp_redirect_status', 'http_status_change_to_non_cacheable', 10, 2);
+
 ?>

--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -3,7 +3,7 @@
  * Plugin Name: EPFL Functions
  * Plugin URI: 
  * Description: Must-use plugin for the EPFL website.
- * Version: 0.0.1
+ * Version: 0.0.2
  * Author: Aline Keller
  * Author URI: http://www.alinekeller.ch
  */


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Lorsque l'on est derrière CloudFlare, les redirections 302 sont cachées, ce qui empêche la navigation correcte entre les différentes langues du site. 
Cette modification change donc les redirections 302 (cachées) en 303 (pas cachées) s'il s'agit d'une redirection en local.
1. Si ça se trouve, ceci résout aussi le problème de boucle infinie lors de l'authentification tequila qui est corrigée dans https://github.com/epfl-idevelop/jahia2wp/pull/766 mais pas sûr car pas testé. Dans tous les cas, mieux d'avoir ceinture/bretelles dans le cas où le plugin "EPFL-Intranet" est distribué sans le "mu-plugin" courant.


**NOTE**: Equivalent de la PR https://github.com/epfl-idevelop/jahia2wp/pull/792 pour "release"
