### PR TITLE
Single scheme to access pods for REST calls

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/rest.php
+++ b/data/wp/wp-content/plugins/epfl/lib/rest.php
@@ -318,7 +318,7 @@ class _RESTRequestBase
              * another one. In that case, the Host: header will still
              * be sent as if from the original query.
              */
-            $hostport_filtered = apply_filters("epfl_rest_rewrite_connect_to", $hostport, $host, $port);
+            $hostport_filtered = apply_filters("epfl_rest_rewrite_connect_to", $hostport, $this->url, $host, $port);
 
             $exploded = explode(':', $hostport_filtered);
             $this->_connect_to = (object) array(
@@ -464,17 +464,19 @@ class _RESTRequestSocketFireAndForget extends _RESTRequestBase {
     }
 }
 
-if (php_sapi_name() !== 'cli') {
-    add_filter('epfl_rest_rewrite_connect_to', function($hostport, $host, $port) {
-        $myhostport = Site::my_hostport();
-        if ($hostport === $myhostport ||
-            $hostport === "$myhostport:443") {
-            return "localhost:8443";
+add_filter('epfl_rest_rewrite_connect_to', function($hostport, $url) {
+    if ($hostport === "www.epfl.ch:443") {
+        if (preg_match('/labs', $url)) {
+            return "httpd-labs:8443";
         } else {
-            return $hostport;
+            return "httpd-www:8443";
         }
-    }, 10, 3);
-}
+    } elseif ($hostport === "jahia2wp-httpd:443") {
+        return "jahia2wp-httpd:8443";
+    } else {
+        return $hostport;
+    }
+}, 10, 2);
 
 
 /**

--- a/data/wp/wp-content/plugins/epfl/menus/wpcli.php
+++ b/data/wp/wp-content/plugins/epfl/menus/wpcli.php
@@ -15,18 +15,6 @@ use function EPFL\I18N\___;
 require_once(__DIR__ . '/epfl-menus.php');
 use \EPFL\Menus\ExternalMenuItem;
 
-add_filter('epfl_rest_rewrite_connect_to', function($hostport, $host, $port) {
-    // TODO: this is not a way to go through life, son
-    if ($hostport === "www.epfl.ch:443") {
-        return "httpd-www:8443";
-    } elseif ($hostport === "jahia2wp-httpd:443") {
-        return "jahia2wp-httpd:8443";
-    } else {
-        return $hostport;
-    }
-}, 10, 3);
-
-
 class EPFLMenusCLICommand extends WP_CLI_Command
 {
     public static function hook () {


### PR DESCRIPTION
Turns out, the "no way to go through life" quip was unwarranted; the
scheme in wpcli.php is the best we have.

* Generalize it (no more duplication between CLI and Web)

* Change parameters to the hook function; as we found out in the case
  of "labs", the host and port are not always enough to take a guess
  where the connection should go

**From issue**: #xx

**High level changes:**

1. list here the changes in usage, from a user point of view
1. ...

**Low level changes:**

1. list here the modification made in the code structure, from a developer point of view
1. ...

**Targetted version**: x.x.x
