### PR TITLE
MU-Plugins updates (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Quota
  * Description: Allows to set quota for medias
- * Version: 0.3
+ * Version: 0.4
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-Stats
  * Description: Provide a filter to allow others plugins to log duration of their external call to webservices
- * @version: 1.3
+ * @version: 1.4
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -12,6 +12,10 @@ use Prometheus\CollectorRegistry;
 */
 function epfl_stats_webservice_call_duration($url, $duration)
 {
+    /* If we are in CLI mode, it's useless to update in APC because it's the APC for mgmt container and not httpd
+    container */
+    if(php_sapi_name()=='cli') return;
+
     global $wp;
 
     $url_details = parse_url($url);
@@ -26,15 +30,28 @@ function epfl_stats_webservice_call_duration($url, $duration)
 
     $registry = new CollectorRegistry($adapter);
 
+    /* To count time we spend waiting for web services (will disappear in a near future) */
     $counter = $registry->registerCounter('wp',
                                       'epfl_shortcode_duration_milliseconds',
-                                      'How long we spent waiting for Web services overall, in milliseconds',
+                                      'How long we spend waiting for Web services overall, in milliseconds',
                                        ['src', 'target_host', 'target_path', 'target_query']);
 
     $counter->incBy(floor($duration*1000), [home_url( $wp->request ),
                                             $target_host,
                                             $url_details['path'],
                                             $query]);
+
+    /* To count number of calls to web services */
+    $counter = $registry->registerCounter('wp',
+                                      'epfl_shortcode_ws_call_total',
+                                      'Number of Web service call',
+                                       ['src', 'target_host', 'target_path', 'target_query']);
+
+    $counter->inc([home_url( $wp->request ),
+                  $target_host,
+                  $url_details['path'],
+                  $query]);
+
 }
 // We register a new action so others plugins can use it to log webservice call duration
 add_action('epfl_stats_webservice_call_duration', 'epfl_stats_webservice_call_duration', 10, 2);
@@ -49,6 +66,10 @@ add_action('epfl_stats_webservice_call_duration', 'epfl_stats_webservice_call_du
 */
 function epfl_stats_media_size_and_count($used_bytes, $quota_bytes, $nb_files)
 {
+    /* If we are in CLI mode, it's useless to update in APC because it's the APC for mgmt container and not httpd
+    container */
+    if(php_sapi_name()=='cli') return;
+
     global $wp;
 
     $adapter = new Prometheus\Storage\APC();

--- a/data/wp/wp-content/mu-plugins/epfl-stats/lib/prometheus.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/lib/prometheus.php
@@ -3,7 +3,7 @@
     /* Exception */
     require_once __DIR__."/Prometheus/Exception/MetricNotFoundException.php";
     require_once __DIR__."/Prometheus/Exception/MetricsRegistrationException.php";
-    require_once __DIR__."/Prometheus/Exception/MetricNotFoundException.php";
+    require_once __DIR__."/Prometheus/Exception/StorageException.php";
 
     /* Storage */
     require_once __DIR__."/Prometheus/Storage/Adapter.php";


### PR DESCRIPTION
Equivalent 2018 de #952 

**EPFL-Quota**
1. Amélioration du code
1. Maintenant un appel avec `?epflquotainitupdate` en GET fonctionnera dans tous les cas pour forcer le rebuild du quota.
1. Ajout de l'info dans l'APC aussi si l'option contenant les infos de quota est ajoutée (c'était fait uniquement à l'update avant)

**EPFL-Stats**
1. Les stats ne sont plus ajoutées dans l'APC si on est en `cli` car ça veut dire que l'on est dans le container `mgmt` et celui-ci n'a pas d'APC et même s'il en avait un, il n'est pas interrogé par C2C pour remonter les données... ET il y aurait 2 APC avec des valeurs différentes. Ceci corrige aussi un bug rencontré par @GregLeBarbar dans la procédure de ventilation.
1. Ajout d'un compteur `wp_epfl_shortcode_ws_call_total` pour compter le nombre d'appels à un WebService. Ceci est temporaire car dans un futur proche, on fera d'une autre manière pour faire ça (Grafana).
