### PR TITLE
Hide menu entries for image optimizer, remove notice (2010)

### DIFF
--- a/data/plugins/generic/ewww-image-optimizer/config-plugin.yml
+++ b/data/plugins/generic/ewww-image-optimizer/config-plugin.yml
@@ -70,3 +70,7 @@ tables:
     option_id: 389
     option_name: ewww_image_optimizer_webp_paths
     option_value: ''
+  - autoload: 'no'
+    option_id: 360
+    option_name: ewww_image_optimizer_dismiss_media_notice
+    option_value: '1'

--- a/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
@@ -3,7 +3,7 @@
  * Plugin Name: EPFL lock plugin and theme install and configuration
  * Plugin URI: 
  * Description: Must-use plugin for the EPFL website.
- * Version: 0.0.3
+ * Version: 0.0.4
  * Author: wwp-admin@epfl.ch
  * */
 
@@ -90,6 +90,10 @@ function EPFL_remove_admin_submenus() {
    remove_submenu_page( 'options-general.php', 'epfl_tequila' );
    remove_submenu_page( 'options-general.php', 'option-folder' );
    remove_submenu_page( 'options-general.php', 'cache_control' );
+   remove_submenu_page( 'options-general.php', 'ewww-image-optimizer/ewww-image-optimizer.php' );
+   remove_submenu_page( 'upload.php', 'ewww-image-optimizer-dynamic-debug' );
+   remove_submenu_page( 'upload.php', 'ewww-image-optimizer-queue-debug' );
+   remove_submenu_page( 'upload.php', 'ewww-image-optimizer-bulk' );
 }
 
 


### PR DESCRIPTION
Equivalent 2010 de #950 

1. Suite à #946 , il fallait aussi cacher les raccourcis pour l'optimisation des images des menus dans la console d'admin... 
1. Ajout aussi d'une petite option à l'installation du plugin pour ne pas afficher une notice