### PR TITLE
EPFL-Emploi - CSS/JS updates done by final user (2018)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-emploi/css/style.css
+++ b/data/wp/wp-content/plugins/epfl-emploi/css/style.css
@@ -7,9 +7,9 @@
 	padding-top: 10px;
 }
 .panel-header {
-	border-bottom: 1px solid #000;
 	text-transform: uppercase;
-	font-size: 1.0em;
+	font-size: .73em;
+	color: #707070;
 	line-height: 1.3em;
 	margin-bottom: 6px;
 }
@@ -35,6 +35,7 @@ button.right{
 	border: 1px solid #999;
 	background-color: #fff;
 	padding: 0;
+	font-size: .83em;
 }
 .keywords-button {
 	position: relative;
@@ -120,6 +121,15 @@ button.right{
 	margin-bottom: 15px;
 }
 .filter-item {
-	font-size: 11px;
 	padding-left: 5px;
+	font-size: .73em;
+	color: #707070;
+}
+
+h1 {
+	font-size: 1.5rem !important;
+}
+
+.py-5 {
+    padding-top: 1.5rem!important;
 }

--- a/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
+++ b/data/wp/wp-content/plugins/epfl-emploi/epfl-emploi.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Emploi
  * Description: provides a shortcode to display job offers
- * Version: 1.3
+ * Version: 1.4
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/data/wp/wp-content/plugins/epfl-emploi/js/script.js
+++ b/data/wp/wp-content/plugins/epfl-emploi/js/script.js
@@ -19,6 +19,12 @@ var transEmplTerm = jQuery('#EPFLEmploiTransEmplTerm').val();
 
 /***************************/
 
+jQuery(document).keyup(function(event) {
+    if (event.keyCode === 13) {
+        jQuery('button[name="search"]').click();
+    }
+});
+
 function onSelectionChanged() {
     var url = defaultUrl
     var query = jQuery('input:checkbox:checked').map(function () {


### PR DESCRIPTION
**Note** 
Le plugin "epfl-emploi" a été "délégué" à l'utilisateur final pour ce qui est de ses modifications car il n'est utilisé que sur un seul site et les utilisateurs ont les compétences pour faire le boulot.

Equivalent 2018 de #922 

1. Quelques modifications CSS/JS pour le plugin