### PR TITLE
Remote-Content: Handle different encoding and re-encode on the fly (2010)

### DIFF
--- a/data/wp/wp-content/plugins/remote-content-shortcode/remote-content-shortcode.php
+++ b/data/wp/wp-content/plugins/remote-content-shortcode/remote-content-shortcode.php
@@ -224,16 +224,19 @@ class RemoteContentShortcode {
                 $headers = array();
                 $this->extract_header_and_response($header_size, $headers, $response);
 
-                echo strlen($response);
-
-                $response_encoding = $this->get_encoding($headers);
-
-                // If response is not encoded using UTF-8
-                if(strtolower($response_encoding) != "utf-8")
+                // We ensure that function exists otherwise, if we have to re-encode, this will leads to a
+                // 500 Internal Server error. To have this function, package "mbstring" must be installed
+                if(function_exists('mb_convert_encoding'))
                 {
-                    echo "reencoding from ", $response_encoding. " to UTF-8";
-                    // we re-encode it to have UTF-8
-                    $response = mb_convert_encoding($response, "UTF-8", $response_encoding);
+
+                    $response_encoding = $this->get_encoding($headers);
+
+                    // If response is not encoded using UTF-8
+                    if(strtolower($response_encoding) != "utf-8")
+                    {
+                        // we re-encode it to have UTF-8
+                        $response = mb_convert_encoding($response, "UTF-8", $response_encoding);
+                    }
                 }
 
 				if ( $selector || $remove ){


### PR DESCRIPTION
Equivalent 2010 de https://github.com/epfl-idevelop/jahia2wp/pull/943

Lorsque la page distante dont on récupère le contenu n'est pas encodée en UTF-8, ben elle s'affiche potentiellement de manière moche... donc utilisation des headers de celle-ci pour déterminer son encodage et la ré-encoder en UTF-8 si besoin.

**Dépendances**
Pour que cette modification fonctionne, il faut que la PR https://github.com/epfl-idevelop/wp-ops/pull/25 soit mergée et l'image déployée. Si elle n'a pas été déployée, un garde fou a été mis en place pour éviter un "500 Internal Server Error"