### PR TITLE
Add 'oneCol' template support

### DIFF
--- a/src/parser/box.py
+++ b/src/parser/box.py
@@ -16,6 +16,7 @@ class Box:
 
     # WP box types
     TYPE_TEXT = "text"
+    TYPE_ONE_COL_CONTAINER = "oneColContainer"
     TYPE_COLORED_TEXT = "coloredText"
     TYPE_PEOPLE_LIST = "peopleList"
     TYPE_INFOSCIENCE = "infoscience"
@@ -60,7 +61,8 @@ class Box:
         "epfl:syntaxHighlightBox": TYPE_SYNTAX_HIGHLIGHT,
         "epfl:keyVisualBox": TYPE_KEY_VISUAL,
         "epfl:mapBox": TYPE_MAP,
-        "epfl:gridBox": TYPE_GRID
+        "epfl:gridBox": TYPE_GRID,
+        "epfl:oneColContainer": TYPE_ONE_COL_CONTAINER
     }
 
     UPDATE_LANG = "UPDATE_LANG_BY_EXPORTER"
@@ -138,7 +140,7 @@ class Box:
         self.set_sort_infos(element)
 
         # text
-        if self.TYPE_TEXT == self.type or self.TYPE_COLORED_TEXT == self.type:
+        if self.type in [self.TYPE_TEXT, self.TYPE_COLORED_TEXT, self.TYPE_ONE_COL_CONTAINER]:
             self.set_box_text(element, multibox)
         # people list
         elif self.TYPE_PEOPLE_LIST == self.type:

--- a/src/parser/jahia_site.py
+++ b/src/parser/jahia_site.py
@@ -559,7 +559,9 @@ class Site:
 
                 # the tags that can contain boxes. Sidebar boxes that are in <extra> tags
                 # are parsed separately
-                tags = ["banner", "main", "col4", "col5" "col6", "col7", "col8"]
+                # Tags starting with "oneCol_*" are for special template like the one used for alice.epfl.ch
+                tags = ["banner", "main", "col4", "col5" "col6", "col7", "col8", "oneCol_left_links",
+                        "oneCol_down_links", "oneCol_up_links", "oneCol_right_links"]
 
                 for tag in tags:
                     self.add_boxes(xml_page=xml_page,


### PR DESCRIPTION
**From issue**: -

**High level changes:**

1. Le parsing du site Alice n'arrivait pas à récupérer le contenu des pages car les "box" se trouvaient sous des tags que l'on ne gérait pas. Donc, extension de la liste des tags où chercher les informations.
La partie qui est sur la droite est également reprise et est ajoutée automatiquement au bas du reste des éléments.

**NOTES**
Le parsing du site "Alice" fonctionne et permet d'importer le site sur WordPress. Cependant, à priori, aucun effet de bord pour les sites n'utilisant pas le thème "OneCol" ne devrait exister. S'il s'avérait qu'il y ait quand même des effets de bord, il faudra faire en sorte d'ajouter un paramètre à la ligne de commande pour dire quel est le template depuis lequel on veut importer le site. Sans certitude sur les effets de bord, aucun temps n'a été pris pour le développement de ceci pour le moment.