### PR TITLE
Add  WP option exist check (2018)

### DIFF
--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -102,6 +102,17 @@ class WPConfig:
                 else:
                     yield WPResult(wp_config.wp_site.path, settings.WP_SITE_INSTALL_KO, "", "", "", "", "")
 
+    def wp_option_exists(self, option_name):
+        """
+        Tells if an option exists in WordPress. This check can be done before we execute WPCLI to retrieve option
+        value because if it doesn't exists, exit code will be 1 and an exception will be raised...
+
+        :param option_name: option to check
+        :return: True|False
+        """
+        command = "option list --search={} --format=csv --field=option_name".format(option_name)
+        return self.run_wp_cli(command) is not True
+
     def run_wp_cli(self, command, encoding=sys.getdefaultencoding(), pipe_input=None, extra_options=None):
         """
         Execute a WP-CLI command. The command doesn't have to start with 'wp '. It will be added automatically, and

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -128,22 +128,33 @@ class WPGenerator:
         # Site category is not given
         if 'category' not in self._site_params:
 
-            # We will use default value for category
-            category = settings.DEFAULT_WP_SITE_CATEGORY
-
             # We try to get it from DB in case of website already exists
             if self.wp_config.is_installed:
-                command = "option get {}".format(settings.OPTION_WP_SITE_CATEGORY)
-                site_category = self.run_wp_cli(command)
 
-                # If we found something in DB
-                if site_category:
-                    category = site_category
-                else:
-                    # Because we don't have info in DB, we add a default value
+                category = None
+
+                # If option exists in DB
+                if self.wp_config.wp_option_exists(settings.OPTION_WP_SITE_CATEGORY):
+
+                    command = "option get {}".format(settings.OPTION_WP_SITE_CATEGORY)
+                    site_category = self.run_wp_cli(command)
+
+                    # If option is not empty
+                    if site_category != "":
+                        category = site_category
+
+                # Because we don't have info in DB, we add a default value
+                if category is None:
+                    # We will use default value for category
+                    category = settings.DEFAULT_WP_SITE_CATEGORY
+
                     command = "option update {} '{}'".format(settings.OPTION_WP_SITE_CATEGORY,
                                                              settings.DEFAULT_WP_SITE_CATEGORY)
                     self.run_wp_cli(command)
+
+            else:  # WordPress is not installed
+                # We will use default value for category
+                category = settings.DEFAULT_WP_SITE_CATEGORY
 
             # We initialize value
             self._site_params['category'] = category


### PR DESCRIPTION
**High level changes:**

Equivalent 2018 de la PR #860 

1. Il apparaît que lorsque l'on essaie de récupérer le contenu d'une option inexistante (via `wp option get...`), cela fait que la `wp` sort avec le code "1" (erreur). Donc une exception est levée. Ceci n'a jamais été rencontré par le passé car toutes les options que l'on accédait existaient. Mais depuis la PR #844 , on accédait potentiellement une option inexistante ("epfl:site_category") et il a été constaté qu'une erreur pouvait être générée durant l'effacement (`clean`) d'un site n'ayant pas cette option.
Ajout donc d'une fonction permettant de définir si une option existe dans WP avant de tenter de récupérer son contenu.

*Note*
Vu que le problème mentionné n'a été constaté qu'à un seul endroit du code, il a volontairement été choisi de ne pas aller ajouter des checks d'existance d'option avant tous les endroits où on allait lire celles-ci. Ceci entrainerait une modification du code assez conséquente et pas forcément nécessaire