### PR TITLE
Handle empty page content (no translation)

### DIFF
--- a/src/parser/page_content.py
+++ b/src/parser/page_content.py
@@ -117,14 +117,17 @@ class PageContent:
             parent = self.page.parent
 
             while parent:
-                sidebar = parent.contents[self.language].sidebar
+                # Check if parent have a content in current lang
+                if self.language in parent.contents:
+                    sidebar = parent.contents[self.language].sidebar
 
-                # we found a sidebar with boxes, we stop
-                if len(sidebar.boxes) > 0:
-                    self.sidebar = sidebar
-                    break
+                    # we found a sidebar with boxes, we stop
+                    if len(sidebar.boxes) > 0:
+                        self.sidebar = sidebar
+                        break
 
-                # otherwise we continue in the hierarchy
+                    # otherwise we continue in the hierarchy
+
                 parent = parent.parent
 
     def set_path(self):


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Pour une raison inconnue (distortion du continuum espace temps peut-être), une page du site LMH n'a AUCUNE traduction pour une page... donc, ajout d'un petit `if` pour éviter le problème.


**Targetted version**: x.x.x
