### PR TITLE
Change way to check if index exists to avoid PHP Notice

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.12
+ * @version: 1.13
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -325,7 +325,7 @@ class MenuItemBag
                  $ancestor = $this->get_parent($ancestor))
             {
                 $ancestor_id = $this->_get_id($ancestor);
-                if ($ancestor_ids[$ancestor_id]) {
+                if (isset($ancestor_ids[$ancestor_id])){
                     throw new TreeLoopError($ancestor_ids);
                 } else {
                     $ancestor_ids[$ancestor_id] = 1;


### PR DESCRIPTION
**High level changes:**

1. Utilisation d'un `isset()` pour contrôler l'état d'une clef de tableau. A voir si ça convient ou s'il faudrait plutôt utiliser `array_key_exists()`
A priori, le changement devrait faire qu'il y a le même comportement mais sans générer des `PHP Notice` dans les logs si on active ceux-ci.