### PR TITLE
Plugin epfl-restauration and new site category

### DIFF
--- a/data/plugins/specific/Restauration/epfl-restauration/config-plugin.yml
+++ b/data/plugins/specific/Restauration/epfl-restauration/config-plugin.yml
@@ -1,0 +1,2 @@
+src: ../wp/wp-content/plugins/epfl-restauration
+activate: yes

--- a/data/plugins/specific/Restauration/plugin-list.yml
+++ b/data/plugins/specific/Restauration/plugin-list.yml
@@ -1,0 +1,3 @@
+plugins:
+  - name: epfl-restauration
+    config: !include epfl-restauration/config-plugin.yml

--- a/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
+++ b/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
@@ -23,8 +23,8 @@ function epfl_restauration_process_shortcode( $atts, $content = null ) {
 
     /* Prod */
     $url = 'https://menus.epfl.ch/cgi-bin/getMenus?'. $params;
-    /* Test */
-    $url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
+    /* uncomment following line to access test environment */
+    //$url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
 
 
     /* Adding JavaScript */
@@ -35,7 +35,7 @@ ob_start();
      code in iframe content to know where to send a message to tell iframe's height. This information will be used by
      JavaScript code in 'js/script.js' to resize iframe */
 ?>
-<iframe src="<?PHP echo $url; ?>" name="<?PHP echo home_url( $wp->request ); ?>" height="500" width="100%" scrolling="no" id="epfl-restauration">
+<iframe src="<?PHP echo $url; ?>" name="<?PHP echo home_url( $wp->request ); ?>" frameborder="0" height="500" width="100%" scrolling="no" id="epfl-restauration">
 </iframe>
 
 <?php

--- a/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
+++ b/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: EPFL Restauration
+ * Description: provides a shortcode to display cafeterias and restaurant menus offers
+ * Version: 0.1
+ * Author: Lucien Chaboudez
+ * Contributors:
+ * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
+ **/
+
+
+function epfl_restauration_process_shortcode( $atts, $content = null ) {
+
+    global $wp;
+
+    $atts = shortcode_atts( array(
+        'params' => '',
+    ), $atts );
+
+    /* We remove ? at the beginning if any*/
+    $params = preg_replace('/^\?/', '', $atts['params']);
+
+
+    /* Prod */
+    $url = 'https://menus.epfl.ch/cgi-bin/getMenus?'. $params;
+    /* Test */
+    $url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
+
+
+    /* Adding JavaScript */
+    wp_enqueue_script( 'epfl_restauration_script', plugin_dir_url(__FILE__).'js/script.js' );
+ob_start();
+
+    /* While rendering the iframe, we have to add current URL in 'name' attribute. This then will be used by JavaScript
+     code in iframe content to know where to send a message to tell iframe's height. This information will be used by
+     JavaScript code in 'js/script.js' to resize iframe */
+?>
+<iframe src="<?PHP echo $url; ?>" name="<?PHP echo home_url( $wp->request ); ?>" height="500" width="100%" scrolling="no" id="epfl-restauration">
+</iframe>
+
+<?php
+
+return ob_get_clean();
+}
+
+add_action( 'init', function() {
+  // define the shortcode
+  add_shortcode('epfl_restauration', 'epfl_restauration_process_shortcode');
+});

--- a/data/wp/wp-content/plugins/epfl-restauration/js/script.js
+++ b/data/wp/wp-content/plugins/epfl-restauration/js/script.js
@@ -1,7 +1,9 @@
 var if_height,
     restauration_iframe = jQuery('#epfl-restauration');
 
-
+/*
+* We add a listener to receive messages sent by iframe containing menu list. Messages tells the iframe's content height.
+* This will be used to resize iframe (if size has changed) */
 window.addEventListener('message', function(e)
 {
 

--- a/data/wp/wp-content/plugins/epfl-restauration/js/script.js
+++ b/data/wp/wp-content/plugins/epfl-restauration/js/script.js
@@ -1,0 +1,16 @@
+var if_height,
+    restauration_iframe = jQuery('#epfl-restauration');
+
+
+window.addEventListener('message', function(e)
+{
+
+    var h = Number( e.data.replace( /.*if_height=(\d+)(?:&|$)/, '$1' ) );
+
+    if (!isNaN( h ) && h > 0 && h !== if_height) {
+        /* Height has changed, update the iframe */
+        if_height = h;
+        restauration_iframe.height(h);
+    }
+
+} , false);


### PR DESCRIPTION
**High level changes:**

1. Ajout d'un plugin "epfl-restauration" pour afficher les menus en incluant une iframe (https://test-menus.epfl.ch/cgi-bin/getMenus)
1. Le shortcode s'utilise simplement avec `[epfl_restauration]` et il est possible de mettre un attribut `params` contenant une query string à ajouter à la fin de l'URL donnée précédemment. Ceci permet de filtrer sur un restaurant en mettant par exemple: `[epfl_restauration params="resto_id=23"]`
1. Ajout d'une catégorie de site "Restauration" pour faire en sorte que ce plugin ne soit installé que pour le site où il y en a besoin.

**NOTE**
- Pour le moment, c'est une version du plugin qui pointe sur l'environnement de test de "menu.epfl.ch" qui a été mise sur https://www.epfl.ch/campus/restaurants-shops-hotels
- Le code du plugin (dans la PR) pointe sur l'environnement de production de "menu.epfl.ch" bien que le webservice ne soit pas encore en production. Celui-ci devrait par contre l'être quand on mettra le plugin à jour lors du prochain wagon de changes (jeudi 28.02).

**Après merge de la PR**
- Changer la catégorie du site https://www.epfl.ch/campus/restaurants-shops-hotels pour mettre "Restauration" dans la source de vérité.
- Ajouter les infos dans la page de Wagon de changes pour la semaine prochaine
