### PR TITLE
Enable plugin by default. Only need Tequila login

### DIFF
--- a/data/plugins/specific/Inside/epfl-intranet/config-plugin.yml
+++ b/data/plugins/specific/Inside/epfl-intranet/config-plugin.yml
@@ -5,7 +5,7 @@ tables:
   - autoload: 'yes'
     option_id: 300
     option_name: plugin:epfl_accred:subscriber_group
-    option_value: ''
+    option_value: '*'
   - autoload: 'yes'
     option_id: 301
     option_name: plugin:epfl_intranet:restrict_to_groups
@@ -13,5 +13,5 @@ tables:
   - autoload: 'yes'
     option_id: 302
     option_name: plugin:epfl_intranet:enabled
-    option_value: '0'
+    option_value: '1'
 


### PR DESCRIPTION
**High level changes:**

1. Activation de l'authentification Tequila par défaut pour les visiteurs des sites de la catégorie Inside.