### PR TITLE
epfl-404: group url/referer in display, add url/referer count, ... (2010)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -55,8 +55,9 @@ class EPFL404
     {
         EPFL404DB::init();
 
-        /* Add option with default value */
+        /* Add options with default value */
         update_option(self::NB_DAYS_TO_KEEP_OPTION, self::DAYS_TO_KEEP_DEFAULT);
+        update_option(self::NB_ENTRIES_TO_KEEP_OPTION, self::NB_ENTRIES_TO_KEEP_DEFAULT);
     }
 
     /*
@@ -91,7 +92,7 @@ class EPFL404
     {
         $hook = add_management_page( 'EPFL 404',
                                      'EPFL 404',
-                                     'administrator',
+                                     'editor',
                                      basename( __FILE__),
                                      [$this, 'render_404_list'] );
 

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-404
  * Description: To log 404 pages
- * @version: 0.1
+ * @version: 0.2
  * @copyright: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -15,7 +15,9 @@ class EPFL404
     static $instance;
 
     const DAYS_TO_KEEP_DEFAULT = 15;
+    const NB_ENTRIES_TO_KEEP_DEFAULT = 1000;
     const NB_DAYS_TO_KEEP_OPTION = 'epfl-404:nb_days_to_keep';
+    const NB_ENTRIES_TO_KEEP_OPTION = 'epfl-404:nb_entries_to_keep';
 
     public $display_table = null;
     public $nb_days_to_keep = self::DAYS_TO_KEEP_DEFAULT;
@@ -28,8 +30,10 @@ class EPFL404
 
 		add_action( 'template_redirect', [$this, 'log_404_calls'] );
 
-        /* Number of days to keep information */
+        /* To avoid to fill database with information, we set limits */
         $this->nb_days_to_keep = get_option(self::NB_DAYS_TO_KEEP_OPTION, self::DAYS_TO_KEEP_DEFAULT);
+        $this->nb_entries_to_keep = get_option(self::NB_ENTRIES_TO_KEEP_OPTION, self::NB_ENTRIES_TO_KEEP_DEFAULT);
+
 	}
 
 
@@ -76,7 +80,7 @@ class EPFL404
                        $_SERVER['REMOTE_ADDR']);
 
         /* Cleaning old entries */
-        EPFL404DB::clean_old_entries($this->nb_days_to_keep);
+        EPFL404DB::clean_old_entries($this->nb_days_to_keep, $this->nb_entries_to_keep);
     }
 
 

