### PR TITLE
Add 'update-plugin-inventory' command

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -56,6 +56,9 @@ Usage:
     [--extra-config=<YAML_FILE>]
   jahia2wp.py update-plugins-many   <csv_file>                      [--debug | --quiet]
     [--force-plugin] [--force-options] [--plugin=<PLUGIN_NAME>|--strict-list]
+  jahia2wp.py update-plugins-inventory   <path>                     [--debug | --quiet]
+    [--force-plugin] [--force-options] [--plugin=<PLUGIN_NAME>|--strict-list]
+    [--extra-config=<YAML_FILE>]
   jahia2wp.py global-report <csv_file> [--output-dir=<OUTPUT_DIR>] [--use-cache] [--debug | --quiet]
     --root_wp_dest=</srv/../epfl> [--greedy] [--htaccess] [--context=<intra|inter|full>] [--dry_run]
 
@@ -1106,6 +1109,37 @@ def update_plugins(wp_env,
                                 strict_plugin_list=strict_list)
 
     print("Successfully updated WordPress plugin list at {}".format(wp_generator.wp_site.url))
+
+
+@dispatch.on('update-plugins-inventory')
+def update_plugins_inventory(path,
+                             plugin=None,
+                             force_plugin=False,
+                             force_options=False,
+                             strict_list=False,
+                             extra_config=None,
+                             **kwargs):
+
+    logging.info("Update plugins from inventory...")
+
+    for site_details in WPConfig.inventory(path):
+
+        if site_details.valid == settings.WP_SITE_INSTALL_OK:
+            logging.info("Updating plugins for %s", site_details.url)
+
+            all_params = {'openshift_env': WPSite.openshift_env_from_path(site_details.path),
+                          'wp_site_url': site_details.url}
+
+            # if we have extra configuration to load,
+            if extra_config is not None:
+                all_params = _add_extra_config(extra_config, all_params)
+
+            WPGenerator(all_params).update_plugins(only_one=plugin,
+                                                   force_plugin=force_plugin,
+                                                   force_options=force_options,
+                                                   strict_plugin_list=strict_list)
+
+    logging.info("All plugins updates done for path: %s", path)
 
 
 @dispatch.on('update-plugins-many')

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -256,13 +256,15 @@ class WPPluginConfigInfos:
             # Let's see if we have to activate the plugin or not
             self.is_active = plugin_config['activate']
 
-            # If plugin is coming from WP store
-            if plugin_config['src'].lower() == settings.PLUGIN_SOURCE_WP_STORE:
+            # If plugin is coming from WP store or if we don't have any info
+            if 'src' not in plugin_config or \
+                    plugin_config['src'].lower() == settings.PLUGIN_SOURCE_WP_STORE:
                 self.zip_path = None
 
             # If plugin is an URL pointing to a ZIP file
             elif plugin_config['src'].startswith('http') and plugin_config['src'].endswith('.zip'):
                 self.handle_plugin_remote_zip(plugin_config['src'])
+                
             else:  # It may be a path to a local folder to use to install plugin
                 # Generate full path
                 full_path = os.path.join(settings.PLUGINS_CONFIG_BASE_FOLDER, plugin_config['src'])

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -256,24 +256,18 @@ class WPPluginConfigInfos:
             # Let's see if we have to activate the plugin or not
             self.is_active = plugin_config['activate']
 
-            # If plugin needs to be activated
-            if self.is_active:
-                # If plugin is coming from WP store
-                if plugin_config['src'].lower() == settings.PLUGIN_SOURCE_WP_STORE:
-                    self.zip_path = None
+            # If plugin is coming from WP store
+            if plugin_config['src'].lower() == settings.PLUGIN_SOURCE_WP_STORE:
+                self.zip_path = None
 
-                # If plugin is an URL pointing to a ZIP file
-                elif plugin_config['src'].startswith('http') and plugin_config['src'].endswith('.zip'):
-                    self.handle_plugin_remote_zip(plugin_config['src'])
-                else:  # It may be a path to a local folder to use to install plugin
-                    # Generate full path
-                    full_path = os.path.join(settings.PLUGINS_CONFIG_BASE_FOLDER, plugin_config['src'])
-                    # Do some checks and create ZIP file with plugin files if necessary
-                    self.handle_plugin_local_src(full_path)
-
-            else:  # Plugin has to be deactivated
-                # So, action is set to nothing
-                self.action = settings.PLUGIN_ACTION_NOTHING
+            # If plugin is an URL pointing to a ZIP file
+            elif plugin_config['src'].startswith('http') and plugin_config['src'].endswith('.zip'):
+                self.handle_plugin_remote_zip(plugin_config['src'])
+            else:  # It may be a path to a local folder to use to install plugin
+                # Generate full path
+                full_path = os.path.join(settings.PLUGINS_CONFIG_BASE_FOLDER, plugin_config['src'])
+                # Do some checks and create ZIP file with plugin files if necessary
+                self.handle_plugin_local_src(full_path)
 
         # If there's no information for DB tables (= no options) for plugin
         if 'tables' not in plugin_config:

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -264,7 +264,7 @@ class WPPluginConfigInfos:
             # If plugin is an URL pointing to a ZIP file
             elif plugin_config['src'].startswith('http') and plugin_config['src'].endswith('.zip'):
                 self.handle_plugin_remote_zip(plugin_config['src'])
-                
+
             else:  # It may be a path to a local folder to use to install plugin
                 # Generate full path
                 full_path = os.path.join(settings.PLUGINS_CONFIG_BASE_FOLDER, plugin_config['src'])


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout de la commande `update-plugin-inventory` afin de pouvoir mettre à jour les plugins (ou un plugin) en utilisant l'inventaire.
1. Correction d'un bug qui faisait que l'utilisation des commandes `update-plugins*` n'installait pas les plugins devant être désactivés.

