### PR TITLE
EPFL-404 - Fix old entries cleaning (2010)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-404/epfl-404.php
+++ b/data/wp/wp-content/plugins/epfl-404/epfl-404.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-404
  * Description: To log 404 pages
- * @version: 0.2
+ * @version: 0.3
  * @copyright: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 


### PR DESCRIPTION
**High level changes:**

Equivalent 2010 de #898 

1. Erreur de ma part dans la requête d'effacement. Pas assez testé avant de mettre la dernière version en production... pas possible de mettre un "max" dans une condition... du coup, séparation en 2 requêtes distinctes, une pour récupérer le max et l'autre pour effectuer l'effacement.