### PR TITLE
Do not install EPFL_jahia_redirect MU-Plugin for Unmanaged (2010)

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -447,7 +447,6 @@ class WPGenerator:
         # TODO: add those plugins into the general list of plugins (with the class WPMuPluginConfig)
         WPMuPluginConfig(self.wp_site, "epfl-functions.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_custom_editor_menu.php").install()
-        WPMuPluginConfig(self.wp_site, "EPFL_jahia_redirect.php").install()
         WPMuPluginConfig(self.wp_site, "EPFL_quota_loader.php", plugin_folder="epfl-quota").install()
         WPMuPluginConfig(self.wp_site, "EPFL_stats_loader.php", plugin_folder="epfl-stats").install()
 
@@ -464,6 +463,7 @@ class WPGenerator:
         # Handling site category
         if self._site_params['category'] != 'Unmanaged':
             WPMuPluginConfig(self.wp_site, "EPFL_disable_comments.php").install()
+            WPMuPluginConfig(self.wp_site, "EPFL_jahia_redirect.php").install()
 
     def enable_updates_automatic_if_allowed(self):
         if self.wp_config.updates_automatic:


### PR DESCRIPTION
Equivalent 2018 de #955 

Il n'y a aucune pertinence à installer ce mu-plugin pour les sites unmanaged... donc suppression de celui-ci à la création d'un site (en se basant sur la catégorie de site)