### PR TITLE
Remove Gaspar username check (2010)

### DIFF
--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from epflldap.ldap_search import get_username, get_email
 
 from django.core.validators import ValidationError
-from veritas.validators import validate_string, validate_openshift_env, validate_gaspar_username
+from veritas.validators import validate_string, validate_openshift_env
 
 from utils import Utils
 

--- a/src/wordpress/models.py
+++ b/src/wordpress/models.py
@@ -138,8 +138,6 @@ class WPUser:
     WP_PASSWORD_LENGTH = 32
 
     def __init__(self, username, email, password=None, display_name=None, role=None):
-        # validate input
-        validate_gaspar_username(username)
 
         self.username = username
         self.email = email


### PR DESCRIPTION
Equivalent 2010 de #903

**High level changes:**

1. Suppression du check de la validité des noms d'utilisateurs (Gaspar) lors de l'inventaire car ça fait planter pour quelques sites unmanaged (donc pas de backup) et ce check n'a aucune pertinence...
