### PR TITLE
Add a meta description plugin

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -45,3 +45,5 @@ plugins:
     config: !include wp-media-folder/v1/config-plugin.yml
   - name: pdfjs-viewer-shortcode
     config: !include pdfjs-viewer-shortcode/v1/config-plugin.yml
+  - name: very-simple-meta-description
+    config: !very-simple-meta-description/v1/config-plugin.yml

--- a/data/plugins/generic/very-simple-meta-description/v1/config-plugin.yml
+++ b/data/plugins/generic/very-simple-meta-description/v1/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes


### PR DESCRIPTION
Certains webmasters veulent un meilleur contrôle du contenu affiché dans les abstracts du résultat des recherches vers leur site (exemple https://www.google.com/search?q=lmtm.epfl.ch)

En installant ce plugin, on leur offre la customisation de la balise <meta description> :
https://wordpress.org/plugins/very-simple-meta-description/