### PR TITLE
Wwp 5 minute cache timeout

### DIFF
--- a/data/plugins/generic/cache-control/v1/config-plugin.yml
+++ b/data/plugins/generic/cache-control/v1/config-plugin.yml
@@ -6,3 +6,7 @@ tables:
     option_id: 379
     option_name: cache_control_front_page_max_age
     option_value: '300'
+  - autoload: 'yes'
+    option_id: 380
+    option_name: cache_control_pages_max_age
+    option_value: '300'

--- a/data/plugins/generic/cache-control/v1/config-plugin.yml
+++ b/data/plugins/generic/cache-control/v1/config-plugin.yml
@@ -5,4 +5,4 @@ tables:
   - autoload: 'yes'
     option_id: 379
     option_name: cache_control_front_page_max_age
-    option_value: '3600'
+    option_value: '300'


### PR DESCRIPTION
**From issue**:  None filed

**High level changes:**

Page updates will take less time to propagate to your phone.

**Low level changes:**

Line up page (and homepage) Cache-Control max-age to 5 minutes

N.B.: this change was already pushed to www.epfl.ch as an "Airbus" (large canary).
