### PR TITLE
Comments deactivation using mu-plugin (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
@@ -1,0 +1,65 @@
+<?php
+/*
+* Plugin Name: EPFL Disable Comments
+* Plugin URI:
+* Description: Must-use plugin to disable comments
+* Version: 0.1
+* Author: Lucien Chaboudez (https://people.epfl.ch/lucien.chaboudez)
+ */
+
+// Remove "comment" shortcut from admin menu (on the left)
+function epfl_dis_com_remove_menu()
+{
+   remove_menu_page( 'edit-comments.php' );
+}
+add_action( 'admin_init', 'epfl_dis_com_remove_menu' );
+
+
+// Disable widget showing last comments
+function epfl_dis_com_disable_rc_widget()
+{
+    unregister_widget( 'WP_Widget_Recent_Comments' );
+}
+add_action( 'widgets_init', 'epfl_dis_com_disable_rc_widget' );
+
+
+function epfl_dis_com_filter_wp_headers( $headers )
+{
+    unset( $headers['X-Pingback'] );
+    return $headers;
+}
+add_filter( 'wp_headers', 'epfl_dis_com_filter_wp_headers');
+
+
+function epfl_dis_com_filter_query()
+{
+    if( is_comment_feed() )
+    {
+        wp_die( __( 'Comments are closed.' ), '', array( 'response' => 403 ) );
+    }
+}
+add_action( 'template_redirect', 'epfl_dis_com_filter_query', 9 );
+
+
+// Remove "comment" icon from admin bar
+function epfl_dis_com_filter_admin_bar()
+{
+    if( is_admin_bar_showing() )
+    {
+        remove_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );
+    }
+}
+add_action( 'template_redirect', 'epfl_dis_com_filter_admin_bar' );
+add_action( 'admin_init', 'epfl_dis_com_filter_admin_bar' );
+
+
+// Deactivate comment form on all elements (posts, medias, ...)
+function epfl_dis_com_on_all( $open, $post_id ) {
+    return false;
+}
+add_filter( 'comments_open', 'epfl_dis_com_on_all', 10 , 2 );
+
+
+
+wp_deregister_script( 'comment-reply' );
+remove_action( 'wp_head', 'feed_links_extra', 3 );

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -461,6 +461,10 @@ class WPGenerator:
         else:
             WPMuPluginConfig(self.wp_site, "EPFL_disable_updates_automatic.php").install()
 
+        # Handling site category
+        if self._site_params['category'] != 'Unmanaged':
+            WPMuPluginConfig(self.wp_site, "EPFL_disable_comments.php").install()
+
     def enable_updates_automatic_if_allowed(self):
         if self.wp_config.updates_automatic:
             WPMuPluginConfig(self.wp_site, "EPFL_enable_updates_automatic.php").install()


### PR DESCRIPTION
Equivalent 2010 de #945 

1. Désactivation de la fonctionnalité de commentaires à l'aide d'un mu-plugin
1. Etant donné qu'il ne faut pas installer ce mu-plugin pour les sites unmanaged, il a été choisi de réutiliser la catégorie de site (colonne `category` dans la source de vérité) pour identifier ces sites. Il faudra donc mettre à jour la source de vérité après merge de cette PR

**Après merge**
- Update du wagon de changes
- Update de la colonne `category` de la source de vérité (onglet "Unmanaged")