### PR TITLE
Wwp shoot polylang cookie again

### DIFF
--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -197,6 +197,10 @@ add_shortcode('colored-box', 'colored_box');
 
 --------------------------------------------------------------*/
 
+/* CloudFlare doesn't like the Polylang cookie (or any cookie) */
+
+define('PLL_COOKIE', false);
+
 /*
     If we have 302 redirection on local address, we transform them to 303 to avoid CloudFlare to cache
     them. If we don't do this, we have issues to switch from one language to another (Polylang) because the


### PR DESCRIPTION

**High level changes:**

No more Polylang cookies (they prevent CloudFlare from caching)
