### PR TITLE
Fix PHP notices

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/admin-controller.php
+++ b/data/wp/wp-content/plugins/epfl/lib/admin-controller.php
@@ -176,7 +176,7 @@ abstract class CustomPostTypeController extends Controller
     abstract static function get_model_class ();
 
     static function is_active () {
-        return $_REQUEST['post_type'] === static::get_post_type();
+        return array_key_exists('post_type', $_REQUEST)?$_REQUEST['post_type'] === static::get_post_type():false;
     }
 
     static function hook ()
@@ -562,7 +562,7 @@ class _CustomPostTypeControllerColumn
     function _action_pre_get_posts ($query)
     {
         if ( ! is_admin() ) return;
-        if (! $this->sort_opts) return;
+        if (! property_exists($this, 'sort_opts')) return;
         if ($query->get( 'orderby' ) !== $this->slug) return;
 
         // Here we could examine $this->sort_opts to support sorting

--- a/data/wp/wp-content/plugins/epfl/lib/model.php
+++ b/data/wp/wp-content/plugins/epfl/lib/model.php
@@ -147,7 +147,7 @@ abstract class Post
 
     function wp_post ()
     {
-        if (! $this->_wp_post) {
+        if (! property_exists($this, '_wp_post')) {
             $this->_wp_post = get_post($this->ID);
         }
         return $this->_wp_post;


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Des erreurs `PHP Notice` étaient remontées par le plugin "Query Monitor" que j'utilise pour diagnostiquer le fonctionnement WP. Pas super problématique mais j'ai quand même corrigé.

**Targetted version**: x.x.x
