### PR TITLE
Fix main root site having the fallback top menu

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/pod.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pod.php
@@ -149,6 +149,14 @@ class Site {
         return $this->equals($this->root());
     }
 
+    /**
+     * The main root Site is the one at the root of the filesystem and
+     * has not a configurated root menu.
+     */
+    function is_main_root () {
+        return $this->is_root() && empty($this->get_configured_root_menu_url());
+    }
+
     function get_subsites () {
         if (! $this->htdocs_path) {
             throw new \Error("Sorry, ->get_subsites() only works on ::this_site() for now");

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1907,6 +1907,11 @@ class MenuFrontendController
      * @return True iff the root menu is correctly stitched
      */
     public static function filter_epfl_root_menu_ready ($ready_orig, $theme_location) {
+        # main root site is always correct, as this is the main ref.
+        if (Site::this_site()->is_main_root()) {
+            return true;
+        }
+        
         $menu = Menu::by_theme_location($theme_location);
         return $menu && $menu->has_root_menu($theme_location);
     }


### PR DESCRIPTION
Corrige le problème du site Root (www.epfl.ch) possédant le fallback menu au lieu de son menu