### PR TITLE
Allow compression when creating tar file

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -319,7 +319,10 @@ class Utils(object):
     @staticmethod
     def generate_tar_file(tar_file_path, tar_listed_inc_file_path, source_path):
         """
-        Generate a tar file from a WordPress installation.
+        Generate a tar file from a WordPress installation. If compression is needed, just add the appropriate
+        extension at the end, ex: file.tar.gz
+
+
         Doing a simple tar file backups everything in the folder and also in subfolders. This can be a problem in case
         of multiple WordPress installation in subfolders of folder we have to backup.
         To avoid to backup those WordPress installations, we'll first list files/folders to backup (using "find") and
@@ -343,12 +346,12 @@ class Utils(object):
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
         cmd_all_others = 'find {0} -print | grep "{0}/wp-"'.format(source_path)
 
-        command = "{{ {} ; {}; }} | tar --create --no-check-device --file={} --listed-incremental={} -T -".format(
-            cmd_first_level_files,
-            cmd_all_others,
-            tar_file_path,
-            tar_listed_inc_file_path
-        )
+        # --auto-compress is used to automatically detect wished file compression depending on given file extension
+        command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
+                  "--listed-incremental={} -T -".format(cmd_first_level_files,
+                                                        cmd_all_others,
+                                                        tar_file_path,
+                                                        tar_listed_inc_file_path)
         return Utils.run_command(command)
 
     @staticmethod

--- a/src/wordpress/backup.py
+++ b/src/wordpress/backup.py
@@ -77,7 +77,7 @@ class WPBackup:
         # set filenames
         self.tarfile = os.path.join(
                 self.path,
-                "_".join((self.timestamp, self.backup_pattern)) + ".tar")
+                "_".join((self.timestamp, self.backup_pattern)) + ".tar.gz")
         self.sqlfile = os.path.join(
                 self.path,
                 "_".join((self.timestamp, self.backup_pattern)) + ".sql")


### PR DESCRIPTION
**High level changes:**

1. C'est sympa de faire des backups mais la taille utilisée par ceux-ci est enoOOOorme ! ... donc, bah, aujout de la possibilité de simplement compresser le fichier TAR créé.

**NOTE**
1. Ne pas oublier de contacter C2C pour leur dire de prévoir un peu de CPU sur le POD cron histoire de pouvoir faire la compression.
1. Tenter de compresser les backups existants pour gagner de la place est un peu useless car finalement, la correction d'un bug (https://github.com/epfl-idevelop/python-rotate-backups/commit/a9f728f49e013c199aec1cd9b079a9a211aba13d ) qui faisait que les vieux backup n'étaient pas effacés + le fait que les nouveaux seront compressés devrait nous permettre de ne pas avoir besoin de plus d'espace sur le volume NAS de backup, ça va se réguler automatiquement tout seul.
