### PR TITLE
Build category specific plugin list at the beginning to avoid useless zip creation (2018)

### DIFF
--- a/functional_tests/test_plugins.py
+++ b/functional_tests/test_plugins.py
@@ -90,7 +90,7 @@ class TestWPPluginConfig:
             'akismet': True
         }.items():
 
-            plugin_config = wp_plugin_list.plugins()[plugin_name]
+            plugin_config = wp_plugin_list.plugins[plugin_name]
             wp_plugin_config = WPPluginConfig(wp_generator_generic.wp_site, plugin_name, plugin_config)
 
             assert wp_plugin_config.is_installed is installed
@@ -105,7 +105,7 @@ class TestWPPluginConfig:
             'akismet': False
         }.items():
 
-            plugin_config = wp_plugin_list_category.plugins()[plugin_name]
+            plugin_config = wp_plugin_list_category.plugins[plugin_name]
             wp_plugin_config = WPPluginConfig(wp_generator_category.wp_site, plugin_name, plugin_config)
 
             assert wp_plugin_config.is_installed is installed
@@ -118,7 +118,7 @@ class TestWPPluginConfig:
             'akismet': False
         }.items():
 
-            plugin_config = wp_plugin_list.plugins()[plugin_name]
+            plugin_config = wp_plugin_list.plugins[plugin_name]
             wp_plugin_config = WPPluginConfig(wp_generator_generic.wp_site, plugin_name, plugin_config)
 
             assert wp_plugin_config.is_activated is activated
@@ -131,7 +131,7 @@ class TestWPPluginConfig:
             'redirection': True
         }.items():
 
-            plugin_config = wp_plugin_list_category.plugins()[plugin_name]
+            plugin_config = wp_plugin_list_category.plugins[plugin_name]
             wp_plugin_config = WPPluginConfig(wp_generator_category.wp_site, plugin_name, plugin_config)
 
             assert wp_plugin_config.is_activated is activated
@@ -143,7 +143,7 @@ class TestWPPluginConfig:
 
         for plugin_name in ['add-to-any', 'redirection']:
 
-            plugin_config = wp_plugin_list_category.plugins()[plugin_name]
+            plugin_config = wp_plugin_list_category.plugins[plugin_name]
             wp_plugin_config = WPPluginConfig(wp_generator_category.wp_site, plugin_name, plugin_config)
             wp_plugin_config.uninstall()
             assert wp_plugin_config.is_installed is False
@@ -154,7 +154,7 @@ class TestWPPluginConfigRestore:
     def test_restore_generic_config(self, wp_generator_generic, wp_plugin_list):
 
         # First, uninstall from WP installation
-        plugin_config = wp_plugin_list.plugins()['add-to-any']
+        plugin_config = wp_plugin_list.plugins['add-to-any']
         wp_plugin_config = WPPluginConfig(wp_generator_generic.wp_site, 'add-to-any', plugin_config)
         wp_plugin_config.uninstall()
 
@@ -169,7 +169,7 @@ class TestWPPluginConfigRestore:
     def test_restore_category_config(self, wp_generator_generic, wp_plugin_list_category):
 
         # First, uninstall from WP installation
-        plugin_config = wp_plugin_list_category.plugins()['add-to-any']
+        plugin_config = wp_plugin_list_category.plugins['add-to-any']
         wp_plugin_config = WPPluginConfig(wp_generator_generic.wp_site, 'add-to-any', plugin_config)
         wp_plugin_config.uninstall()
 

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -510,7 +510,7 @@ class WPGenerator:
         logging.info("%s - Plugins - Generating list for '%s' category", repr(self), self._site_params['category'])
 
         # Looping through plugins to install
-        for plugin_name, config_dict in plugin_list.plugins().items():
+        for plugin_name, config_dict in plugin_list.plugins.items():
 
             # If a filter on plugin was given and it's not the current plugin, we skip
             if only_one is not None and only_one != plugin_name:
@@ -578,7 +578,7 @@ class WPGenerator:
                 installed_plugins += inactive_plugins.split("\n")
 
             # List coming from YAML file
-            defined_plugin_name_list = list(plugin_list.plugins().keys())
+            defined_plugin_name_list = list(plugin_list.plugins.keys())
 
             for plugin_name in installed_plugins:
 

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 import os
 import zipfile
 import logging
-import copy
 import yaml
 import settings
 import shutil

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -39,7 +39,7 @@ class WPPluginList:
             logging.error("%s - Specific config path not exists: %s", repr(self), specific_config_path)
 
         # For specific plugins configuration
-        self._generic_plugins = OrderedDict()
+        self.plugins = OrderedDict()
 
         # Extend possibilities of YAML reader
         yaml.add_constructor("!include", self._yaml_include)
@@ -70,8 +70,49 @@ class WPPluginList:
                 for plugin_infos in plugin_list['plugins']:
                     # Extracting plugin configuration
                     # plugin_infos['config'] contains content of plugin YAML configuration file
