### PR TITLE
Add webservice call logging

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -79,3 +79,5 @@ plugins:
     config: !include cache-control/config-plugin.yml
   - name: epfl-404
     config: !include epfl-404/config-plugin.yml
+  - name: epfl-stats
+    config: !include epfl-stats/config-plugin.yml

--- a/data/plugins/generic/epfl-stats/config-plugin.yml
+++ b/data/plugins/generic/epfl-stats/config-plugin.yml
@@ -1,0 +1,2 @@
+src: ../wp/wp-content/plugins/epfl-stats
+activate: yes

--- a/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL Infoscience shortcode
  * Plugin URI: https://github.com/jaepetto/EPFL-SC-Infoscience
  * Description: provides a shortcode to dispay results from Infoscience
- * Version: 1.2
+ * Version: 1.3
  * Author: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
  * Contributors: LuluTchab, GregLeBarbar
@@ -42,7 +42,16 @@ function epfl_infoscience_process_shortcode( $attributes, $content = null )
     if ( false === $result ){
         if ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'infoscience.epfl.ch' ) == 0 && epfl_infoscience_url_exists( $url ) ) {
 
+            $start = microtime(true);
             $response = wp_remote_get( $url );
+            $end = microtime(true);
+
+            // If there is some mechanism to log webservice call, we do it
+            if(has_action('epfl_log_webservice_call'))
+            {
+                do_action('epfl_log_webservice_call', $url, $end-$start);
+            }
+
             $page = wp_remote_retrieve_body( $response );
 
             // wrap the page

--- a/data/wp/wp-content/plugins/epfl-memento/epfl-memento.php
+++ b/data/wp/wp-content/plugins/epfl-memento/epfl-memento.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: EPFL Memento shortcode
  * Description: provides a shortcode to display events feed
- * @version: 1.3
+ * @version: 1.4
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  *
  * Text Domain: epfl-memento

--- a/data/wp/wp-content/plugins/epfl-memento/utils.php
+++ b/data/wp/wp-content/plugins/epfl-memento/utils.php
@@ -16,7 +16,15 @@ Class EventUtils
      */
     public static function get_items(string $url) {
 
-        $response = wp_remote_get($url);
+        $start = microtime(true);
+        $response = wp_remote_get( $url );
+        $end = microtime(true);
+
+        // If there is some mechanism to log webservice call, we do it
+        if(has_action('epfl_log_webservice_call'))
+        {
+            do_action('epfl_log_webservice_call', $url, $end-$start);
+        }
 
         if (is_array($response)) {
             $header = $response['headers']; // array of http header lines

--- a/data/wp/wp-content/plugins/epfl-news/epfl-news.php
+++ b/data/wp/wp-content/plugins/epfl-news/epfl-news.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL News shortcode
  * Description: provides a shortcode to display news feed
- * @version: 1.1
+ * @version: 1.2
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl-news/utils.php
+++ b/data/wp/wp-content/plugins/epfl-news/utils.php
@@ -16,7 +16,15 @@ Class NewsUtils
      */
     public static function get_items(string $url) {
 
-        $response = wp_remote_get($url);
+        $start = microtime(true);
+        $response = wp_remote_get( $url );
+        $end = microtime(true);
+
+        // If there is some mechanism to log webservice call, we do it
+        if(has_action('epfl_log_webservice_call'))
+        {
+            do_action('epfl_log_webservice_call', $url, $end-$start);
+        }
 
         if (is_array($response)) {
                 $header = $response['headers']; // array of http header lines

--- a/data/wp/wp-content/plugins/epfl-people/epfl-people.php
+++ b/data/wp/wp-content/plugins/epfl-people/epfl-people.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL People shortcode
  * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
  * Description: provides a shortcode to display results from People
- * Version: 1.2
+ * Version: 1.3
  * Author: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
  * Contributors: LuluTchab, GregLeBarbar
@@ -54,7 +54,16 @@ function epfl_people_process_shortcode( $attributes, $content = null )
         if ( ( strcasecmp( parse_url( $url, PHP_URL_HOST ), 'people.epfl.ch' ) == 0 or strcasecmp( parse_url( $url, PHP_URL_HOST ), 'test-people.epfl.ch' ) == 0 ) && epfl_people_url_exists( $url ) ) {
 
             // Get the content of the page
+            $start = microtime(true);
             $response = wp_remote_get( $url );
+            $end = microtime(true);
+
+            // If there is some mechanism to log webservice call, we do it
+            if(has_action('epfl_log_webservice_call'))
+            {
+                do_action('epfl_log_webservice_call', $url, $end-$start);
+            }
+
             $page = wp_remote_retrieve_body( $response );
 
             // cache the result

--- a/data/wp/wp-content/plugins/epfl-scienceqa/epfl-scienceqa.php
+++ b/data/wp/wp-content/plugins/epfl-scienceqa/epfl-scienceqa.php
@@ -5,7 +5,7 @@
  * Author:          Loïc Cattani
  * Text Domain:     epfl-scienceqa
  * Domain Path:     /languages
- * Version:         1.1
+ * Version:         1.2
  * Copyright:      Copyright (c) 2018 Loïc Cattani
  */
 

--- a/data/wp/wp-content/plugins/epfl-scienceqa/utils.php
+++ b/data/wp/wp-content/plugins/epfl-scienceqa/utils.php
@@ -9,7 +9,15 @@ Class ScienceQAUtils
    */
   public static function get_items(string $url)
   {
-    $response = wp_remote_get($url);
+    $start = microtime(true);
+    $response = wp_remote_get( $url );
+    $end = microtime(true);
+
+    // If there is some mechanism to log webservice call, we do it
+    if(has_action('epfl_log_webservice_call'))
+    {
+        do_action('epfl_log_webservice_call', $url, $end-$start);
+    }
     
     if (is_wp_error($response))
     {

--- a/data/wp/wp-content/plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/plugins/epfl-stats/epfl-stats.php
@@ -1,0 +1,52 @@
+<?PHP
+/**
+ * Plugin Name: EPFL-Stats
+ * Description: Provide a filter to allow others plugins to log duration of their external call to webservices
+ * @version: 1.0
+ * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
+ */
+
+require_once 'lib/prometheus.php';
+
+use Prometheus\CollectorRegistry;
+
+/*
+    Save a webservice call duration including source page and timestamp on which call occurs
+
+    @param $url         -> Webservice URL call
+    @param $duration    -> webservice call duration (microsec)
+*/
+function epfl_stats_perf($url, $duration)
+{
+
+    global $wp;
+
+    $url_details = parse_url($url);
+
+    /* Building target host name with scheme */
+    $target_host  = $url_details['scheme']."://".$url_details['host'];
+    if(array_key_exists('port', $url_details) && $url_details['port'] != "") $target_host .= ":".$url_details['port'];
+
+    $query = (array_key_exists('query', $url_details))?$url_details['query']:"";
+
+    $adapter = new Prometheus\Storage\APC();
+
+    $registry = new CollectorRegistry($adapter);
+
+    $gauge = $registry->registerGauge('wp',
+                                      'epfl_shortcode_duration_second',
+                                      'How long a web service request takes',
+                                       ['src', 'target_host', 'target_path', 'target_query', 'timestamp']);
+    /* Timestamp is given in millisec (C2C prerequisite) */
+    $gauge->set($duration, [home_url( $wp->request ),
+                            $target_host,
+                            $url_details['path'],
+                            $query,
+                            floor(microtime(true)*1000)]);
+
+    error_log('logging URL $url\n');
+
+}
+
+// We register a new action so others plugins can use it to log webservice call duration
+add_action('epfl_log_webservice_call', 'epfl_stats_perf', 10, 2);

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Collector.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Collector.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Prometheus;
+
+
+use Prometheus\Storage\Adapter;
+
+abstract class Collector
+{
+    const RE_METRIC_LABEL_NAME = '/^[a-zA-Z_:][a-zA-Z0-9_:]*$/';
+
+    protected $storageAdapter;
+    protected $name;
+    protected $help;
+    protected $labels;
+
+    /**
+     * @param Adapter $storageAdapter
+     * @param string $namespace
+     * @param string $name
+     * @param string $help
+     * @param array $labels
+     */
+    public function __construct(Adapter $storageAdapter, $namespace, $name, $help, $labels = array())
+    {
+        $this->storageAdapter = $storageAdapter;
+        $metricName = ($namespace ? $namespace . '_' : '') . $name;
+        if (!preg_match(self::RE_METRIC_LABEL_NAME, $metricName)) {
+            throw new \InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
+        }
+        $this->name = $metricName;
+        $this->help = $help;
+        foreach ($labels as $label) {
+            if (!preg_match(self::RE_METRIC_LABEL_NAME, $label)) {
+                throw new \InvalidArgumentException("Invalid label name: '" . $label . "'");
+            }
+        }
+        $this->labels = $labels;
+    }
+
+    /**
+     * @return string
+     */
+    public abstract function getType();
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getLabelNames()
+    {
+        return $this->labels;
+    }
+
+    public function getHelp()
+    {
+        return $this->help;
+    }
+
+    public function getKey()
+    {
+        return sha1($this->getName() . serialize($this->getLabelNames()));
+    }
+
+    /**
+     * @param $labels
+     */
+    protected function assertLabelsAreDefinedCorrectly($labels)
+    {
+        if (count($labels) != count($this->labels)) {
+            throw new \InvalidArgumentException(sprintf('Labels are not defined correctly: ', print_r($labels, true)));
+        }
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/CollectorRegistry.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/CollectorRegistry.php
@@ -1,0 +1,235 @@
+<?php
+
+
+namespace Prometheus;
+
+
+use Prometheus\Exception\MetricNotFoundException;
+use Prometheus\Exception\MetricsRegistrationException;
+use Prometheus\Storage\Adapter;
+use Prometheus\Storage\Redis;
+
+class CollectorRegistry
+{
+    /**
+     * @var CollectorRegistry
+     */
+    private static $defaultRegistry;
+
+    /**
+     * @var Adapter
+     */
+    private $storageAdapter;
+    /**
+     * @var Gauge[]
+     */
+    private $gauges = array();
+    /**
+     * @var Counter[]
+     */
+    private $counters = array();
+    /**
+     * @var Histogram[]
+     */
+    private $histograms = array();
+
+    public function __construct(Adapter $redisAdapter)
+    {
+        $this->storageAdapter = $redisAdapter;
+    }
+
+    /**
+     * @return CollectorRegistry
+     */
+    public static function getDefault()
+    {
+        if (!self::$defaultRegistry) {
+            return self::$defaultRegistry = new static(new Redis());
+        }
+        return self::$defaultRegistry;
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function getMetricFamilySamples()
+    {
+        return $this->storageAdapter->collect();
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array $labels e.g. ['controller', 'action']
+     * @return Gauge
+     * @throws MetricsRegistrationException
+     */
+    public function registerGauge($namespace, $name, $help, $labels = array())
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (isset($this->gauges[$metricIdentifier])) {
+            throw new MetricsRegistrationException("Metric already registered");
+        }
+        $this->gauges[$metricIdentifier] = new Gauge(
+            $this->storageAdapter,
+            $namespace,
+            $name,
+            $help,
+            $labels
+        );
+        return $this->gauges[$metricIdentifier];
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     * @return Gauge
+     * @throws MetricNotFoundException
+     */
+    public function getGauge($namespace, $name)
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (!isset($this->gauges[$metricIdentifier])) {
+            throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
+        }
+        return $this->gauges[$metricIdentifier];
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array $labels e.g. ['controller', 'action']
+     * @return Gauge
+     */
+    public function getOrRegisterGauge($namespace, $name, $help, $labels = array())
+    {
+        try {
+            $gauge = $this->getGauge($namespace, $name);
+        } catch (MetricNotFoundException $e) {
+            $gauge = $this->registerGauge($namespace, $name, $help, $labels);
+        }
+        return $gauge;
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array $labels e.g. ['controller', 'action']
+     * @return Counter
+     * @throws MetricsRegistrationException
+     */
+    public function registerCounter($namespace, $name, $help, $labels = array())
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (isset($this->counters[$metricIdentifier])) {
+            throw new MetricsRegistrationException("Metric already registered");
+        }
+        $this->counters[$metricIdentifier] = new Counter(
+            $this->storageAdapter,
+            $namespace,
+            $name,
+            $help,
+            $labels
+        );
+        return $this->counters[self::metricIdentifier($namespace, $name)];
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     * @return Counter
+     * @throws MetricNotFoundException
+     */
+    public function getCounter($namespace, $name)
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (!isset($this->counters[$metricIdentifier])) {
+            throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
+        }
+        return $this->counters[self::metricIdentifier($namespace, $name)];
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array $labels e.g. ['controller', 'action']
+     * @return Counter
+     */
+    public function getOrRegisterCounter($namespace, $name, $help, $labels = array())
+    {
+        try {
+            $counter = $this->getCounter($namespace, $name);
+        } catch (MetricNotFoundException $e) {
+            $counter = $this->registerCounter($namespace, $name, $help, $labels);
+        }
+        return $counter;
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array $labels e.g. ['controller', 'action']
+     * @param array $buckets e.g. [100, 200, 300]
+     * @return Histogram
+     * @throws MetricsRegistrationException
+     */
+    public function registerHistogram($namespace, $name, $help, $labels = array(), $buckets = null)
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (isset($this->histograms[$metricIdentifier])) {
+            throw new MetricsRegistrationException("Metric already registered");
+        }
+        $this->histograms[$metricIdentifier] = new Histogram(
+            $this->storageAdapter,
+            $namespace,
+            $name,
+            $help,
+            $labels,
+            $buckets
+        );
+        return $this->histograms[$metricIdentifier];
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     * @return Histogram
+     * @throws MetricNotFoundException
+     */
+    public function getHistogram($namespace, $name)
+    {
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (!isset($this->histograms[$metricIdentifier])) {
+            throw new MetricNotFoundException("Metric not found:" . $metricIdentifier);
+        }
+        return $this->histograms[self::metricIdentifier($namespace, $name)];
+    }
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array $labels e.g. ['controller', 'action']
+     * @param array $buckets e.g. [100, 200, 300]
+     * @return Histogram
+     */
+    public function getOrRegisterHistogram($namespace, $name, $help, $labels = array(), $buckets = null)
+    {
+        try {
+            $histogram = $this->getHistogram($namespace, $name);
+        } catch (MetricNotFoundException $e) {
+            $histogram = $this->registerHistogram($namespace, $name, $help, $labels, $buckets);
+        }
+        return $histogram;
+    }
+
+    private static function metricIdentifier($namespace, $name)
+    {
+        return $namespace . ":" . $name;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Counter.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Counter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Prometheus;
+
+
+use Prometheus\Storage\Adapter;
+
+class Counter extends Collector
+{
+    const TYPE = 'counter';
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return self::TYPE;
+    }
+
+    /**
+     * @param array $labels e.g. ['status', 'opcode']
+     */
+    public function inc(array $labels = array())
+    {
+        $this->incBy(1, $labels);
+    }
+
+    /**
+     * @param int $count e.g. 2
+     * @param array $labels e.g. ['status', 'opcode']
+     */
+    public function incBy($count, array $labels = array())
+    {
+        $this->assertLabelsAreDefinedCorrectly($labels);
+
+        $this->storageAdapter->updateCounter(
+            array(
+                'name' => $this->getName(),
+                'help' => $this->getHelp(),
+                'type' => $this->getType(),
+                'labelNames' => $this->getLabelNames(),
+                'labelValues' => $labels,
+                'value' => $count,
+                'command' => Adapter::COMMAND_INCREMENT_INTEGER
+            )
+        );
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/MetricNotFoundException.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/MetricNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Prometheus\Exception;
+
+
+/**
+ * Exception thrown if a metric can't be found in the CollectorRegistry.
+ */
+class MetricNotFoundException extends \Exception
+{
+
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/MetricsRegistrationException.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/MetricsRegistrationException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Prometheus\Exception;
+
+
+/**
+ * Exception thrown if an error occurs during metrics registration.
+ */
+class MetricsRegistrationException extends \Exception
+{
+
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/StorageException.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Exception/StorageException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Prometheus\Exception;
+
+
+/**
+ * Exception thrown if an error occurs during metrics storage.
+ */
+class StorageException extends \Exception
+{
+
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Gauge.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Gauge.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Prometheus;
+
+
+use Prometheus\Storage\Adapter;
+
+class Gauge extends Collector
+{
+    const TYPE = 'gauge';
+
+    /**
+     * @param double $value e.g. 123
+     * @param array $labels e.g. ['status', 'opcode']
+     */
+    public function set($value, $labels = array())
+    {
+        $this->assertLabelsAreDefinedCorrectly($labels);
+
+        $this->storageAdapter->updateGauge(
+            array(
+                'name' => $this->getName(),
+                'help' => $this->getHelp(),
+                'type' => $this->getType(),
+                'labelNames' => $this->getLabelNames(),
+                'labelValues' => $labels,
+                'value' => $value,
+                'command' => Adapter::COMMAND_SET
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return self::TYPE;
+    }
+
+    public function inc($labels = array())
+    {
+        $this->incBy(1, $labels);
+    }
+
+    public function incBy($value, $labels = array())
+    {
+        $this->assertLabelsAreDefinedCorrectly($labels);
+
+        $this->storageAdapter->updateGauge(
+            array(
+                'name' => $this->getName(),
+                'help' => $this->getHelp(),
+                'type' => $this->getType(),
+                'labelNames' => $this->getLabelNames(),
+                'labelValues' => $labels,
+                'value' => $value,
+                'command' => Adapter::COMMAND_INCREMENT_FLOAT
+            )
+        );
+    }
+
+    public function dec($labels = array())
+    {
+        $this->decBy(1, $labels);
+    }
+
+    public function decBy($value, $labels = array())
+    {
+        $this->incBy(-$value, $labels);
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Histogram.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Histogram.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Prometheus;
+
+
+use Prometheus\Storage\Adapter;
+
+class Histogram extends Collector
+{
+    const TYPE = 'histogram';
+
+    private $buckets;
+
+    /**
+     * @param Adapter $adapter
+     * @param string $namespace
+     * @param string $name
+     * @param string $help
+     * @param array $labels
+     * @param array $buckets
+     */
+    public function __construct(Adapter $adapter, $namespace, $name, $help, $labels = array(), $buckets = null)
+    {
+        parent::__construct($adapter, $namespace, $name, $help, $labels);
+
+        if (null === $buckets) {
+            $buckets = self::getDefaultBuckets();
+        }
+
+        if (0 == count($buckets)) {
+            throw new \InvalidArgumentException("Histogram must have at least one bucket.");
+        }
+
+        for ($i = 0; $i < count($buckets) - 1; $i++) {
+            if ($buckets[$i] >= $buckets[$i + 1]) {
+                throw new \InvalidArgumentException(
+                    "Histogram buckets must be in increasing order: " .
+                    $buckets[$i] . " >= " . $buckets[$i + 1]
+                );
+            }
+        }
+        foreach ($labels as $label) {
+            if ($label === 'le') {
+                throw new \InvalidArgumentException("Histogram cannot have a label named 'le'.");
+            }
+        }
+        $this->buckets = $buckets;
+    }
+
+    /**
+     * List of default buckets suitable for typical web application latency metrics
+     * @return array
+     */
+    public static function getDefaultBuckets()
+    {
+        return array(
+            0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0
+        );
+    }
+
+    /**
+     * @param double $value e.g. 123
+     * @param array $labels e.g. ['status', 'opcode']
+     */
+    public function observe($value, $labels = array())
+    {
+        $this->assertLabelsAreDefinedCorrectly($labels);
+
+        $this->storageAdapter->updateHistogram(
+            array(
+                'value' => $value,
+                'name' => $this->getName(),
+                'help' => $this->getHelp(),
+                'type' => $this->getType(),
+                'labelNames' => $this->getLabelNames(),
+                'labelValues' => $labels,
+                'buckets' => $this->buckets,
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return self::TYPE;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/MetricFamilySamples.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/MetricFamilySamples.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Prometheus;
+
+class MetricFamilySamples
+{
+    private $name;
+    private $type;
+    private $help;
+    private $labelNames;
+    private $samples = array();
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        $this->name = $data['name'];
+        $this->type = $data['type'];
+        $this->help = $data['help'];
+        $this->labelNames = $data['labelNames'];
+        foreach ($data['samples'] as $sampleData) {
+            $this->samples[] = new Sample($sampleData);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHelp()
+    {
+        return $this->help;
+    }
+
+    /**
+     * @return Sample[]
+     */
+    public function getSamples()
+    {
+        return $this->samples;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLabelNames()
+    {
+        return $this->labelNames;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLabelNames()
+    {
+        return !empty($this->labelNames);
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/PushGateway.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/PushGateway.php
@@ -1,0 +1,91 @@
+<?php
+
+
+namespace Prometheus;
+
+
+use GuzzleHttp\Client;
+
+class PushGateway
+{
+    private $address;
+
+    /**
+     * PushGateway constructor.
+     * @param $address string host:port of the push gateway
+     */
+    public function __construct($address)
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * Pushes all metrics in a Collector, replacing all those with the same job.
+     * Uses HTTP PUT.
+     * @param CollectorRegistry $collectorRegistry
+     * @param $job
+     * @param $groupingKey
+     */
+    public function push(CollectorRegistry $collectorRegistry, $job, $groupingKey = null)
+    {
+        $this->doRequest($collectorRegistry, $job, $groupingKey, 'put');
+    }
+
+    /**
+     * Pushes all metrics in a Collector, replacing only previously pushed metrics of the same name and job.
+     * Uses HTTP POST.
+     * @param CollectorRegistry $collectorRegistry
+     * @param $job
+     * @param $groupingKey
+     */
+    public function pushAdd(CollectorRegistry $collectorRegistry, $job, $groupingKey = null)
+    {
+        $this->doRequest($collectorRegistry, $job, $groupingKey, 'post');
+    }
+
+    /**
+     * Deletes metrics from the Pushgateway.
+     * Uses HTTP POST.
+     * @param $job
+     * @param $groupingKey
+     */
+    public function delete($job, $groupingKey = null)
+    {
+        $this->doRequest(null, $job, $groupingKey, 'delete');
+    }
+
+    /**
+     * @param CollectorRegistry $collectorRegistry
+     * @param $job
+     * @param $groupingKey
+     * @param $method
+     */
+    private function doRequest(CollectorRegistry $collectorRegistry, $job, $groupingKey, $method)
+    {
+        $url = "http://" . $this->address . "/metrics/job/" . $job;
+        if (!empty($groupingKey)) {
+            foreach ($groupingKey as $label => $value) {
+                $url .= "/" . $label . "/" . $value;
+            }
+        }
+        $client = new Client();
+        $requestOptions = array(
+            'headers' => array(
+                'Content-Type' => RenderTextFormat::MIME_TYPE
+            ),
+            'connect_timeout' => 10,
+            'timeout' => 20,
+        );
+        if ($method != 'delete') {
+            $renderer = new RenderTextFormat();
+            $requestOptions['body'] = $renderer->render($collectorRegistry->getMetricFamilySamples());
+        }
+        $response = $client->request($method, $url, $requestOptions);
+        $statusCode = $response->getStatusCode();
+        if ($statusCode != 202) {
+            $msg = "Unexpected status code " . $statusCode . " received from pushgateway " . $this->address . ": " . $response->getBody();
+            throw new \RuntimeException($msg);
+        }
+    }
+
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/RenderTextFormat.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/RenderTextFormat.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Prometheus;
+
+
+class RenderTextFormat
+{
+    const MIME_TYPE = 'text/plain; version=0.0.4';
+
+    /**
+     * @param MetricFamilySamples[] $metrics
+     * @return string
+     */
+    public function render(array $metrics)
+    {
+        usort($metrics, function(MetricFamilySamples $a, MetricFamilySamples $b)
+        {
+            return strcmp($a->getName(), $b->getName());
+        });
+
+        $lines = array();
+
+        foreach ($metrics as $metric) {
+            $lines[] = "# HELP " . $metric->getName() . " {$metric->getHelp()}";
+            $lines[] = "# TYPE " . $metric->getName() . " {$metric->getType()}";
+            foreach ($metric->getSamples() as $sample) {
+                $lines[] = $this->renderSample($metric, $sample);
+            }
+        }
+        return implode("\n", $lines) . "\n";
+    }
+
+    private function renderSample(MetricFamilySamples $metric, Sample $sample)
+    {
+        $escapedLabels = array();
+
+        $labelNames = $metric->getLabelNames();
+        if ($metric->hasLabelNames() || $sample->hasLabelNames()) {
+            $labels = array_combine(array_merge($labelNames, $sample->getLabelNames()), $sample->getLabelValues());
+            foreach ($labels as $labelName => $labelValue) {
+                $escapedLabels[] = $labelName . '="' . $this->escapeLabelValue($labelValue) . '"';
+            }
+            return $sample->getName() . '{' . implode(',', $escapedLabels) . '} ' . $sample->getValue();
+        }
+        return $sample->getName() . ' ' . $sample->getValue();
+    }
+
+    private function escapeLabelValue($v)
+    {
+        $v = str_replace("\\", "\\\\", $v);
+        $v = str_replace("\n", "\\n", $v);
+        $v = str_replace("\"", "\\\"", $v);
+        return $v;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Sample.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Sample.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Prometheus;
+
+
+class Sample
+{
+    private $name;
+    private $labelNames;
+    private $labelValues;
+    private $value;
+
+    public function __construct(array $data)
+    {
+        $this->name = $data['name'];
+        $this->labelNames = $data['labelNames'];
+        $this->labelValues = $data['labelValues'];
+        $this->value = $data['value'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLabelNames()
+    {
+        return (array)$this->labelNames;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLabelValues()
+    {
+        return (array)$this->labelValues;
+    }
+
+    /**
+     * @return int|double
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLabelNames()
+    {
+        return !empty($this->labelNames);
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Storage/APC.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Storage/APC.php
@@ -1,0 +1,351 @@
+<?php
+
+
+namespace Prometheus\Storage;
+
+
+use Prometheus\MetricFamilySamples;
+use RuntimeException;
+
+class APC implements Adapter
+{
+    const PROMETHEUS_PREFIX = 'prom';
+
+    /**
+     * @throws StorageException
+     */
+    public function __construct()
+    {
+        if (!ini_get('apc.enabled') || ((php_sapi_name() == 'cli') && !ini_get('apc.enable_cli'))) {
+            throw new StorageException('APC is not enabled');
+        }
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function collect()
+    {
+        $metrics = $this->collectHistograms();
+        $metrics = array_merge($metrics, $this->collectGauges());
+        $metrics = array_merge($metrics, $this->collectCounters());
+        return $metrics;
+    }
+
+    public function updateHistogram(array $data)
+    {
+        // Initialize the sum
+        $sumKey = $this->histogramBucketValueKey($data, 'sum');
+        $new = apcu_add($sumKey, $this->toInteger(0));
+
+        // If sum does not exist, assume a new histogram and store the metadata
+        if ($new) {
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        }
+
+        // Atomically increment the sum
+        // Taken from https://github.com/prometheus/client_golang/blob/66058aac3a83021948e5fb12f1f408ff556b9037/prometheus/value.go#L91
+        $done = false;
+        while (!$done) {
+            $old = apcu_fetch($sumKey);
+            $done = apcu_cas($sumKey, $old, $this->toInteger($this->fromInteger($old) + $data['value']));
+        }
+
+        // Figure out in which bucket the observation belongs
+        $bucketToIncrease = '+Inf';
+        foreach ($data['buckets'] as $bucket) {
+            if ($data['value'] <= $bucket) {
+                $bucketToIncrease = $bucket;
+                break;
+            }
+        }
+
+        // Initialize and increment the bucket
+        apcu_add($this->histogramBucketValueKey($data, $bucketToIncrease), 0);
+        apcu_inc($this->histogramBucketValueKey($data, $bucketToIncrease));
+    }
+
+    public function updateGauge(array $data)
+    {
+        $valueKey = $this->valueKey($data);
+        if ($data['command'] == Adapter::COMMAND_SET) {
+            apcu_store($valueKey, $this->toInteger($data['value']));
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        } else {
+            $new = apcu_add($valueKey, $this->toInteger(0));
+            if ($new) {
+                apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+            }
+            // Taken from https://github.com/prometheus/client_golang/blob/66058aac3a83021948e5fb12f1f408ff556b9037/prometheus/value.go#L91
+            $done = false;
+            while (!$done) {
+                $old = apcu_fetch($valueKey);
+                $done = apcu_cas($valueKey, $old, $this->toInteger($this->fromInteger($old) + $data['value']));
+            }
+        }
+    }
+
+    public function updateCounter(array $data)
+    {
+        $new = apcu_add($this->valueKey($data), 0);
+        if ($new) {
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        }
+        apcu_inc($this->valueKey($data), $data['value']);
+    }
+
+    public function flushAPC()
+    {
+       apcu_clear_cache();
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function metaKey(array $data)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], 'meta'));
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function valueKey(array $data)
+    {
+        return implode(':', array(
+            self::PROMETHEUS_PREFIX,
+            $data['type'],
+            $data['name'],
+            $this->encodeLabelValues($data['labelValues']),
+            'value'
+        ));
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function histogramBucketValueKey(array $data, $bucket)
+    {
+        return implode(':', array(
+            self::PROMETHEUS_PREFIX,
+            $data['type'],
+            $data['name'],
+            $this->encodeLabelValues($data['labelValues']),
+            $bucket,
+            'value'
+        ));
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function metaData(array $data)
+    {
+        $metricsMetaData = $data;
+        unset($metricsMetaData['value']);
+        unset($metricsMetaData['command']);
+        unset($metricsMetaData['labelValues']);
+        return $metricsMetaData;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectCounters()
+    {
+        $counters = array();
+        foreach (new \APCUIterator('/^prom:counter:.*:meta/') as $counter) {
+            $metaData = json_decode($counter['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+                'samples' => array(),
+            );
+            foreach (new \APCUIterator('/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $data['samples'][] = array(
+                    'name' => $metaData['name'],
+                    'labelNames' => array(),
+                    'labelValues' => $this->decodeLabelValues($labelValues),
+                    'value' => $value['value']
+                );
+            }
+            $this->sortSamples($data['samples']);
+            $counters[] = new MetricFamilySamples($data);
+        }
+        return $counters;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectGauges()
+    {
+        $gauges = array();
+        foreach (new \APCUIterator('/^prom:gauge:.*:meta/') as $gauge) {
+            $metaData = json_decode($gauge['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+                'samples' => array(),
+            );
+            foreach (new \APCUIterator('/^prom:gauge:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $data['samples'][] = array(
+                    'name' => $metaData['name'],
+                    'labelNames' => array(),
+                    'labelValues' => $this->decodeLabelValues($labelValues),
+                    'value' => $this->fromInteger($value['value'])
+                );
+            }
+
+            $this->sortSamples($data['samples']);
+            $gauges[] = new MetricFamilySamples($data);
+        }
+        return $gauges;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectHistograms()
+    {
+        $histograms = array();
+        foreach (new \APCUIterator('/^prom:histogram:.*:meta/') as $histogram) {
+            $metaData = json_decode($histogram['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+                'buckets' => $metaData['buckets'],
+                'samples' => array(),
+            );
+
+            // Add the Inf bucket so we can compute it later on
+            $data['buckets'][] = '+Inf';
+
+            $histogramBuckets = array();
+            foreach (new \APCUIterator('/^prom:histogram:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $bucket = $parts[4];
+                // Key by labelValues
+                $histogramBuckets[$labelValues][$bucket] = $value['value'];
+            }
+
+            // Compute all buckets
+            $labels = array_keys($histogramBuckets);
+            sort($labels);
+            foreach ($labels as $labelValues) {
+                $acc = 0;
+                $decodedLabelValues = $this->decodeLabelValues($labelValues);
+                foreach ($data['buckets'] as $bucket) {
+                    $bucket = (string) $bucket;
+                    if (!isset($histogramBuckets[$labelValues][$bucket])) {
+                        $data['samples'][] = array(
+                            'name' => $metaData['name'] . '_bucket',
+                            'labelNames' => array('le'),
+                            'labelValues' => array_merge($decodedLabelValues, array($bucket)),
+                            'value' => $acc
+                        );
+                    } else {
+                        $acc += $histogramBuckets[$labelValues][$bucket];
+                        $data['samples'][] = array(
+                            'name' => $metaData['name'] . '_' . 'bucket',
+                            'labelNames' => array('le'),
+                            'labelValues' => array_merge($decodedLabelValues, array($bucket)),
+                            'value' => $acc
+                        );
+                    }
+                }
+
+                // Add the count
+                $data['samples'][] = array(
+                    'name' => $metaData['name'] . '_count',
+                    'labelNames' => array(),
+                    'labelValues' => $decodedLabelValues,
+                    'value' => $acc
+                );
+
+                // Add the sum
+                $data['samples'][] = array(
+                    'name' => $metaData['name'] . '_sum',
+                    'labelNames' => array(),
+                    'labelValues' => $decodedLabelValues,
+                    'value' => $this->fromInteger($histogramBuckets[$labelValues]['sum'])
+                );
+
+            }
+            $histograms[] = new MetricFamilySamples($data);
+        }
+        return $histograms;
+    }
+
+    /**
+     * @param mixed $val
+     * @return int
+     */
+    private function toInteger($val)
+    {
+        return unpack('Q', pack('d', $val))[1];
+    }
+
+    /**
+     * @param mixed $val
+     * @return int
+     */
+    private function fromInteger($val)
+    {
+        return unpack('d', pack('Q', $val))[1];
+    }
+
+    private function sortSamples(array &$samples)
+    {
+        usort($samples, function($a, $b){
+            return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+        });
+    }
+
+    /**
+     * @param array $values
+     * @return string
+     * @throws RuntimeException
+     */
+    private function encodeLabelValues(array $values)
+    {
+        $json = json_encode($values);
+        if (false === $json) {
+            throw new RuntimeException(json_last_error_msg());
+        }
+        return base64_encode($json);
+    }
+
+    /**
+     * @param string $values
+     * @return array
+     * @throws RuntimeException
+     */
+    private function decodeLabelValues($values)
+    {
+        $json = base64_decode($values, true);
+        if (false === $json) {
+            throw new RuntimeException('Cannot base64 decode label values');
+        }
+        $decodedValues = json_decode($json, true);
+        if (false === $decodedValues) {
+            throw new RuntimeException(json_last_error_msg());
+        }
+        return $decodedValues;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Storage/Adapter.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/Storage/Adapter.php
@@ -1,0 +1,24 @@
+<?php
+namespace Prometheus\Storage;
+
+use Prometheus\Collector;
+use Prometheus\MetricFamilySamples;
+use Prometheus\Sample;
+
+interface Adapter
+{
+    const COMMAND_INCREMENT_INTEGER = 1;
+    const COMMAND_INCREMENT_FLOAT = 2;
+    const COMMAND_SET = 3;
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function collect();
+
+    public function updateHistogram(array $data);
+
+    public function updateGauge(array $data);
+
+    public function updateCounter(array $data);
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/functions.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/Prometheus/functions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Prometheus;
+
+use Prometheus\CollectorRegistry;
+
+/*
+    Save a webservice call duration including source page and timestamp on which call occurs
+
+    @param $url         -> Webservice URL call
+    @param $duration    -> webservice call duration (microsec)
+*/
+function record_ws_call($url, $duration)
+{
+
+    global $wp;
+
+    $adapter = new Storage\APC();
+
+    $registry = new CollectorRegistry($adapter);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array $labels e.g. ['controller', 'action']
+     * @return Counter
+     * @throws MetricsRegistrationException
+     */
+    $counter = $registry->registerCounter('epfl', 'shortcode', '', ['page', 'url', 'duration', 'timestamp']);
+    $counter->incBy(1, [home_url( $wp->request ), $url, $duration, microtime(true)]);
+}

--- a/data/wp/wp-content/plugins/epfl-stats/lib/prometheus.php
+++ b/data/wp/wp-content/plugins/epfl-stats/lib/prometheus.php
@@ -1,0 +1,104 @@
+<?PHP
+
+    /* Exception */
+    require_once __DIR__."/Prometheus/Exception/MetricNotFoundException.php";
+    require_once __DIR__."/Prometheus/Exception/MetricsRegistrationException.php";
+    require_once __DIR__."/Prometheus/Exception/MetricNotFoundException.php";
+
+    /* Storage */
+    require_once __DIR__."/Prometheus/Storage/Adapter.php";
+    require_once __DIR__."/Prometheus/Storage/APC.php";
+
+    /* Base */
+    require_once __DIR__."/Prometheus/Collector.php";
+    require_once __DIR__."/Prometheus/CollectorRegistry.php";
+    require_once __DIR__."/Prometheus/Counter.php";
+    require_once __DIR__."/Prometheus/Gauge.php";
+    require_once __DIR__."/Prometheus/Histogram.php";
+    require_once __DIR__."/Prometheus/MetricFamilySamples.php";
+    require_once __DIR__."/Prometheus/PushGateway.php";
+    require_once __DIR__."/Prometheus/RenderTextFormat.php";
+    require_once __DIR__."/Prometheus/Sample.php";
+
+
+/*
+ * Custom definition of class Prometheus\RenderTextFormat to be able to display results as we want
+ */
+class EPFLRenderTextFormat
+{
+    const MIME_TYPE = 'text/plain; version=0.0.4';
+
+    /**
+     * @param Prometheus\MetricFamilySamples[] $metrics
+     * @param array $moveToEnd -> List of labels to not put between { } but to add at the end, after 'value'
+     * @return string
+     */
+    public function render(array $metrics, array $moveToEnd)
+    {
+
+        usort($metrics, function(Prometheus\MetricFamilySamples $a, Prometheus\MetricFamilySamples $b)
+        {
+            return strcmp($a->getName(), $b->getName());
+        });
+
+        $lines = array();
+
+        foreach ($metrics as $metric) {
+            $lines[] = "# HELP " . $metric->getName() . " {$metric->getHelp()}";
+            $lines[] = "# TYPE " . $metric->getName() . " {$metric->getType()}";
+            foreach ($metric->getSamples() as $sample) {
+                $lines[] = $this->renderSample($metric, $sample, $moveToEnd);
+            }
+        }
+        return implode("\n", $lines) . "\n";
+    }
+
+
+    /**
+     * @param Prometheus\MetricFamilySamples[] $metric
+     * @param Prometheus\Sample[] $sample
+     * @param array $moveToEnd -> List of labels to not put between { } but to add at the end, after 'value'
+     * @return string
+     */
+    private function renderSample(Prometheus\MetricFamilySamples $metric, Prometheus\Sample $sample, array $moveToEnd)
+    {
+        $escapedLabels = array();
+
+        $allLabels = $metric->getLabelNames();
+        /* Removing labels we have to add at the end */
+        $labelNames = array_diff($allLabels, $moveToEnd);
+
+        if ($metric->hasLabelNames() || $sample->hasLabelNames()) {
+            $labels = array_combine(array_merge($allLabels, $sample->getLabelNames()), $sample->getLabelValues());
+            foreach ($labels as $labelName => $labelValue) {
+
+                if(!in_array($labelName, $labelNames))continue;
+                $escapedLabels[] = $labelName . '="' . $this->escapeLabelValue($labelValue) . '"';
+            }
+            $result = $sample->getName() . '{' . implode(',', $escapedLabels) . '}';
+        }
+        else
+        {
+            $result = $sample->getName();
+        }
+
+        $result .= ' '.$sample->getValue();
+
+        /* Adding values we have to add at the end */
+        foreach($moveToEnd as $endLabel)
+        {
+            $result .= ' '.$this->escapeLabelValue($labels[$endLabel]);
+        }
+
+        return $result;
+    }
+
+    private function escapeLabelValue($v)
+    {
+        $v = str_replace("\\", "\\\\", $v);
+        $v = str_replace("\n", "\\n", $v);
+        $v = str_replace("\"", "\\\"", $v);
+        return $v;
+    }
+
+}

--- a/data/wp/wp-content/plugins/epfl-stats/ws/.htaccess
+++ b/data/wp/wp-content/plugins/epfl-stats/ws/.htaccess
@@ -1,0 +1,6 @@
+<Files "metrics.php">
+    Require ip 172.16.0.0/12
+    Require ip ::1
+    Require ip 10.180.21.0/24
+    Require local
+</Files>

--- a/data/wp/wp-content/plugins/epfl-stats/ws/metrics.php
+++ b/data/wp/wp-content/plugins/epfl-stats/ws/metrics.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__."/../lib/prometheus.php";
+
+
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+
+$adapter = new Prometheus\Storage\APC();
+
+$registry = new CollectorRegistry($adapter);
+/* Using custom render class */
+$renderer = new EPFLRenderTextFormat();
+
+$result = $renderer->render($registry->getMetricFamilySamples(), ['timestamp']);
+header('Content-type: ' . RenderTextFormat::MIME_TYPE);
+echo $result;
+
+/* If we have to flush cache right after request, */
+if(array_key_exists('flush', $_GET))
+{
+    $adapter->flushAPC();
+}

--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -539,6 +539,7 @@ def export(site, wp_site_url, unit_name_or_id, to_wordpress=False, clean_wordpre
                            'epfl-xml',
                            'epfl-video',
                            'epfl-404',
+                           'epfl-stats',
                            'epfl-google-forms',
                            'feedzy-rss-feeds',
                            'cache-control',


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. En lien avec #873 
1. Ajout d'un plugin "epfl-stats" pour pouvoir logguer les durées des appels aux différents webservices depuis les autres plugins installés.


**Low level changes:**

1. Modification des plugins pour enregistrer les durées des appels:
- epfl-infoscience
- epfl-memento
- epfl-news
- epfl-people
- epfl-scienceqa

**Après merge de la PR**
- Ajouter le nécessaire sur Confluence pour le prochain wagon de change (epfl-stats, epfl-infoscience, epfl-memento, epfl-news, epfl-people, epfl-scienceqa)
- Informer C2C que les stats seront accessibles pour "subdomains" après le prochain change à l'URL suivante : https://wp-metrics.epfl.ch/wp-content/plugins/epfl-stats/ws/metrics.php
