### PR TITLE
EPFL-Share: Remove Google+

### DIFF
--- a/data/wp/wp-content/plugins/EPFL-Share/EPFL-Share.php
+++ b/data/wp/wp-content/plugins/EPFL-Share/EPFL-Share.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: EPFL-Share
 Description: Provide share button for EPFL websites
-Version: 0.1
+Version: 0.2
 Author: <a href="Mailto:wwp-admin@epfl.ch">wwp-admin@epfl.ch</a>
 */
 
@@ -24,7 +24,6 @@ class EPFLShare
     'facebook' => '<li class="%li_class%"><i style="%style%" alt="Facebook" Title="Facebook" class="EPFLShare EPFLShareFacebookBackground" onclick=\'EPFLSharePopup("https://www.facebook.com/sharer/sharer.php?u=%encoded_post_url%")\'><ss style="%inner_style%" class="EPFLShareSvg EPFLShareFacebookSvg"></ss></i></li>',
     'twitter' => '<li class="%li_class%"><i style="%style%" alt="Twitter" Title="Twitter" class="EPFLShare EPFLShareTwitterBackground" onclick=\'EPFLSharePopup("http://twitter.com/intent/tweet?text=%post_title%&url=%encoded_post_url%&hashtags=epfl,epflcampus")\'><ss style="%inner_style%" class="EPFLShareSvg EPFLShareTwitterSvg"></ss></i></li>',
     'linkedin' => '<li class="%li_class%"><i style="%style%" alt="LinkedIn" Title="LinkedIn" class="EPFLShare EPFLShareLinkedinBackground" onclick=\'EPFLSharePopup("http://www.linkedin.com/shareArticle?mini=true&url=%encoded_post_url%&title=%post_title%")\'><ss style="%inner_style%" class="EPFLShareSvg EPFLShareLinkedinSvg"></ss></i></li>',
-    'google_plus' => '<li class="%li_class%"><i style="%style%" alt="Google+" Title="Google+" class="EPFLShare EPFLShareGoogleplusBackground" onclick=\'EPFLSharePopup("https://plus.google.com/share?url=%encoded_post_url%")\'><ss style="%inner_style%" class="EPFLShareSvg EPFLShareGoogleplusSvg"></ss></i></li>',
     'email' => '<li class="%li_class%"><i style="%style%" alt="Email" Title="Email" class="EPFLShare EPFLShareEmailBackground" onclick="window.location.href = \'mailto:?subject=\' + decodeURIComponent(\'%post_title%\' ).replace(\'&\', \'%26\') + \'&body=\' + decodeURIComponent(\'%encoded_post_url%\' )"><ss style="display:block" class="EPFLShareSvg EPFLShareEmailSvg"></ss></i></li>'
   );
 

--- a/data/wp/wp-content/plugins/EPFL-Share/style.css
+++ b/data/wp/wp-content/plugins/EPFL-Share/style.css
@@ -54,10 +54,6 @@ ul.EPFLShareUl li:before {
    background-color: #0077B5
 }
 
-.EPFLShareGoogleplusBackground {
-   background-color: #dd4b39
-}
-
 .EPFLShareEmailBackground {
    background-color: #649A3F
 }
@@ -79,10 +75,6 @@ div.EPFLShareHorizontal li {
 .EPFLShareHorizontal .EPFLShareLinkedinSvg,
 .EPFLShareLinkedinSvg {
    background: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20viewBox%3D%22-2%20-2%2035%2039%22%3E%3Cpath%20d%3D%22M6.227%2012.61h4.19v13.48h-4.19V12.61zm2.095-6.7a2.43%202.43%200%200%201%200%204.86c-1.344%200-2.428-1.09-2.428-2.43s1.084-2.43%202.428-2.43m4.72%206.7h4.02v1.84h.058c.56-1.058%201.927-2.176%203.965-2.176%204.238%200%205.02%202.792%205.02%206.42v7.395h-4.183v-6.56c0-1.564-.03-3.574-2.178-3.574-2.18%200-2.514%201.7-2.514%203.46v6.668h-4.187V12.61z%22%20fill%3D%22%23fff%22%2F%3E%3C%2Fsvg%3E') no-repeat center center
-}
-.EPFLShareHorizontal .EPFLShareGoogleplusSvg,
-.EPFLShareGoogleplusSvg {
-   background: url('data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20viewBox%3D%22-1%20-1%2034%2034%22%3E%3Cpath%20d%3D%22M27%2015h-2v-2h-2v2h-2v2h2v2h2v-2h2m-15-2v2.4h3.97c-.16%201.03-1.2%203.02-3.97%203.02-2.39%200-4.34-1.98-4.34-4.42s1.95-4.42%204.34-4.42c1.36%200%202.27.58%202.79%201.08l1.9-1.83C15.47%209.69%2013.89%209%2012%209c-3.87%200-7%203.13-7%207s3.13%207%207%207c4.04%200%206.72-2.84%206.72-6.84%200-.46-.05-.81-.11-1.16H12z%22%20fill%3D%22%23fff%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E') no-repeat center center
 }
 .EPFLShareHorizontal .EPFLShareEmailSvg,
 .EPFLShareEmailSvg {


### PR DESCRIPTION
**From issue**: lié à INC0271706 

**High level changes:**

1. Suppression du lien de partage Google+ car il va disparaître d'ici à la fin de l'été 2019 (selon Wikipedia). Il n'est d'ailleurs plus possible de créer un nouveau compte depuis quelques temps déjà. Donc la pertinence de partager des infos dessus est nulle.