--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -92,7 +92,7 @@ class EPFL404
     {
         $hook = add_management_page( 'EPFL 404',
                                      'EPFL 404',
-                                     'editor',
+                                     'manage_options',
                                      basename( __FILE__),
                                      [$this, 'render_404_list'] );
 

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
@@ -88,13 +88,15 @@ class EPFL404DB
     /*
      * Cleans old records
      * @param int $nb_days_to_keep
+     * @param int $nb_entries_to_keep
      */
-    public static function clean_old_entries($nb_days_to_keep)
+    public static function clean_old_entries($nb_days_to_keep, $nb_entries_to_keep)
     {
         global $wpdb;
 
         $sql = "DELETE FROM ".self::EPFL404_DB_TABLE.
-               " WHERE ".self::EPFL404_DB_FIELD_DATE."< DATE_SUB(NOW(), INTERVAL ".$nb_days_to_keep." DAY)";
+               " WHERE ".self::EPFL404_DB_FIELD_DATE."< DATE_SUB(NOW(), INTERVAL ".$nb_days_to_keep." DAY)".
+               " OR ".self::EPFL404_DB_FIELD_ID."< (MAX(".self::EPFL404_DB_FIELD_ID.")-".$nb_entries_to_keep.")"" ;
 
         if ( $wpdb->query( $sql ) === false )
         {

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-db.php
@@ -150,7 +150,7 @@ class EPFL404DB
 
       global $wpdb;
 
-      $sql = "SELECT * FROM ".self::EPFL404_DB_TABLE;
+      $sql = "SELECT *, COUNT(CONCAT(".self::EPFL404_DB_FIELD_URL.",".self::EPFL404_DB_FIELD_REFERER.")) AS 'nb' FROM ".self::EPFL404_DB_TABLE;
 
       if ( ! empty( $_REQUEST['orderby'] ) ) {
         $sql .= ' ORDER BY ' . esc_sql( $_REQUEST['orderby'] );

--- a/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-table.php
+++ b/data/wp/wp-content/plugins/epfl-404/inc/epfl-404-table.php
@@ -92,10 +92,10 @@ class EPFL404Table extends WP_List_Table
     {
         $columns = [
             'cb'      => '<input type="checkbox" />',
-            EPFL404DB::EPFL404_DB_FIELD_URL         => 'URL',
-            EPFL404DB::EPFL404_DB_FIELD_REFERER     => 'Referer',
-            EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP   => 'IP',
-            EPFL404DB::EPFL404_DB_FIELD_DATE        => 'Date'
+            EPFL404DB::EPFL404_DB_FIELD_URL             => 'URL',
+            EPFL404DB::EPFL404_DB_FIELD_REFERER         => 'Referer',
+            EPFL404DB::EPFL404_QUERY_FIELD_NB_OCCUR     => '# occurences',
+            EPFL404DB::EPFL404_QUERY_FIELD_LAST_OCCUR   => 'Last occurence'
         ];
 
         return $columns;
@@ -110,10 +110,10 @@ class EPFL404Table extends WP_List_Table
     public function get_sortable_columns()
     {
         $sortable_columns = array(
-            EPFL404DB::EPFL404_DB_FIELD_URL         => array( EPFL404DB::EPFL404_DB_FIELD_URL, true ),
-            EPFL404DB::EPFL404_DB_FIELD_REFERER     => array( EPFL404DB::EPFL404_DB_FIELD_REFERER, false ),
-            EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP   => array( EPFL404DB::EPFL404_DB_FIELD_SOURCE_IP, false ),
-            EPFL404DB::EPFL404_DB_FIELD_DATE        => array( EPFL404DB::EPFL404_DB_FIELD_DATE, false ),
+            EPFL404DB::EPFL404_DB_FIELD_URL             => array( EPFL404DB::EPFL404_DB_FIELD_URL, true ),
+            EPFL404DB::EPFL404_DB_FIELD_REFERER         => array( EPFL404DB::EPFL404_DB_FIELD_REFERER, false ),
+            EPFL404DB::EPFL404_QUERY_FIELD_NB_OCCUR     => array( EPFL404DB::EPFL404_QUERY_FIELD_NB_OCCUR, false ),
+            EPFL404DB::EPFL404_QUERY_FIELD_LAST_OCCUR   => array( EPFL404DB::EPFL404_QUERY_FIELD_LAST_OCCUR, false ),
         );
 
       return $sortable_columns;


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. La page des informations 404 est maintenant affichée pour les éditeurs aussi.
1. Les informations sont toujours enregistrées de la même manière dans la DB, aucun changement dans la structure.
1. Nouveau critère pour l'effacement des vieilles données journalisées. En plus de la durée, il y a un nombre d'enregistrement max que l'on garde dans la DB. Par défaut c'est à 1000 mais c'est changeable avec option `epfl-404:nb_entries_to_keep`
1. Correction d'un nom de variable dyslexiquement orthographié (hommage inconscient à @lvenries 😋 )
1. Lors de l'affichage des données, on groupe maintenant par combinaison URL/referer afin de rendre les informations plus lisibles. Ceci permet de voir plus facilement le nombre d'erreurs 404 sur une page donnée qui sont faites depuis un site donné.
- La colonne "IP" n'est plus affichée (c'était l'IP du client, pas pertinente, mais reste enregistrée dans la DB)
- La colonne "Date" se change en "Last occurrence" (dernière fois que la combi URL/referer a été appelée)
- Ajout d'une colonne "# occurrences" pour savoir combien de fois la combi URL/referer a été appelée

Aperçu du tableau maintenant:
![image](https://user-images.githubusercontent.com/11942430/52635122-4d32f480-2ec9-11e9-950a-9aa4f9088894.png)
