### PR TITLE
Mu-plugin Jahia-Redirect : Detect 'rest' calls and do nothing (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.1
+ * @version: 1.2
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -59,6 +59,9 @@ function jahia_redirection_comment_trashed_pages($redirect_list)
     https://developer.wordpress.org/reference/functions/extract_from_markers/
 */
 function update_jahia_redirections($post_id, $post_after, $post_before){
+
+    /* If function doesn't exists, it means it can be a REST request so we don't do anything */
+    if(!function_exists('get_home_path')) return;
 
     $htaccess = get_home_path().".htaccess";
 


### PR DESCRIPTION
**High level changes:**

Equivalent 2018 de #924 

1. Lors des imports de sites, le mu-plugin est aussi appelé durant les requêtes REST. Et suite à une modification faite récemment, une fonction (`get_home_path()`) était appelée plus tôt dans le code et il s'avère que si c'est un appel REST, celle-ci n'existe pas ... donc check si elle existe et si ce n'est pas le cas, on sort.