### PR TITLE
EPFL-Emploi : moving filters on the left side of page... (2010)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-emploi/css/style-filter-left.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style-filter-left.css
@@ -1,0 +1,12 @@
+.search-filters {
+	float:left;
+	margin: 0px 20px 0px; 20px;
+}
+
+#id_themes{
+	padding-left: 20px;
+	margin-bottom:3px;
+	columns: 1;
+	-webkit-columns: 1;
+	-moz-columns: 1;
+}

--- a/data/wp/wp-content/plugins/epfl-emploi/css/style-filter-top.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style-filter-top.css
@@ -1,0 +1,7 @@
+#id_themes{
+	padding-left: 20px;
+	margin-bottom:3px;
+	columns: 3;
+	-webkit-columns: 3;
+	-moz-columns: 3;
+}

--- a/data/wp/wp-content/plugins/epfl-emploi/css/style.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style.css
@@ -1,3 +1,4 @@
+
 .panel-content {
 	padding: .3075em 0
 }
@@ -8,16 +9,13 @@
 .panel-header {
 	border-bottom: 1px solid #000;
 	text-transform: uppercase;
-	font-size: 1.2em;
-	line-height: 1.2em;
+	font-size: 1.0em;
+	line-height: 1.3em;
 	margin-bottom: 6px;
 }
 #id_themes{
 	padding-left: 20px;
 	margin-bottom:3px;
-	columns: 3;
-	-webkit-columns: 3;
-	-moz-columns: 3;
 }
 #id_themes li{
 	list-style-position: outside;
@@ -30,7 +28,7 @@ button.right{
 }
 #id_keywords {
 	display: inline-block;
-	width: 80%;
+	width: 90%;
 	position: relative;
 	height: 25px;
 	vertical-align: baseline;

