### PR TITLE
Additional support for "lab" menus

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/pod.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pod.php
@@ -74,7 +74,7 @@ class Site {
             throw new \Error('Unable to find htdocs in ' . $abspath);
         }
         $htdocs = $matched[1];
-        $below_htdocs = preg_replace('#^/#', '', 
+        $below_htdocs = preg_replace('#^/#', '',
                                      preg_replace('#/$#', '', $matched[2]));
         return array($htdocs, $below_htdocs);
     }
@@ -191,17 +191,15 @@ class Site {
 
     /**
      * Get a pod config value, or all config
-     * 
+     *
      * Configuration file should be in www.epfl.ch/htdocs/epfl-wp-sites-config.ini
-     * 
+     *
      * @return (String|bool) false if not found
      */
 
     static function get_pod_config ($key='') {
-        list($htdocs_path, $under_htdocs) = static::_htdocs_split();
-        $ini_path = $htdocs_path . '/epfl-wp-sites-config.ini';
-
-        if (file_exists($ini_path)) {
+        $ini_path = static::_get_wp_site_config_path();
+        if ($ini_path) {
             $ini_array = parse_ini_file($ini_path);
             if (!empty($key)) {
                 if (array_key_exists($key, $ini_array)){
@@ -211,5 +209,29 @@ class Site {
                 return $ini_array;
             }
         }
+    }
+
+    static $_wp_site_config_path_cache = FALSE;
+    static function _get_wp_site_config_path () {
+        if (FALSE === static::$_wp_site_config_path_cache) {
+            [ $htdocs, $my_subdirs ] = static::_htdocs_split();
+
+            for(
+              $path_components = explode('/', $my_subdirs);
+              count($path_components);
+              array_pop($path_components))
+            {
+                $try_path = $htdocs . "/" . implode("/", $path_components) . "/epfl-wp-sites-config.ini";
+                if (file_exists($try_path)) {
+                    static::$_wp_site_config_path_cache = $try_path;
+                    break;
+                }
+            }
+            if (FALSE === static::$_wp_site_config_path_cache) {
+              static::$_wp_site_config_path_cache = NULL;
+            }
+        }
+
+        return static::$_wp_site_config_path_cache;
     }
 }

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1902,33 +1902,6 @@ class MenuFrontendController
             ::find(array('menu_term_id' => $menu_term_id))
             ->first_preferred(array('language' => get_current_language()));
     }
-    /**
-     * Add information on item that the walkers may need.
-     * Like if a custom entry has external-menu children
-     */
-    static function enhance_nav_menu_items_datas
-        ($items_orig, $menu, $args)
-    {
-        # when we get a custom link check if it has an external-menu child.
-        # this means we have to identify the Custom link as a custom link for
-        # the External Menu item
-        foreach ($items_orig as $key => $item) {
-            if ($item->object === 'custom') {
-                # try to find External menu item in the descendancy
-                foreach ($items_orig as $sub_item) {
-                    if ($sub_item->menu_item_parent === strval($item->ID)) {
-                        if ($emi = ExternalMenuItem::get($sub_item)) {
-                            # set the info into the parent that he may be a link for external menu
-                            $items_orig[$key]->epfl_has_external_menu_child = true;
-                            continue 2;
-                        }
-                    }
-                }
-            }
-        }
-
-        return $items_orig;
-    }
 
     /**
      * Change the return value of @link wp_get_nav_menu_items to the
@@ -1938,7 +1911,6 @@ class MenuFrontendController
     static function filter_wp_nav_menu_items_for_theme
         ($items_orig, $menu, $args)
     {
-        $items_orig = static::enhance_nav_menu_items_datas($items_orig, $menu, $args);
         if (static::_is_being_called_by_theme('wp_get_nav_menu_items')) {
             return static::stitch_menu($items_orig, $menu);
         } else {
@@ -1950,11 +1922,6 @@ class MenuFrontendController
      * @return True iff the root menu is correctly stitched
      */
     public static function filter_epfl_root_menu_ready ($ready_orig, $theme_location) {
-        # always pretend to be ready in debug mode
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            return true;
-        }
-
         # main root site is always correct, as this is the main ref.
         if (Site::this_site()->is_main_root()) {
             return true;


### PR DESCRIPTION
**From issue**: None filed

**High level changes:**

None — See [epfl-theme](https://github.com/epfl-idevelop/wp-theme-2018/pull/182) instead.

**Low level changes:**

1. Walk the file system to find epfl-wp-sites-config.ini, allowing it to reside in any place (not just at the site root)
1. In `trim_external`, annotate the cut point with how many external menu items there were before trimming, so that the theme can implement ["phantom" root menu entries](https://github.com/epfl-idevelop/wp-theme-2018/pull/182)
1. In `get_fully_stitched_tree`, annotate with epfl_soa so that the theme may discern which menu entries are "ours" (also needed for the "phantom" root menu entries requirement)
