### PR TITLE
ABSPATH / WP_CONTENT_DIR assumption fixes

### DIFF
--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -290,7 +290,7 @@ class Settings extends \EPFL\SettingsBase
     {
         $accred_min_version = 0.11;
         $accred_plugin_relative_path = 'accred/EPFL-Accred.php';
-        $accred_plugin_full_path = ABSPATH. 'wp-content/plugins/'. $accred_plugin_relative_path;
+        $accred_plugin_full_path = WP_CONTENT_DIR . '/plugins/'. $accred_plugin_relative_path;
 
         /* Accred Plugin missing */
         if(!is_plugin_active($accred_plugin_relative_path))

--- a/data/wp/wp-content/plugins/epfl/lib/pod.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pod.php
@@ -48,7 +48,7 @@ class Site {
                 return new $thisclass($under_htdocs);
             }
             if (! count($path_components)) {
-                throw new \Error('Unable to find root site from ' . ABSPATH);
+                throw new \Error('Unable to find root site from ' . WP_CONTENT_DIR);
             }
         }
     }
@@ -67,15 +67,21 @@ class Site {
         return is_file("$path/wp-config.php");
     }
 
+    /**
+     * @return A list of two elements, where the first is the absolute path
+     *         to the htdocs directory and the second is the relative path
+     *         from the htdocs directory to the directory containing
+     *         wp-config.php
+     */
     static private function _htdocs_split () {
-        $abspath = ABSPATH;
-        $abspath = preg_replace('#/+#', '/', $abspath);
-        if (! preg_match('#(^.*/htdocs)(/.*|)$#', $abspath, $matched)) {
-            throw new \Error('Unable to find htdocs in ' . $abspath);
+        $wp_content_dir = preg_replace('#/+#', '/', WP_CONTENT_DIR);
+        if (! preg_match('#(^.*/htdocs)(/.*|)$#', $wp_content_dir, $matched)) {
+            throw new \Error('Unable to find htdocs in ' . $wp_content_dir);
         }
         $htdocs = $matched[1];
         $below_htdocs = preg_replace('#^/#', '',
-                                     preg_replace('#/$#', '', $matched[2]));
+                                     preg_replace('#/wp-content/?$#', '',
+                                                  $matched[2]));
         return array($htdocs, $below_htdocs);
     }
 

--- a/data/wp/wp-content/plugins/epfl/lib/pod.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pod.php
@@ -67,8 +67,8 @@ class Site {
         return is_file("$path/wp-config.php");
     }
 
-    static private function _htdocs_split ($abspath = NULL) {
-        if ($abspath === NULL) { $abspath = ABSPATH; }
+    static private function _htdocs_split () {
+        $abspath = ABSPATH;
         $abspath = preg_replace('#/+#', '/', $abspath);
         if (! preg_match('#(^.*/htdocs)(/.*|)$#', $abspath, $matched)) {
             throw new \Error('Unable to find htdocs in ' . $abspath);


### PR DESCRIPTION
**From issue**: None filed

**High level changes:**

None

**Low level changes:**

The EPFL plug-in no longer assumes that `WP_CONTENT_DIR` is below `ABSPATH`, lifting a roadblock on the path to symlink-heavy deployments (where the WordPress code is in the Docker image, as opposed to the NAS). See related work in [wp-dev](https://github.com/epfl-idevelop/wp-dev/)and [wp-ops](https://github.com/epfl-idevelop/wp-ops/tree/wwp-continuous-integration)
