### PR TITLE
Add 'QA' category for migration-wp sites

### DIFF
--- a/data/plugins/specific/QA/EPFL-WP-Settings-Add_Jira_collector_to_page-master/config-plugin.yml
+++ b/data/plugins/specific/QA/EPFL-WP-Settings-Add_Jira_collector_to_page-master/config-plugin.yml
@@ -1,0 +1,2 @@
+src: specific/QA/EPFL-WP-Settings-Add_Jira_collector_to_page-master/jira_feedback.zip
+activate: yes

--- a/data/plugins/specific/QA/plugin-list.yml
+++ b/data/plugins/specific/QA/plugin-list.yml
@@ -1,0 +1,3 @@
+plugins:
+  - name: EPFL-WP-Settings-Add_Jira_collector_to_page-master
+    config: !include EPFL-WP-Settings-Add_Jira_collector_to_page-master/config-plugin.yml


### PR DESCRIPTION
**High level changes:**

1. Au lieu de manuellement modifier à chaque fois le fichier `data/plugins/generic/plugin-list.yml` sur "int" afin d'ajouter le plugin permettant de faire des feedbacks, création d'une catégorie de site appelée "QA" (comme pour "Inside") et dans laquelle on installerait le plugin de feedback.

**Une fois la PR mergée, effectuer les opérations suivantes **
1. Se connecter sur le pod "int"
> vjahia
git checkout -- ../data/plugins/generic/config-lot1.yml
git pull
cd ../data/plugins/
mv generic/EPFL-WP-Settings-Add_Jira_collector_to_page-master/v1/jira_feedback.zip specific/QA/EPFL-WP-Settings-Add_Jira_collector_to_page-master/
rm -rf generic/EPFL-WP-Settings-Add_Jira_collector_to_page-master

2. Aller sur la source de vérité, onglet "Sites WP INT - Migrations" et changer la valeur qui est dans la colonne `category` afin de mettre "QA" à la place de "GeneralPublic"
3. Mettre à jour la procédure de migration en production depuis WordPress pour dire qu'il faut remettre "GeneralPublic" dans la source de vérité