### PR TITLE
Improve webservices call logging

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.9
+ * @version: 1.10
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -79,6 +79,12 @@ Class Utils
 
         global $wp;
 
+        $url_details = parse_url($url);
+
+        /* Building target host name with scheme */
+        $target_host  = $url_details['scheme']."://".$url_details['host'];
+        if($url_details['port'] != "") $target_host .= ":".$url_details['port'];
+
         $adapter = new Prometheus\Storage\APC();
 
         $registry = new CollectorRegistry($adapter);
@@ -86,9 +92,13 @@ Class Utils
         $gauge = $registry->registerGauge('wp',
                                           'epfl_shortcode_duration_second',
                                           'How long a web service request takes',
-                                           ['src', 'target', 'timestamp']);
+                                           ['src', 'target_host', 'target_path', 'target_query', 'timestamp']);
         /* Timestamp is given in millisec (C2C prerequisite) */
-        $gauge->set($duration, [home_url( $wp->request ), $url, floor(microtime(true)*1000)]);
+        $gauge->set($duration, [home_url( $wp->request ),
+                                $target_host,
+                                $url_details['path'],
+                                $url_details['query'],
+                                floor(microtime(true)*1000)]);
 
     }
 }


### PR DESCRIPTION
1. Demande de C2C de split l'info `target` en 3 éléments: 
- `target_host` (ex: https://people.epfl.ch)
- `target_path` (ex: /cgi-bin/wsgetpeople/)
- `target_query`(ex: units=IDEVING&lang=fr)
Ceci permettra de plus facilement faire des filtres dans Kibana et aussi ça rendra les graphiques plus lisibles. 

