### PR TITLE
EPFL-Quota: Bugfix for URL trigger to recalculate usage and set in APC (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Quota
  * Description: Allows to set quota for medias
- * Version: 0.2
+ * Version: 0.3
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/data/wp/wp-content/mu-plugins/epfl-quota/epfl-quota.php
+++ b/data/wp/wp-content/mu-plugins/epfl-quota/epfl-quota.php
@@ -295,13 +295,15 @@ add_action( 'plugins_loaded', function () {
 
     /* Loads translations */
     load_plugin_textdomain( 'epfl-quota', FALSE, basename( dirname( __FILE__ ) ) . '/languages/' );
+
+    /* If manual init/update process has been triggered,
+     NOTE: this can be done by adding "epflquotainitupdate" as GET parameter in an URL */
+    if(array_key_exists('epflquotainitupdate', $_GET))
+    {
+
+        EPFLQuota::init_update();
+    }
 } );
 
-/* If manual init/update process has been triggered,
- NOTE: this can be done by adding "epflquotainitupdate" as GET parameter in an URL */
-if(array_key_exists('epflquotainitupdate', $_GET))
-{
 
-    EPFLQuota::init_update();
-}
 


### PR DESCRIPTION
Equivalent 2018 de #935 

1. Le check pour savoir s'il y avait un paramètre `GET` demandant de reconstruire le quota était fait trop "tôt" (chargement du fichier PHP du plugin). L'action de recalcul et sauvegarde dans la DB était faite correctement mais l'appel à l'action (via `do_action`) pour ajouter l'information dans l'APC ne pouvait pas être effectué car l'action en question n'avait pas encore été ajoutée par le plugin `epfl-stats`...
On fait en sorte de décaler l'exécution du code qui check l'existence des paramètre `GET` pour que ça se fasse une fois que tous les plugins ont été chargés.

Conséquence avant correction du bug: seuls les sites sur lesquels on ajoute/supprime un média vont correctement mettre leurs informations dans l'APC afin que ça soit récupéré par Prometheus. Pour les autres, rien n'est présent.