### PR TITLE
Add try/except when creating WPSite from path

### DIFF
--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -80,8 +80,13 @@ class WPConfig:
             dir_names = sorted(dir_names)
             for dir_name in dir_names:
                 logging.debug('checking %s/%s', parent_path, dir_name)
-                wp_site = WPSite.from_path(os.path.join(parent_path, dir_name))
-                if wp_site is None:
+                try:
+                    from_path = os.path.join(parent_path, dir_name)
+                    wp_site = WPSite.from_path(from_path)
+                    if wp_site is None:
+                        continue
+                except:
+                    logging.error("Cannot extract WPSite from path '%s' - Error %s", from_path, sys.exc_info())
                     continue
                 wp_config = cls(wp_site)
                 if wp_config.is_config_valid:

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -107,33 +107,30 @@ class WPSite:
 
     @classmethod
     def from_path(cls, path):
-        try:
-            given_path = os.path.abspath(path).rstrip('/')
 
-            openshift_env = WPSite.openshift_env_from_path(given_path)
+        given_path = os.path.abspath(path).rstrip('/')
 
-            # validate given path
-            if not os.path.isdir(given_path):
-                logging.warning("given path '%s' is not a valid dir", given_path)
+        openshift_env = WPSite.openshift_env_from_path(given_path)
 
-            # make sure we are in an apache root directory
-            if 'htdocs' not in given_path:
-                return None
+        # validate given path
+        if not os.path.isdir(given_path):
+            logging.warning("given path '%s' is not a valid dir", given_path)
 
-            # build URL from path
-            regex = re.compile("/([^/]*)")
-            directories = regex.findall(os.path.abspath(path))
-            htdocs_index = directories.index('htdocs')
-            domain = directories[htdocs_index-1]
-            folders = '/'.join(directories[htdocs_index+1:])
-            url = "{}://{}/{}".format(cls.PROTOCOL, domain, folders)
-
-            # return WPSite
-            return cls(openshift_env, url)
-        except:
-
-            logging.error("Cannot extract WPSite from path '%s' - Error %s", path, sys.exc_info())
+        # make sure we are in an apache root directory
+        if 'htdocs' not in given_path:
             return None
+
+        # build URL from path
+        regex = re.compile("/([^/]*)")
+        directories = regex.findall(os.path.abspath(path))
+        htdocs_index = directories.index('htdocs')
+        domain = directories[htdocs_index-1]
+        folders = '/'.join(directories[htdocs_index+1:])
+        url = "{}://{}/{}".format(cls.PROTOCOL, domain, folders)
+
+        # return WPSite
+        return cls(openshift_env, url)
+
 
 
 class WPUser:

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -1,7 +1,6 @@
 import os
 import re
 import logging
-import sys
 
 from urllib.parse import urlparse
 from epflldap.ldap_search import get_username, get_email
@@ -107,7 +106,6 @@ class WPSite:
 
     @classmethod
     def from_path(cls, path):
-
         given_path = os.path.abspath(path).rstrip('/')
 
         openshift_env = WPSite.openshift_env_from_path(given_path)
@@ -130,7 +128,6 @@ class WPSite:
 
         # return WPSite
         return cls(openshift_env, url)
-
 
 
 class WPUser:


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Dans l'utilisation de l'inventaire pour notamment faire du backup, ça foire parfois avec la création de l'objet `WPSite`. Ajout d'un `try` et `except` pour gérer ceci.

**NOTE**
Cette PR une fois approuvée et mergée, il faudra ensuite faire un merge de "release" dans "master" afin que la modification soit dispo pour le prochain run du backup la nuit prochaine.