### PR TITLE
Add CustomCSS site category

### DIFF
--- a/data/plugins/specific/CustomCSS/plugin-list.yml
+++ b/data/plugins/specific/CustomCSS/plugin-list.yml
@@ -1,0 +1,3 @@
+plugins:
+  - name: simple-custom-css
+    config: !include simple-custom-css/config-plugin.yml

--- a/data/plugins/specific/CustomCSS/simple-custom-css/config-plugin.yml
+++ b/data/plugins/specific/CustomCSS/simple-custom-css/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes


### PR DESCRIPTION
**High level changes:**

1. Ajoute une catégorie de site "CustomCSS" permettant de dire quels sites ont le plugin "simple-custom-css" d'installé.
1. Cette PR est uniquement pour 2010 car @lvenries veut faire disparaître le CSS Custom quand on passe en 2018.
1. Une fois la PR mergée, il faudra aller changer la catégorie des sites suivants pour mettre "CustomCSS" dans la source de vérité:
- cape
- clickers
- developpement-durable
- library
- lis
- valais