### PR TITLE
Fix education menu bug

### DIFF
--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1135,8 +1135,13 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
                 // show up in the wp-admin list UI.
                 $that->set_language($lang);
 
-                $site_url_dir = parse_url($site_url, PHP_URL_PATH);
-                $title = $menu_descr->description . "[$lang] @ $site_url_dir";
+                if (! $that->wp_post()->post_title) {
+                    $site_moniker = parse_url($site_url, PHP_URL_PATH);
+                    $menu_moniker = $menu_descr->description;
+                    wp_update_post(array(
+                        'ID' => $that->ID,
+                        'post_title' =>  "$menu_moniker\[$lang\] @ $site_moniker"));
+                }
 
                 $instances[] = $that;
             }
@@ -1220,7 +1225,7 @@ class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
     function __toString () {
         return sprintf('<ExternalMenuItem(id=%d name="%s")>',
                        $this->ID,
-                       get_the_title($this->ID));
+                       $this->wp_post()->post_title);
     }
 }
 

--- a/data/wp/wp-content/plugins/epfl/menus/wpcli.php
+++ b/data/wp/wp-content/plugins/epfl/menus/wpcli.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/epfl-menus.php');
 use \EPFL\Menus\ExternalMenuItem;
 
 add_filter('epfl_rest_rewrite_connect_to', function($hostport, $host, $port) {
+    // TODO: this is not a way to go through life, son
     if ($hostport === "www2018.epfl.ch:443") {
         return "httpd-sandbox:8443";
     } else {


### PR DESCRIPTION
**From issue**: None filed #keepthebureaucracyatbay

**High level changes:**

"Refresh" button once again sets a title on External Menu Items that don't have one already

**Low level changes:**

As part of ExternalMenuItem::load_from_wp_site_url(), set the title if it is empty for any reason (typically because the ExternalMenuItem just got created; but also otherwise if the operator voluntarily sets the title to the empty string)