### PR TITLE
Plugins : Various fixes (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.0
+ * @version: 1.1
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -32,6 +32,7 @@ function epfl_jahia_redirect_debug( $var ) {
 */
 function update_jahia_redirections($post_id, $post_after, $post_before){
 
+
     /* If permalink is still the same */
     if($post_before->post_name == $post_after->post_name) return;
 
@@ -45,7 +46,24 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
     /* Looping through redirections to update if necessary */
     for($i=0; $i<sizeof($redirect_list); $i++)
     {
-        $redirect_list[$i] = preg_replace('/\/'.$post_before->post_name.'\/$/', "/".$post_after->post_name."/", $redirect_list[$i]);
+        /* If current entry matches */
+        if(preg_match('/\/'.$post_before->post_name.'\/$/', $redirect_list[$i])===1)
+        {
+            /* If page was put in trash, */
+            if($post_after->post_status == 'trash')
+            {
+                /* We remove redirect to page because now in the trash... */
+                unset($redirect_list[$i]);
+            }
+            else /* Page was just renamed */
+            {
+                $redirect_list[$i] = preg_replace('/\/'.$post_before->post_name.'\/$/', "/".$post_after->post_name."/", $redirect_list[$i]);
+            }
+
+            /* We can exit the loop because we found page slug and it is unique so continue looking is useless */
+            break;
+        }
+
     }
 
     /* .htaccess update */

--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -18,6 +18,34 @@ function epfl_jahia_redirect_debug( $var ) {
     print "</pre>";
 }
 
+
+/*
+    GOAL : Go through given redirection list to see if redirection to trashed pages are commented.
+            Commenting redirection of trashed pages wasn't initially done in this plugin so this
+            function is just here to have a correct state for all redirections before starting
+            to handle pages trashed and untrashed.
+
+    IN   : $redirect_list   -> Array with redirections present in .htaccess file
+
+    RET  : Updated redirection list.
+*/
+function jahia_redirection_comment_trashed_pages($redirect_list)
+{
+
+    /* Looping through redirections to update if necessary */
+    for($i=0; $i<sizeof($redirect_list); $i++)
+    {
+        /* If current entry is trashed and is not commented */
+        if(preg_match('/^[^#](.*)__trashed\/$/', $redirect_list[$i])===1)
+        {
+            /* We comment it */
+            $redirect_list[$i] = '#'.$redirect_list[$i];
+        }
+    }
+
+    return $redirect_list;
+}
+
 /*
     GOAL : Update .htaccess redirection file
 
@@ -32,16 +60,18 @@ function epfl_jahia_redirect_debug( $var ) {
 */
 function update_jahia_redirections($post_id, $post_after, $post_before){
 
-
-    /* If permalink is still the same */
-    if($post_before->post_name == $post_after->post_name) return;
-
     $htaccess = get_home_path().".htaccess";
 
     $redirect_list = extract_from_markers( $htaccess, JAHIA_REDIRECT_MARKER);
 
     /* If no redirection in .htaccess file, */
     if(sizeof($redirect_list)==0) return;
+
+    /* We first comment redirections on trashed pages if any */
+    $redirect_list = jahia_redirection_comment_trashed_pages($redirect_list);
+
+    /* If permalink is still the same */
+    if($post_before->post_name == $post_after->post_name) return;
 
     /* Looping through redirections to update if necessary */
     for($i=0; $i<sizeof($redirect_list); $i++)

--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -49,15 +49,27 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
         /* If current entry matches */
         if(preg_match('/\/'.$post_before->post_name.'\/$/', $redirect_list[$i])===1)
         {
-            /* If page was put in trash, */
-            if($post_after->post_status == 'trash')
+            /* We update slug */
+            $redirect_list[$i] = preg_replace('/\/'.$post_before->post_name.'\/$/', "/".$post_after->post_name."/", $redirect_list[$i]);
+
+            /* If page is now in trash, */
+            if($post_before->post_status != 'trash' && $post_after->post_status == 'trash')
             {
-                /* We remove redirect to page because now in the trash... */
-                unset($redirect_list[$i]);
+                /* We comment the line so redirection won't be done on trashed page but information will still
+                be available in .htaccess in case we restore the page from trash */
+                if($redirect_list[$i][0] != '#')
+                {
+                    $redirect_list[$i] = '#'.$redirect_list[$i];
+                }
             }
-            else /* Page was just renamed */
+            /* If page was restored from trash */
+            else if($post_before->post_status == 'trash' && $post_after->post_status != 'trash')
             {
-                $redirect_list[$i] = preg_replace('/\/'.$post_before->post_name.'\/$/', "/".$post_after->post_name."/", $redirect_list[$i]);
+                /* If line is commented, we remove comment */
+                if($redirect_list[$i][0] == '#')
+                {
+                    $redirect_list[$i] = substr($redirect_list[$i],1);
+                }
             }
 
             /* We can exit the loop because we found page slug and it is unique so continue looking is useless */

--- a/data/wp/wp-content/plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/plugins/epfl-stats/epfl-stats.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-Stats
  * Description: Provide a filter to allow others plugins to log duration of their external call to webservices
- * @version: 1.0
+ * @version: 1.1
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -18,6 +18,7 @@ use Prometheus\CollectorRegistry;
 */
 function epfl_stats_perf($url, $duration)
 {
+
 
     global $wp;
 
@@ -44,7 +45,7 @@ function epfl_stats_perf($url, $duration)
                             $query,
                             floor(microtime(true)*1000)]);
 
-    error_log('logging URL $url\n');
+    error_log("logging URL $url = (".($duration*1000)." ms)");
 
 }
 


### PR DESCRIPTION
@lvenries : je te file le review de cette PR principalement pour le point sur les redirections, voir si tu es OK avec ce fonctionnement

**High level changes:**

Equivalent 2010 de #915

1. *epfl-stats* : le logging était mal fait via `error_log()`... fait un peu vite des simples quotes utilisées donc chaîne pas formatée correctement
1. *EPFL_jahia_redirect* : 
- Ajout de la gestion des pages qui passent dans la corbeille. A ce moment-là, la ligne de la redirection est mise en commentaire dans le fichier `.htaccess` (en plus que le slug soit renommé). Lors du restore de la page depuis la corbeille, le slug est remis à jour dans la redirection et la ligne est décommentée.
- Vu qu'il peut potentiellement y avoir des redirections qui existent déjà pour des pages dans 'trash', ajout d'un bout de code qui se chargera de commenter ces lignes (facile vu que les slugs de ces pages finissent par `__trashed`) afin que le reste du code de gestion de ces pages puisse fonctionner correctement.

