### PR TITLE
get_menus(): skip exporting the ones that start with an underscore

### DIFF
--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1296,10 +1296,14 @@ class MenuRESTController
     static function get_menus () {
         $retval = [];
         foreach (MenuMapEntry::all_in_current_language() as $entry) {
-            array_push($retval, array(
-                'slug' => $entry->get_theme_location(),
-                'description'    => $entry->get_description(),
-            ));
+            $slug        = $entry->get_theme_location();
+            $description = $entry->get_description();
+            if (substr($string, 0, 1) !== '_') {
+                array_push($retval, array(
+                    'slug'        => $slug,
+                    'description' => $description
+                ));
+            }
         }
         return $retval;
     }


### PR DESCRIPTION
**From issue**: None filed

**High level changes:**

Menus from https://github.com/epfl-idevelop/wp-theme-2018/pull/165 will *not* be "refresh"ed as external menus on neighbor sites

