### PR TITLE
EPFL-Restauration: Add schedule support

### DIFF
--- a/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
+++ b/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Restauration
  * Description: provides a shortcode to display cafeterias and restaurant menus offers
- * Version: 0.1
+ * Version: 0.2
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
@@ -15,32 +15,56 @@ function epfl_restauration_process_shortcode( $atts, $content = null ) {
 
     $atts = shortcode_atts( array(
         'params' => '',
+        'type' => 'menu', // can be 'menu' or 'schedule'
     ), $atts );
 
     /* We remove ? at the beginning if any*/
     $params = preg_replace('/^\?/', '', $atts['params']);
+    $type = sanitize_text_field($atts['type']);
 
 
-    /* Prod */
-    $url = 'https://menus.epfl.ch/cgi-bin/getMenus?'. $params;
-    /* uncomment following line to access test environment */
-    //$url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
+    /* If we want schedule list */
+    if($type=='schedule')
+    {
+        /* Prod */
+        $url = 'https://menus.epfl.ch/cgi-bin/getHoraire?'. $params;
+        /* uncomment following line to access test environment */
+        $url = 'https://test-menus.epfl.ch/cgi-bin/getHoraire?'. $params;
+
+        $response = wp_remote_get($url);
+
+        if(is_array($response))
+        {
+          return $response['body'];
+        }
+    }
+    else /* We assume $type is equal to 'menu' */
+    {
+        /* Prod */
+        $url = 'https://menus.epfl.ch/cgi-bin/getMenus?'. $params;
+        /* uncomment following line to access test environment */
+        $url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
+
+        /* Adding JavaScript */
+        wp_enqueue_script( 'epfl_restauration_script', plugin_dir_url(__FILE__).'js/script.js' );
 
 
-    /* Adding JavaScript */
-    wp_enqueue_script( 'epfl_restauration_script', plugin_dir_url(__FILE__).'js/script.js' );
-ob_start();
+        ob_start();
 
-    /* While rendering the iframe, we have to add current URL in 'name' attribute. This then will be used by JavaScript
-     code in iframe content to know where to send a message to tell iframe's height. This information will be used by
-     JavaScript code in 'js/script.js' to resize iframe */
+            /* While rendering the iframe, we have to add current URL in 'name' attribute. This then will be used by JavaScript
+             code in iframe content to know where to send a message to tell iframe's height. This information will be used by
+             JavaScript code in 'js/script.js' to resize iframe */
 ?>
-<iframe src="<?PHP echo $url; ?>" name="<?PHP echo home_url( $wp->request ); ?>" frameborder="0" height="500" width="100%" scrolling="no" id="epfl-restauration">
-</iframe>
-
+        <iframe src="<?PHP echo $url; ?>" name="<?PHP echo home_url( $wp->request ); ?>" frameborder="0" height="500" width="100%" scrolling="no" id="epfl-restauration">
+        </iframe>
 <?php
 
-return ob_get_clean();
+        return ob_get_clean();
+
+
+    }
+
+
 }
 
 add_action( 'init', function() {

--- a/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
+++ b/data/wp/wp-content/plugins/epfl-restauration/epfl-restauration.php
@@ -29,7 +29,7 @@ function epfl_restauration_process_shortcode( $atts, $content = null ) {
         /* Prod */
         $url = 'https://menus.epfl.ch/cgi-bin/getHoraire?'. $params;
         /* uncomment following line to access test environment */
-        $url = 'https://test-menus.epfl.ch/cgi-bin/getHoraire?'. $params;
+        //$url = 'https://test-menus.epfl.ch/cgi-bin/getHoraire?'. $params;
 
         $response = wp_remote_get($url);
 
@@ -43,7 +43,7 @@ function epfl_restauration_process_shortcode( $atts, $content = null ) {
         /* Prod */
         $url = 'https://menus.epfl.ch/cgi-bin/getMenus?'. $params;
         /* uncomment following line to access test environment */
-        $url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
+        //$url = 'https://test-menus.epfl.ch/cgi-bin/getMenus?'. $params;
 
         /* Adding JavaScript */
         wp_enqueue_script( 'epfl_restauration_script', plugin_dir_url(__FILE__).'js/script.js' );


### PR DESCRIPTION
**High level changes:**

1. Ajout d'un paramètre `type=` pour définir si on veut afficher le menu (par défaut si le paramètre est omis) ou les horaires. Dans ce cas-là, il faut mettre `type="schedule"`