--- a/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
+++ b/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
@@ -14,11 +14,14 @@ function epfl_emploi_process_shortcode( $atts, $content = null ) {
     $atts = shortcode_atts( array(
         'url' => '',
         'except_positions' => '',
+        // to choose filter display location. "left" is default (for 2018) and we can select "top"
+        'filter_pos' => 'left',
     ), $atts );
 
     /* We transform &amp; to & (and also others encoded things) to have a clean URL to work with*/
     $url                = htmlspecialchars_decode($atts['url']);
-    $except_positions   = $atts['except_positions'];
+    $except_positions   = sanitize_text_field($atts['except_positions']);
+    $filter_pos         = sanitize_text_field($atts['filter_pos']);
 
     if($url == '')
     {
@@ -44,6 +47,17 @@ function epfl_emploi_process_shortcode( $atts, $content = null ) {
 
     /* Including CSS file*/
     wp_enqueue_style( 'epfl_emploi_style', plugin_dir_url(__FILE__).'css/style.css' );
+
+    if($filter_pos == 'left')
+    {
+        wp_enqueue_style( 'epfl_emploi_filter_style', plugin_dir_url(__FILE__).'css/style-filter-left.css' );
+    }
+    else
+    {
+        wp_enqueue_style( 'epfl_emploi_filter_style', plugin_dir_url(__FILE__).'css/style-filter-top.css' );
+    }
+
+    /* Including Script */
     wp_enqueue_script( 'epfl_emploi_filter_array_emulate', plugin_dir_url(__FILE__).'js/prototype-filter-emulate.js' );
     wp_enqueue_script( 'epfl_emploi_script', plugin_dir_url(__FILE__).'js/script.js' );
 
@@ -61,40 +75,64 @@ function epfl_emploi_process_shortcode( $atts, $content = null ) {
     /* We replace query in original url to have 'searchPositionUrl' value for JS */
     $url_search_position = str_replace($url_query, $new_url_query, $url);
 
-ob_start();
+    ob_start();
 
+    /* If filters must appears on the left, */
+    if($filter_pos=='left')
+    {
 ?>
+<div class="container">
 
-<div class="panel-content keywords-panel form"><input id="id_keywords" name="keywords" type="text" />
-<button class="themed search-button keywords-button" name="search" onclick="onSelectionChanged()"><span class="icon-search">&nbsp;</span></button></div>
+    <div class="search-filters">
+<?PHP } ?>
 
-<div aria-expanded="true" aria-hidden="false" aria-labelledby="toggle-1" class="list-unstyled toggle-expanded" id="toggle-pane-0">&nbsp;</div>
+        <div class="panel-content keywords-panel form">
+            <input id="id_keywords" name="keywords" type="text" />
+            <button class="themed search-button keywords-button" name="search" onclick="onSelectionChanged()">
+                <span class="icon-search">&nbsp;</span>
+            </button>
+        </div>
 
-<div class="toolbar-emploi actu-advanced-search-toolbar ui-toolbar" data-widget="toolbar" role="toolbar">
-    <button class="toolbar-item" name="search" onclick="onSelectionChanged()" role="button" tabindex="0"><?PHP echo __('Search', 'epfl-emploi'); ?></button>
-    <button class="toolbar-item right" onclick="reset()"><?PHP echo __('Reset', 'epfl-emploi'); ?></button>
+        <div aria-expanded="true" aria-hidden="false" aria-labelledby="toggle-1" class="list-unstyled toggle-expanded" id="toggle-pane-0">&nbsp;</div>
 
-    <!-- URLs -->
-    <input type="hidden" id="EPFLEmploiDefaultUrl" value="<?PHP echo $url; ?>">
-    <input type="hidden" id="EPFLEmploiSearchPositionUrl" value="<?PHP echo $url_search_position; ?>">
+        <div class="toolbar-emploi actu-advanced-search-toolbar ui-toolbar" data-widget="toolbar" role="toolbar">
+            <button class="toolbar-item" name="search" onclick="onSelectionChanged()" role="button" tabindex="0"><?PHP echo __('Search', 'epfl-emploi'); ?></button>
+            <button class="toolbar-item right" onclick="reset()"><?PHP echo __('Reset', 'epfl-emploi'); ?></button>
 
-    <!-- Parameters -->
-    <input type="hidden" id="EPFLEmploiExceptPositions" value="<?PHP echo $except_positions; ?>">
+            <!-- URLs -->
+            <input type="hidden" id="EPFLEmploiDefaultUrl" value="<?PHP echo $url; ?>">
+            <input type="hidden" id="EPFLEmploiSearchPositionUrl" value="<?PHP echo $url_search_position; ?>">
 
-
-    <!-- Lang & Translations -->
-    <input type="hidden" id="EPFLEmploiLang" value="<?PHP echo $lang_to_id[$lang]; ?>">
-    <input type="hidden" id="EPFLEmploiTransFunction" value="<?PHP echo esc_attr__('Function', 'epfl-emploi'); ?>">
-    <input type="hidden" id="EPFLEmploiTransLocation" value="<?PHP echo esc_attr__('Location', 'epfl-emploi'); ?>">
-    <input type="hidden" id="EPFLEmploiTransWorkRate" value="<?PHP echo esc_attr__('Work Rate', 'epfl-emploi'); ?>">
-    <input type="hidden" id="EPFLEmploiTransEmplTerm" value="<?PHP echo esc_attr__('Term of employment', 'epfl-emploi'); ?>">
+            <!-- Parameters -->
+            <input type="hidden" id="EPFLEmploiExceptPositions" value="<?PHP echo $except_positions; ?>">
 
 
+            <!-- Lang & Translations -->
+            <input type="hidden" id="EPFLEmploiLang" value="<?PHP echo $lang_to_id[$lang]; ?>">
+            <input type="hidden" id="EPFLEmploiTransFunction" value="<?PHP echo esc_attr__('Function', 'epfl-emploi'); ?>">
+            <input type="hidden" id="EPFLEmploiTransLocation" value="<?PHP echo esc_attr__('Location', 'epfl-emploi'); ?>">
+            <input type="hidden" id="EPFLEmploiTransWorkRate" value="<?PHP echo esc_attr__('Work Rate', 'epfl-emploi'); ?>">
+            <input type="hidden" id="EPFLEmploiTransEmplTerm" value="<?PHP echo esc_attr__('Term of employment', 'epfl-emploi'); ?>">
+        </div>
+
+<?PHP
+/* If filters must appears on the left, */
+    if($filter_pos=='left')
+    {
+?>
+    </div>
+<?PHP } ?>
+
+    <div id="umantis_iframe">&nbsp;</div>
+
+<?PHP
+/* If filters must appears on the left, */
+    if($filter_pos=='left')
+    {
+?>
 </div>
 
-<div id="umantis_iframe">&nbsp;</div>
-
-<?php
+<?php }
 
 return ob_get_clean();
 }


### PR DESCRIPTION
**High level changes:**

version 2010 de #911 

1. Petite diminution (encore) de la taille de la police pour le texte qui est en majuscule au-dessus des catégories de filtres.
1. Demande de pouvoir déplacer les filtres de recherche dynamiques sur la gauche (parce qu'ils ont vu ça sur https://actu.epfl.ch et c'est zoli) 
1. Ajout d'une possibilité de positionner les filtres sur la gauche ou au-dessus comme précédemment (par défaut, c'est sur la gauche). C'est l'attribut `filter_pos="top"` qui permet d'afficher les filtres au-dessus. Cette manière de faire avec un paramètre permettant de contrôler la position des filtres a été faite : 
- pour pouvoir faire en sorte que le même plugin puisse continuer à fonctionner sur 2010 également (même s'il va disparaître)
- pour s'affranchir d'un potentiel re-changement d'avis de la part des Webmasters pour dire que finalement, c'est plus joli au-dessus....
