### PR TITLE
Mu-plugin - EPFL_disable_comments - Fix PHP notice (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL Disable Comments
 * Plugin URI:
 * Description: Must-use plugin to disable comments
-* Version: 0.1
+* Version: 0.2
 * Author: Lucien Chaboudez (https://people.epfl.ch/lucien.chaboudez)
  */
 
@@ -59,7 +59,10 @@ function epfl_dis_com_on_all( $open, $post_id ) {
 }
 add_filter( 'comments_open', 'epfl_dis_com_on_all', 10 , 2 );
 
+function epfl_dis_com_deregister_script()
+{
+    wp_deregister_script( 'comment-reply' );
+}
+add_filter('wp_enqueue_scripts', 'epfl_dis_com_deregister_script');
 
-
-wp_deregister_script( 'comment-reply' );
 remove_action( 'wp_head', 'feed_links_extra', 3 );


### PR DESCRIPTION
Equivalent 2010 de #959 

Suppression d'un `PHP Notice` car le `wp_deregister_script` était fait trop tôt dans le code.