### PR TITLE
Add ServiceNow search shortcode

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.7
+ * @version: 1.8
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -28,6 +28,7 @@ require_once 'shortcodes/epfl-share/epfl-share.php';
 require_once 'shortcodes/epfl-contact/epfl-contact.php';
 require_once 'shortcodes/epfl-tableau/epfl-tableau.php';
 require_once 'shortcodes/epfl-google-forms/epfl-google-forms.php';
+require_once 'shortcodes/epfl-servicenow-search/epfl-servicenow-search.php';
 require_once 'menus/epfl-menus.php';
 require_once 'epfl-multisite.php';
 // Disabled due to 'epfl-intranet' plugin use

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-servicenow-search/epfl-servicenow-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-servicenow-search/epfl-servicenow-search.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Simple display of input field to do a search in ServiceNow (in a new tab)
+ */
+function epfl_service_now_search_process_shortcode( $atts, $content = null ) {
+?>
+
+<form onsubmit="$('#snow-search').click()">
+   <input type="text" id="snow-keyword" size="30">
+   <span id="snow-search" class="dashicons dashicons-search" style="font-size:32px;cursor:pointer" onclick="window.open('https://support.epfl.ch/help?id=search&spa=1&q='+$('#snow-keyword').val(), '_blank');"></span>
+</form>
+
+
+<?php
+}
+
+add_action( 'init', function() {
+  // define the shortcode
+  add_shortcode('epfl_servicenow_search', __NAMESPACE__ . '\epfl_service_now_search_process_shortcode');
+});


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Ajout d'un shortcode `epfl_servicenow_search` qui ne fait qu'afficher un champ de recherche qui ouvre finalement un nouveau tab sur le site https://support.epfl.ch avec le texte de recherche entré.
Fonctionne avec clique sur la loupe ou en appuyant sur "enter" quand dans champ de recherche.

Et ça a cet aspect :
![image](https://user-images.githubusercontent.com/11942430/50009941-811c9700-ffb8-11e8-9534-92ba1a2d66a1.png)
