### PR TITLE
Plugin EPFL-emploi: Cleaning, comment and display update (2018)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-emploi/css/style.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style.css
@@ -8,10 +8,21 @@
 	padding-right: 0;
 	padding-top: 10px;
 	}
+	.panel-header {
+		border-bottom: 1px solid #000;
+		text-transform: uppercase;
+		font-size: 1.4em;
+		line-height: 1.2em;
+	}
 	#id_themes{
   	columns: 3;
   	-webkit-columns: 3;
   	-moz-columns: 3;
+	}
+	#id_themes li{
+		list-style-position: outside;
+		list-style-type: none;
+		line-height:17px;
 	}
 	#id_keywords {
 	display: inline-block;

--- a/data/wp/wp-content/plugins/epfl-emploi/css/style.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style.css
@@ -24,6 +24,9 @@
 		list-style-type: none;
 		line-height:17px;
 	}
+	button.right{
+		float:right;
+	}
 	#id_keywords {
 	display: inline-block;
 	width: 80%;

--- a/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
+++ b/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Emploi
  * Description: provides a shortcode to display job offers
- * Version: 1.2
+ * Version: 1.3
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
@@ -60,7 +60,6 @@ function epfl_emploi_process_shortcode( $atts, $content = null ) {
     $new_url_query = http_build_query($parameters);
     /* We replace query in original url to have 'searchPositionUrl' value for JS */
     $url_search_position = str_replace($url_query, $new_url_query, $url);
-
 
 ob_start();
 

--- a/data/wp/wp-content/plugins/epfl-emploi/js/script.js
+++ b/data/wp/wp-content/plugins/epfl-emploi/js/script.js
@@ -145,14 +145,21 @@ simpleAJAXLib.init();
 /**** Displays Job list ****/
 var time = new Date().getTime();
 var if_height, src = defaultUrl+'&t='+time,
-emploiFrame = jQuery( '<iframe src="' + src + '" name="' + document.location.href + '" width="652" height="500" frameborder="0" scrolling="no" id="job-board" ><script>setInterval(function() {window.top.postMessage(document.body.scrollHeight, "*");}, 500); <\/script><\/iframe>' ).appendTo( '#umantis_iframe' );
+    /* We dynamically create the iframe and we set current page URL as 'name' attribute to allow JavaScript code inside iframe (hosted on another website) to send information
+     * to this page. This information contains height of HTML content displayed in the iframe and will help us to resize the iframe to fit its content. */
+emploiFrame = jQuery( '<iframe src="' + src + '" name="' + document.location.href + '" width="652" height="500" frameborder="0" scrolling="no" id="job-board" ><\/iframe>' ).appendTo( '#umantis_iframe' );
 
+/*
+* We add a listener to receive messages sent by iframe containing job offer list. Messages tells the iframe's content height
+* and has format : if_height=<height_in_pixels>
+* This will be used to resize iframe (if size has changed). */
 window.addEventListener('message', function(e)
 {
-
+    /* Extracting height from received message */
     var h = Number( e.data.replace( /.*if_height=(\d+)(?:&|$)/, '$1' ) );
 
-    if (!isNaN( h ) && h > 0 && h !== if_height) {
+    if (!isNaN( h ) && h > 0 && h !== if_height)
+    {
         /* Height has changed, update the iframe */
         if_height = h;
         emploiFrame.height(h);


### PR DESCRIPTION
Equivalent 2018 de #901

**High level changes:**

1. Suppression de code HTML créé dynamiquement pour rien... 
1. Ajout de commentaires pour expliquer un minimum la magie du redimensionnement automatique de l'iframe en fonction de son contenu 🌟 
1. Ajout d'éléments dans le CSS pour que ça s'affiche correctement sur la charte 2018 (reprise de ce qui est par défaut dans le thème 2010)

**Après merge PR**
- Mise à jour page sur les wagons de change

