### PR TITLE
script pour migrer les sites de intlabs vers prodlabs

### DIFF
--- a/src/jahia2wp-utils/intlabs_to_prodlabs_backup.sh
+++ b/src/jahia2wp-utils/intlabs_to_prodlabs_backup.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+echo "Quel est le nom du site?"
+read -r site
+
+if [ ${#site} != 0 ]
+
+then 
+	#Obtenir les donnees pour creer un site wopress vide
+	blogdescription=`wp option get blogdescription --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}`
+	blogname=`wp option get blogname --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}`
+	unit=`wp option get plugin:epfl_accred:unit --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}`
+	unit_id=`wp option get plugin:epfl_accred:unit_id --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}`
+	langue=`wp polylang  --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} languages`
+
+	mapfile -t ligne <<< "$langue"
+
+	nbr_ligne=${#ligne[@]}
+
+	for (( i=0; i<${nbr_ligne}; i++ )); 
+
+	do
+		if [[ ${ligne[$i]} == *"[DEFAULT]"* ]]
+						
+		then
+			langues=${ligne[$i]:0:2} 
+		fi
+	done
+
+	for (( i=0; i<${nbr_ligne}; i++ )); 
+
+	do
+
+		if [[ ${ligne[$i]} != *"[DEFAULT]"* ]]
+
+		then
+			langues=$langues","${ligne[$i]:0:2} 
+		fi
+	done
+
+	#Mettre l'entete dans le csv
+	echo "wp_site_url,wp_tagline,wp_site_title,site_type,openshift_env,category,theme,theme_faculty,status,installs_locked,updates_automatic,langs,unit_name,unit_id," > ${site}.csv
+
+	#Mettre les donnees dans le csv
+	echo "https://www.epfl.ch/labs/"$site","\"$blogdescription\"","$blogname",wordpress,labs,GeneralPublic,Epfl,,yes,yes,yes,"\"$langues\"","$unit","$unit_id"," >> ${site}.csv
+
+	#Copier le fichier labs_to_prod dans labs
+	scp -P 32222 -o StrictHostKeyChecking=no /srv/int/jahia2wp/src/jahia2wp-utils/${site}.csv www-data@ssh-wwp.epfl.ch:/tmp/${site}.csv
+				
+	#Exporter la base de données du site
+	wp db export /tmp/${site}.sql --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}
+
+	#Compresser les medias et .htaccess
+	tar -czf /tmp/${site}.tar.gz -C /srv/int/migration-wp.epfl.ch/htdocs/labs/${site}/wp-content/ uploads
+	
+	#Copier la db et le tar dans LABS
+	scp -P 32222 -o StrictHostKeyChecking=no /tmp/${site}.sql www-data@ssh-wwp.epfl.ch:/tmp/
+	scp -P 32222 -o StrictHostKeyChecking=no /tmp/${site}.tar.gz www-data@ssh-wwp.epfl.ch:/tmp/
+		
+	#Nettoyage des fichiers temporaires
+	rm -rf /tmp/${site}.sql
+	rm -rf /srv/int/jahia2wp/src/jahia2wp-utils/${site}.csv
+	rm -rf /tmp/${site}.tar.gz
+
+
+else
+	./intlabs_to_prodlabs.sh
+fi
+
+
+

--- a/src/jahia2wp-utils/intlabs_to_prodlabs_restore.sh
+++ b/src/jahia2wp-utils/intlabs_to_prodlabs_restore.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+echo "Quel est le nom du site?"
+
+read -r site
+
+if [ ${#site} != 0 ]
+
+then
+	#Generer le site vide
+	python ../jahia2wp.py generate-many /tmp/${site}.csv
+
+	#Decompresser le tar des medias et .htaccess
+	tar -xzvf /tmp/${site}.tar.gz -C /srv/labs/www.epfl.ch/htdocs/labs/${site}/wp-content/   
+	
+	#Restaurer la base de donnees sur le site en prod
+	wp db import /tmp/${site}.sql --path=/srv/labs/www.epfl.ch/htdocs/labs/${site}
+
+	#Search and replace du site en int vers prod
+	wp search-replace migration-wp.epfl.ch/labs/${site} www.epfl.ch/labs/${site} --path=/srv/labs/www.epfl.ch/htdocs/labs/${site} --skip-columns=guid	
+	
+	#Supprimer les fichiers temporaires de backup sur la prod
+	rm /tmp/${site}.sql
+	rm /tmp/${site}.tar.gz
+      	rm /tmp/${site}.csv	
+
+	#Desactiver et activer le plugin mainwp-child pour ajotuer le site dans wp-manager
+	wp plugin deactivate mainwp-child --path=/srv/labs/www.epfl.ch/htdocs/labs/${site}	
+	wp plugin activate mainwp-child --path=/srv/labs/www.epfl.ch/htdocs/labs/${site}
+
+	#Rafraichir les externals menus
+	wp epfl-menus refresh --path=/srv/labs/www.epfl.ch/htdocs/labs/${site}	
+	
+	#Activer tous les plugins
+	wp plugin activate --all --path=/srv/labs/www.epfl.ch/htdocs/labs/${site}
+
+	#Mettre l'ancien site dans le sandbox
+	#Deplacer les fichiers du site
+	mv /srv/subdomains/${site}.epfl.ch/htdocs /srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+
+	#Editer le fichier .htacess dans subdomains
+	mkdir /srv/subdomains/${site}.epfl.ch/htdocs
+	echo "# BEGIN WordPress-Redirects-After-Ventilation" > /srv/subdomains/${site}.epfl.ch/htdocs/.htaccess
+	echo "RewriteRule ^(.*)$ https://www.epfl.ch/labs/${site}/\$1 [L,QSA,R=301]" >> /srv/subdomains/${site}.epfl.ch/htdocs/.htaccess
+	echo "# END WordPress-Redirects-After-Ventilation" >> /srv/subdomains/${site}.epfl.ch/htdocs/.htaccess
+
+	#Editer le fichier .htacess dans sandbox
+	sed -i "s|RewriteBase /|RewriteBase /$site/|g" /srv/sandbox/archive-wp.epfl.ch/htdocs/$site/.htaccess
+	sed -i "s|RewriteRule . /index.php|RewriteRule . /$site/index.php|g" /srv/sandbox/archive-wp.epfl.ch/htdocs/$site/.htaccess
+
+	#Faire search and replace du site en prod vers archive
+	wp search-replace ${site}.epfl.ch archive-wp.epfl.ch/${site} --path=/srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+
+	#Activer le coming soon et changer le texte du coming soon
+	wp option patch update seed_csp4_settings_content status 1 --path=/srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+	wp option patch update seed_csp4_settings_content headline "Archive "${site} --path=/srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+		
+	#Supprimer le plugin mainwp child
+	wp plugin deactivate mainwp-child --path=/srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+	wp plugin delete mainwp-child --path=/srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
+
+else
+	./intlabs_to_prodlabs.sh
+fi
+


### PR DESCRIPTION
1. Le script de backup sert à transférer la base de données, les médias et le .htaccess du site en labs (int) vers labs (prod) ainsi qu'à obtenir les données du site en int pour les mettre dans un fichier .csv qui permettra la création d'un site wordpress vide en prod.
1. Le script de restore sert à créer un site wordpress vide, à récupérer les médias et le .htaccess et la base de données et les mettre dans le site vide, et aussi à activer et désactiver les plugins. Dans le script il y a aussi l'archivage de l'ancien site qui était en prod.

Sur confluences, il y a la documentation pour l'utilisation des scripts 
https://confluence.epfl.ch:8443/pages/viewpage.action?pageId=88116002