-                    self._generic_plugins[plugin_infos['name']] = WPPluginConfigInfos(plugin_infos['name'],
-                                                                                      plugin_infos['config'])
+                    self.plugins[plugin_infos['name']] = WPPluginConfigInfos(plugin_infos['name'],
+                                                                             plugin_infos['config'])
+
+        # If category is different from default one (default = generic plugin list), we have to include
+        # category related plugins.
+        if self._site_params['category'] != settings.DEFAULT_WP_SITE_CATEGORY:
+
+            # Building path to site category plugin list
+            category_specific_plugin_file = os.path.join(self._specific_config_path,
+                                                         self._site_params['category'],
+                                                         'plugin-list.yml')
+
+            # If no specific plugin list found for category,
+            if not os.path.exists(category_specific_plugin_file):
+                logging.warning("%s - No specific plugins found for category '%s'",
+                                repr(self),
+                                self._site_params['category'])
+
+            else:  # Specific plugin found for category
+
+                # Reading YAML file containing specific plugins
+                plugin_list = yaml.load(open(category_specific_plugin_file, 'r'))
+
+                # If nothing in file
+                if plugin_list is None:
+                    logging.error("%s - YAML file seems to be empty: %s", repr(self), category_specific_plugin_file)
+
+                # Check if exists
+                if 'plugins' not in plugin_list:
+                    logging.error("%s - YAML format error. 'plugins' key not found in file: %s",
+                                  repr(self), category_specific_plugin_file)
+
+                # Going through directory containing specific plugin configuration for site 'site_name'
+                for plugin_infos in plugin_list['plugins']:
+
+                    # If we already have plugin configuration,
+                    if plugin_infos['name'] in self.plugins:
+                        self.plugins[plugin_infos['name']].merge_with_specific(plugin_infos['config'])
+
+                    # We don't already have plugin configuration
+                    else:
+                        self.plugins[plugin_infos['name']] = WPPluginConfigInfos(plugin_infos['name'],
+                                                                                 plugin_infos['config'])
 
     def __repr__(self):
         return "WPPluginList"
@@ -124,60 +165,6 @@ class WPPluginList:
         else:  # No error, we return the value
             return self._site_params[node.value]
 
-    def __build_plugins_for_site(self):
-        """ Build specific plugin configuration for website if exists
-        """
-
-        # If category is different from default one (default = generic plugin list), we take only generic plugins
-        if self._site_params['category'] == settings.DEFAULT_WP_SITE_CATEGORY:
-            return self._generic_plugins
-
-        # Building path to site category plugin list
-        category_specific_plugin_file = os.path.join(self._specific_config_path,
-                                                     self._site_params['category'],
-                                                     'plugin-list.yml')
-        # If no specific plugin list found for category,
-        if not os.path.exists(category_specific_plugin_file):
-            logging.warning("%s - No specific plugins found for category '%s'",
-                            repr(self),
-                            self._site_params['category'])
-            return self._generic_plugins
-
-        # Copying plugin list to have "specific one"
-        specific_plugins = copy.deepcopy(self._generic_plugins)
-
-        # Reading YAML file containing specific plugins
-        plugin_list = yaml.load(open(category_specific_plugin_file, 'r'))
-
-        # If nothing in file
-        if plugin_list is None:
-            logging.error("%s - YAML file seems to be empty: %s", repr(self), category_specific_plugin_file)
-
-        # Check if exists
-        if 'plugins' not in plugin_list:
-            logging.error("%s - YAML format error. 'plugins' key not found in file: %s",
-                          repr(self), category_specific_plugin_file)
-
-        # Going through directory containing specific plugin configuration for site 'site_name'
-        for plugin_infos in plugin_list['plugins']:
-
-            # If we already have plugin configuration,
-            if plugin_infos['name'] in specific_plugins:
-                specific_plugins[plugin_infos['name']].merge_with_specific(plugin_infos['config'])
-
-            # We don't already have plugin configuration
-            else:
-                specific_plugins[plugin_infos['name']] = WPPluginConfigInfos(plugin_infos['name'],
-                                                                             plugin_infos['config'])
-
-        return specific_plugins
-
-    def plugins(self):
-        """ Return plugin list for all sites or for specific site
-        """
-
-        return self.__build_plugins_for_site()
-
     def list_plugins(self, with_config=False, for_plugin=None):
         """
         List plugins (and configuration) for WP site
@@ -192,7 +179,7 @@ class WPPluginList:
         ret_str = "Plugin list for category '{}':\n".format(self._site_params['category'])
 
         # Looping through plugins to display
-        for plugin_name, plugin_config in self.plugins().items():
+        for plugin_name, plugin_config in self.plugins.items():
 
             # If we have to display information for current plugin.
             # ---

--- a/src/wordpress/tests/test_plugins.py
+++ b/src/wordpress/tests/test_plugins.py
@@ -60,7 +60,7 @@ class TestWPPluginList:
     def test_generic_plugin_list(self, wp_plugin_list):
         plugins_to_test = ['add-to-any', 'hello', 'akismet']
 
-        plugin_list = wp_plugin_list.plugins()
+        plugin_list = wp_plugin_list.plugins
         assert len(plugin_list) == len(plugins_to_test)
         for plugin_name in plugins_to_test:
             assert plugin_name in plugin_list
@@ -68,7 +68,7 @@ class TestWPPluginList:
     def test_category_plugin_list(self, wp_plugin_list_category):
         plugins_to_test = ['add-to-any', 'hello', 'redirection', 'akismet']
 
-        plugin_list = wp_plugin_list_category.plugins()
+        plugin_list = wp_plugin_list_category.plugins
         assert len(plugin_list) == len(plugins_to_test)
         for plugin_name in plugins_to_test:
             assert plugin_name in plugin_list


### PR DESCRIPTION
1. La manière dont le code fonctionnait faisait que les fichiers ZIP générés à la volée (pour les sites d'une catégorie autre que celle définie par défaut) étaient générés 2x par erreur... suite à la première génération, le plugin était installé et le ZIP supprimé mais un 2e appel à une partie de code recréait le ZIP et celui-ci n'était ensuite pas supprimé... 
1. Simplification du code en plus de corriger le problème
1. Adaptation des tests au nouveau code.