### PR TITLE
Add 404 logging plugin

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -47,3 +47,5 @@ plugins:
     config: !include pdfjs-viewer-shortcode/v1/config-plugin.yml
   - name: very-simple-meta-description
     config: !include very-simple-meta-description/v1/config-plugin.yml
+  - name: epfl-404
+    config: !include epfl-404/v1/config-plugin.yml

--- a/data/plugins/generic/epfl-404/v1/config-plugin.yml
+++ b/data/plugins/generic/epfl-404/v1/config-plugin.yml
@@ -1,0 +1,2 @@
+src: ../wp/wp-content/plugins/epfl-404
+activate: yes

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -90,7 +90,7 @@ class EPFL404
     {
         $hook = add_management_page( 'EPFL 404',
                                      'EPFL 404',
-                                     'administrator',
+                                     'manage_options',
                                      basename( __FILE__),
                                      [$this, 'render_404_list'] );
 

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -27,9 +27,6 @@ class EPFL404
 		add_action( 'admin_menu', [$this, 'setup_admin_menu'] );
 
 		add_action( 'template_redirect', [$this, 'log_404_calls'] );
-		
-		register_activation_hook(__FILE__, [$this, 'plugin_activate']);
-        register_uninstall_hook( __FILE__, [__CLASS__, 'plugin_uninstall']);
 
         /* Number of days to keep information */
         $this->nb_days_to_keep = get_option(self::NB_DAYS_TO_KEEP_OPTION, self::DAYS_TO_KEEP_DEFAULT);
@@ -50,7 +47,7 @@ class EPFL404
     /*
      * To create DB tables at plugin activation
      */
-    function plugin_activate()
+    public static function plugin_activate()
     {
         EPFL404DB::init();
 
@@ -90,7 +87,7 @@ class EPFL404
     {
         $hook = add_management_page( 'EPFL 404',
                                      'EPFL 404',
-                                     'manage_options',
+                                     'administrator',
                                      basename( __FILE__),
                                      [$this, 'render_404_list'] );
 
@@ -153,7 +150,9 @@ add_action( 'plugins_loaded', function () {
 	EPFL404::get_instance();
 } );
 
-
+/* Activation and uninstall */
+register_activation_hook(__FILE__, ['EPFL404', 'plugin_activate']);
+register_uninstall_hook( __FILE__, ['EPFL404', 'plugin_uninstall']);
 
 
 

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Plugin Name: EPFL-404
+ * Description: To log 404 pages
+ * @version: 0.1
+ * @copyright: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
+ */
+
+require_once('inc/epfl-404-db.php');
+require_once('inc/epfl-404-table.php');
+
+
+class EPFL404
+{
+    static $instance;
+
+    public $display_table = null;
+
+    // class constructor
+	public function __construct()
+	{
+		add_filter( 'set-screen-option', [__CLASS__, 'set_screen'], 10, 3 );
+		add_action( 'admin_menu', [$this, 'setup_admin_menu'] );
+
+		add_action( 'template_redirect', [$this, 'log_404_calls'] );
+		
+		register_activation_hook(__FILE__, [$this, 'plugin_activate']);
+        register_uninstall_hook( __FILE__, [__CLASS__, 'plugin_uninstall']);
+	}
+
+
+    /** Singleton instance */
+    public static function get_instance()
+    {
+        if ( ! isset( self::$instance ) )
+        {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /*
+     * To create DB tables at plugin activation
+     */
+    function plugin_activate()
+    {
+        EPFL404DB::init();
+    }
+
+    /*
+     * To delete plugin data
+     */
+    public static function plugin_uninstall()
+    {
+        EPFL404DB::drop();
+    }
+
+
+    /*
+     * Logs a 404 page request
+     */
+    function log_404_calls()
+    {
+        if(!is_404()) return;
+
+        EPFL404DB::log($_SERVER['REQUEST_URI'],
+                       isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : NULL,
+                       $_SERVER['REMOTE_ADDR']);
+    }
+
+
+    /*
+     * Create links in admin menu
+     */
+    public function setup_admin_menu()
+    {
+        $hook = add_management_page( 'EPFL 404',
+                                     'EPFL 404',
+                                     'administrator',
+                                     basename( __FILE__),
+                                     [$this, 'render_404_list'] );
+
+        add_action( 'load-' . $hook, [$this, 'screen_option'] );
+    }
+
+
+    /*
+     * Displays 404 log list in a table
+     */
+    function render_404_list()
+    {
+
+        ?>
+        <div class="wrap">
+            <h2>404 URLs List</h2>
+
+            <div id="poststuff">
+                <div id="post-body" class="metabox-holder columns-2">
+                    <div id="post-body-content">
+                        <div class="meta-box-sortables ui-sortable">
+                            <form method="post">
+                                <?php
+                                $this->display_table->prepare_items();
+                                $this->display_table->display(); ?>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <br class="clear">
+            </div>
+        </div>
+        <?PHP
+    }
+
+
+    public static function set_screen( $status, $option, $value )
+    {
+        return $value;
+    }
+
+
+    function screen_option()
+    {
+        $option = 'per_page';
+        $args   = [
+            'label'   => '404 URLs per page',
+            'default' => 50,
+            'option'  => '404_per_page'
+        ];
+
+        add_screen_option( $option, $args );
+
+        $this->display_table = new EPFL404Table();
+
+    }
+}
+
+add_action( 'plugins_loaded', function () {
+	EPFL404::get_instance();
+} );
+
+
+
+
+
+
+

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -14,10 +14,11 @@ class EPFL404
 {
     static $instance;
 
-    const DEFAULT_DAYS_TO_KEEP = 15;
+    const DAYS_TO_KEEP_DEFAULT = 15;
+    const NB_DAYS_TO_KEEP_OPTION = 'epfl-404:nb_days_to_keep';
 
     public $display_table = null;
-    public $nb_days_to_keep = self::DEFAULT_DAYS_TO_KEEP;
+    public $nb_days_to_keep = self::DAYS_TO_KEEP_DEFAULT;
 
     // class constructor
 	public function __construct()
@@ -31,7 +32,7 @@ class EPFL404
         register_uninstall_hook( __FILE__, [__CLASS__, 'plugin_uninstall']);
 
         /* Number of days to keep information */
-        $this->nb_days_to_keep = get_option('epfl-404:nb_days_to_keep', self::DEFAULT_DAYS_TO_KEEP);
+        $this->nb_days_to_keep = get_option(self::NB_DAYS_TO_KEEP_OPTION, self::DAYS_TO_KEEP_DEFAULT);
 	}
 
 
@@ -52,6 +53,9 @@ class EPFL404
     function plugin_activate()
     {
         EPFL404DB::init();
+
+        /* Add option with default value */
+        update_option(self::NB_DAYS_TO_KEEP_OPTION, self::DAYS_TO_KEEP_DEFAULT);
     }
 
     /*

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -14,7 +14,10 @@ class EPFL404
 {
     static $instance;
 
+    const DEFAULT_DAYS_TO_KEEP = 15;
+
     public $display_table = null;
+    public $nb_days_to_keep = self::DEFAULT_DAYS_TO_KEEP;
 
     // class constructor
 	public function __construct()
@@ -26,6 +29,9 @@ class EPFL404
 		
 		register_activation_hook(__FILE__, [$this, 'plugin_activate']);
         register_uninstall_hook( __FILE__, [__CLASS__, 'plugin_uninstall']);
+
+        /* Number of days to keep information */
+        $this->nb_days_to_keep = get_option('epfl-404:nb_days_to_keep', self::DEFAULT_DAYS_TO_KEEP);
 	}
 
 
@@ -67,6 +73,9 @@ class EPFL404
         EPFL404DB::log($_SERVER['REQUEST_URI'],
                        isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : NULL,
                        $_SERVER['REMOTE_ADDR']);
+
+        /* Cleaning old entries */
+        EPFL404DB::clean_old_entries($this->nb_days_to_keep);
     }
 
 
@@ -93,7 +102,7 @@ class EPFL404
 
         ?>
         <div class="wrap">
-            <h2>404 URLs List</h2>
+            <h2>404 List <small>(for last <?PHP echo $this->nb_days_to_keep; ?> days)</small></h2>
 
             <div id="poststuff">
                 <div id="post-body" class="metabox-holder columns-2">

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
@@ -2,6 +2,7 @@
 
 class EPFL404DB
 {
+    /* Table information/structure */
     const EPFL404_DB_TABLE              = 'epfl_404';
     const EPFL404_DB_FIELD_ID           = 'epfl_404_id';
     const EPFL404_DB_FIELD_URL          = 'epfl_404_url';
@@ -9,7 +10,9 @@ class EPFL404DB
     const EPFL404_DB_FIELD_SOURCE_IP    = 'epfl_404_source_ip';
     const EPFL404_DB_FIELD_DATE         = 'epfl_404_date';
 
-
+    /*
+     * Returns DB charset
+     */
     protected static function epfl_404_get_charset()
     {
         global $wpdb;
@@ -28,8 +31,10 @@ class EPFL404DB
         return $charset_collate;
     }
 
+
     /*
      * Prepare a SQL request value
+     * @param string $val
      */
     protected static function prepare_sql_value($val)
     {
@@ -76,6 +81,25 @@ class EPFL404DB
         if ( $wpdb->query( $sql ) === false )
         {
             throw new Exception( 'There was a database error uninstalling EPFL-404: ' . $wpdb->print_error() );
+        }
+    }
+
+
+    /*
+     * Cleans old records
+     * @param int $nb_days_to_keep
+     */
+    public static function clean_old_entries($nb_days_to_keep)
+    {
+        global $wpdb;
+
+        $sql = "DELETE FROM ".self::EPFL404_DB_TABLE.
+               " WHERE ".self::EPFL404_DB_FIELD_DATE."< DATE_SUB(NOW(), INTERVAL ".$nb_days_to_keep." DAY)";
+
+        if ( $wpdb->query( $sql ) === false )
+        {
+            /* We don't throw an exception this time, so website continue to works correctly, only 404 logging fails */
+            error_log("epfl-404: Error cleaning old 404 entries: ".$pwdb->print_error());
         }
     }
 

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
@@ -1,0 +1,171 @@
+<?PHP
+
+class EPFL404DB
+{
+    const EPFL404_DB_TABLE              = 'epfl_404';
+    const EPFL404_DB_FIELD_ID           = 'epfl_404_id';
+    const EPFL404_DB_FIELD_URL          = 'epfl_404_url';
+    const EPFL404_DB_FIELD_REFERER      = 'epfl_404_referer';
+    const EPFL404_DB_FIELD_SOURCE_IP    = 'epfl_404_source_ip';
+    const EPFL404_DB_FIELD_DATE         = 'epfl_404_date';
+
+
+    protected static function epfl_404_get_charset()
+    {
+        global $wpdb;
+
+        $charset_collate = '';
+        if ( ! empty( $wpdb->charset ) )
+        {
+            $charset_collate = "DEFAULT CHARACTER SET $wpdb->charset";
+        }
+
+        if ( ! empty( $wpdb->collate ) )
+        {
+            $charset_collate .= " COLLATE=$wpdb->collate";
+        }
+
+        return $charset_collate;
+    }
+
+    /*
+     * Prepare a SQL request value
+     */
+    protected static function prepare_sql_value($val)
+    {
+        return ($val===NULL) ? "NULL": "'".addslashes($val)."'";
+    }
+
+
+    /*
+     * To create DB tables at plugin activation
+     */
+    public static function init()
+    {
+        global $wpdb;
+
+        $charset_collate = EPFL404DB::epfl_404_get_charset();
+
+        //$wpdb->query("DROP TABLE ".self::EPFL404_DB_TABLE);
+
+        $sql = "CREATE TABLE IF NOT EXISTS `".self::EPFL404_DB_TABLE."` ( ".
+               "`".self::EPFL404_DB_FIELD_ID."` int(11) NOT NULL AUTO_INCREMENT, ".
+               "`".self::EPFL404_DB_FIELD_URL."` varchar(255) NOT NULL, ".
+               "`".self::EPFL404_DB_FIELD_REFERER."` varchar(255) DEFAULT NULL,".
+               "`".self::EPFL404_DB_FIELD_SOURCE_IP."` varchar(255) NOT NULL,".
+               "`".self::EPFL404_DB_FIELD_DATE."` datetime NOT NULL,".
+               "PRIMARY KEY (`".self::EPFL404_DB_FIELD_ID."`)".
+               ") ENGINE=InnoDB ".$charset_collate." AUTO_INCREMENT=1;";
+
+        if ( $wpdb->query( $sql ) === false )
+        {
+            throw new Exception( 'There was a database error installing EPFL-404: ' . $wpdb->print_error() );
+        }
+    }
+
+
+    /*
+     * Drop 404 log content from Database
+     */
+    public static function drop()
+    {
+        global $wpdb;
+
+        $sql = "DROP TABLE ".self::EPFL404_DB_TABLE;
+
+        if ( $wpdb->query( $sql ) === false )
+        {
+            throw new Exception( 'There was a database error uninstalling EPFL-404: ' . $wpdb->print_error() );
+        }
+    }
+
+
+    /*
+     * Add 404 log in DB
+     * @param string $url
+     * @param string $referer (can be NULL)
+     * @param string $ip
+     */
+    public static function log($url, $referer, $ip)
+    {
+        global $wpdb;
+
+        /* Params for SQL request */
+        $params = [
+                    self::EPFL404_DB_FIELD_ID         => "''", // auto increment
+                    self::EPFL404_DB_FIELD_URL        => self::prepare_sql_value($url),
+                    self::EPFL404_DB_FIELD_REFERER    => self::prepare_sql_value($referer),
+                    self::EPFL404_DB_FIELD_SOURCE_IP  => self::prepare_sql_value($ip),
+                    self::EPFL404_DB_FIELD_DATE       => 'NOW()'
+                  ];
+
+        /* Creating request */
+        $sql = "INSERT INTO ".self::EPFL404_DB_TABLE." (".implode(",", array_keys($params)).")".
+               "VALUES(".implode(",", $params).")";
+
+        if ( $wpdb->query( $sql ) === false )
+        {
+            /* We don't throw an exception this time, so website continue to works correctly, only 404 logging fails */
+            error_log("Error adding 404 info in database: ".$pwdb->print_error());
+        }
+    }
+
+
+    /**
+     * Retrieve 404’s data from the database
+     *
+     * @param int $per_page
+     * @param int $page_number
+     *
+     * @return mixed
+     */
+    public static function get_log( $per_page = 5, $page_number = 1 )
+    {
+
+      global $wpdb;
+
+      $sql = "SELECT * FROM ".self::EPFL404_DB_TABLE;
+
+      if ( ! empty( $_REQUEST['orderby'] ) ) {
+        $sql .= ' ORDER BY ' . esc_sql( $_REQUEST['orderby'] );
+        $sql .= ! empty( $_REQUEST['order'] ) ? ' ' . esc_sql( $_REQUEST['order'] ) : ' ASC';
+      }
+
+      $sql .= " LIMIT $per_page";
+
+      $sql .= ' OFFSET ' . ( $page_number - 1 ) * $per_page;
+
+
+      $result = $wpdb->get_results( $sql, 'ARRAY_A' );
+
+      return $result;
+    }
+
+
+    /**
+     * Delete a 404 log record.
+     *
+     * @param int $id 404 log ID
+     */
+    public static function delete_log_entry( $id )
+    {
+      global $wpdb;
+
+
+      $wpdb->delete(self::EPFL404_DB_TABLE, [ self::EPFL404_DB_FIELD_ID => $id ], [ '%d' ]);
+    }
+
+
+    /**
+     * Returns the count of records in the database.
+     *
+     * @return null|string
+     */
+    public static function record_count() {
+      global $wpdb;
+
+      $sql = "SELECT COUNT(*) FROM ".self::EPFL404_DB_TABLE;
+
+      return $wpdb->get_var( $sql );
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-table.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-table.php
@@ -1,0 +1,197 @@
+<?PHP
+
+if ( ! class_exists( 'WP_List_Table' ) )
+{
+	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+}
+
+class EPFL404Table extends WP_List_Table
+{
+
+	/** Class constructor */
+	public function __construct()
+	{
+
+		parent::__construct( [
+			'singular' => '404', //singular name of the listed records
+			'plural'   => '404s', //plural name of the listed records
+			'ajax'     => false //should this table support ajax?
+
+		] );
+
+	}
+
+
+    /** Text displayed when no customer data is available */
+    public function no_items()
+    {
+        echo "No 404 entries";
+    }
+
+
+    /**
+     * Method for name column
+     *
+     * @param array $item an array of DB data
+     *
+     * @return string
+     */
+    function column_epfl_404_url( $item )
+    {
+
+        // create a nonce
+        $delete_nonce = wp_create_nonce( 'epfl_404_delete_entry' );
+
+        $title = '<strong>' . $item[EPFL404DB::EPFL404_DB_FIELD_URL] . '</strong>';
+
+        $actions = [
+                    'delete' => sprintf('<a href="?page=%s&action=%s&404entry=%s&_wpnonce=%s">Delete</a>',
+                                        esc_attr( $_REQUEST['page'] ),
+                                        'delete',
+                                        absint( $item[EPFL404DB::EPFL404_DB_FIELD_ID] ),
+                                        $delete_nonce )
+                   ];
+
+        return $title . $this->row_actions( $actions );
+    }
+
+
+    /**
+     * Render a column when no column specific method exists.
+     *
+     * @param array $item
+     * @param string $column_name
+     *
+     * @return mixed
+     */
+    public function column_default( $item, $column_name )
+    {
+        return $item[ $column_name ];
+    }
+
+
+    /**
+     * Render the bulk edit checkbox
+     *
+     * @param array $item
+     *
+     * @return string
+     */
+    function column_cb( $item )
+    {
+        return sprintf('<input type="checkbox" name="bulk-delete[]" value="%s" />', $item[EPFL404DB::EPFL404_DB_FIELD_ID]);
+    }
+
+
+    /**
+     *  Associative array of columns
+     *
+     * @return array
+     */
+    function get_columns()
+    {
+        $columns = [
+            'cb'      => '<input type="checkbox" />',
+            EPFL404DB::EPFL404_DB_FIELD_URL         => 'URL',
+            EPFL404DB::EPFL404_DB_FIELD_REFERER     => 'Referer',
+            EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP   => 'IP',
+            EPFL404DB::EPFL404_DB_FIELD_DATE        => 'Date'
+        ];
+
+        return $columns;
+    }
+
+
+    /**
+     * Columns to make sortable.
+     *
+     * @return array
+     */
+    public function get_sortable_columns()
+    {
+        $sortable_columns = array(
+            EPFL404DB::EPFL404_DB_FIELD_URL         => array( EPFL404DB::EPFL404_DB_FIELD_URL, true ),
+            EPFL404DB::EPFL404_DB_FIELD_REFERER     => array( EPFL404DB::EPFL404_DB_FIELD_REFERER, false ),
+            EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP   => array( EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP, false ),
+            EPFL404DB::EPFL404_DB_FIELD_DATE        => array( EPFL404DB::EPFL404_DB_FIELD_DATE, false ),
+        );
+
+      return $sortable_columns;
+    }
+
+
+    /**
+     * Returns an associative array containing the bulk action
+     *
+     * @return array
+     */
+    public function get_bulk_actions()
+    {
+        return [ 'bulk-delete' => 'Delete'];
+    }
+
+
+    /**
+     * Handles data query and filter, sorting, and pagination.
+     */
+    public function prepare_items()
+    {
+
+        $this->_column_headers = $this->get_column_info();
+
+        /** Process bulk action */
+        $this->process_bulk_action();
+
+        $per_page     = $this->get_items_per_page( '404_per_page', 5 );
+        $current_page = $this->get_pagenum();
+        $total_items  = EPFL404DB::record_count();
+
+        $this->set_pagination_args( [
+            'total_items' => $total_items, //WE have to calculate the total number of items
+            'per_page'    => $per_page //WE have to determine how many items to show on a page
+        ] );
+
+        $this->items = EPFL404DB::get_log( $per_page, $current_page );
+    }
+
+
+    public function process_bulk_action()
+    {
+
+        //Detect when a bulk action is being triggered...
+        if ( 'delete' === $this->current_action() )
+        {
+
+            // In our file that handles the request, verify the nonce.
+            $nonce = esc_attr( $_REQUEST['_wpnonce'] );
+
+            if ( ! wp_verify_nonce( $nonce, 'epfl_404_delete_entry' ) )
+            {
+                die( 'Go get a life script kiddies' );
+            }
+            else
+            {
+                EPFL404DB::delete_log_entry( absint( $_GET['404entry'] ) );
+
+                return;
+            }
+
+        }
+
+        // If the delete bulk action is triggered
+        if ( ( isset( $_POST['action'] ) && $_POST['action'] == 'bulk-delete' )
+           || ( isset( $_POST['action2'] ) && $_POST['action2'] == 'bulk-delete' ))
+        {
+
+            $delete_ids = esc_sql( $_POST['bulk-delete'] );
+
+            // loop over the array of record IDs and delete them
+            foreach ( $delete_ids as $id )
+            {
+                EPFL404DB::delete_log_entry( $id );
+
+            }
+
+        }
+    }
+}

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -515,17 +515,16 @@ def export(site, wp_site_url, unit_name_or_id, to_wordpress=False, clean_wordpre
     # there are dependencies between plugins, arrange them in the right way.
     deactivated_plugins = ['mainwp-child',
                            'EPFL-Content-Filter',
-                           'epfl-intranet',
                            'feedzy-rss-feeds',
                            'remote-content-shortcode',
                            'shortcode-ui',
                            'shortcode-ui-richtext',  # This one needs to come after the previous one
                            'simple-sitemap',
                            'svg-support',
-                           'enlighter',
                            'tinymce-advanced',
                            'varnish-http-purge',
                            'epfl',
+                           'epfl-404',
                            'epfl-infoscience',
                            'wp-media-folder',
                            'pdfjs-viewer-shortcode',


### PR DESCRIPTION
**High level changes:**

1. Si activé, créé un log des 404 dans une table dédiée. Les informations suivantes sont enregistrées:
- URL demandée (et donc en 404)
- URL source ou "referer" (si disponible)
- Adresse IP source
- Date/heure
1. Possibilité de trier le tableau, de supprimer des entrées une par une
1. Table créée dans la DB à l'activation du plugin
1. Table supprimée de la DB si plugin supprimé

Les infos sur la page suivante ont été très utiles pour créer le plugin: https://www.sitepoint.com/using-wp_list_table-to-create-wordpress-admin-tables/
