### PR TITLE
Add possibility to have a post install script for plugins (2018)

### DIFF
--- a/data/plugins/generic/ewww-image-optimizer/config-plugin.yml
+++ b/data/plugins/generic/ewww-image-optimizer/config-plugin.yml
@@ -1,5 +1,7 @@
 src: web
 activate: yes
+# In normal case, plugin installs some binaries when we visit its admin config page but because it was hidden from users, install never occurs so we use a separate script to do it
+post_install_script: generic/ewww-image-optimizer/post-install.sh
 tables:
   options:
   - autoload: 'yes'

--- a/data/plugins/generic/ewww-image-optimizer/post-install.sh
+++ b/data/plugins/generic/ewww-image-optimizer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Building path using given WordPress install path
+SRC_BIN_PATH="${1}/wp-content/plugins/ewww-image-optimizer/binaries/"
+TRGT_BIN_PATH="${1}/wp-content/ewww/"
+
+# Copy a bin file from source path to target path
+function copyBin
+{
+    cp "${SRC_BIN_PATH}${1}-linux" "${TRGT_BIN_PATH}${1}"
+    chmod a+x "${TRGT_BIN_PATH}${1}"
+}
+
+# Creating target dir if not exists
+if [ ! -e ${TRGT_BIN_PATH} ]
+then
+    mkdir ${TRGT_BIN_PATH}
+fi
+
+# Copying files
+copyBin gifsicle
+copyBin jpegtran
+copyBin optipng

--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+import subprocess
 
 import settings
 from wordpress import WPConfig
@@ -57,6 +58,11 @@ class WPPluginConfig(WPConfig):
         # If we used a ZIP and it was generated 'on the fly', we do some cleaning
         if self.config.zip_path is not None and self.config.zipped_on_the_fly:
             os.remove(self.config.zip_path)
+
+        # If there is a post install script
+        if self.config.post_install_script:
+            # We execute the post install script and give him the path to WP installation
+            subprocess.call([self.config.post_install_script, self.wp_site.path])
 
     def uninstall(self):
         self.run_wp_cli('plugin deactivate {}'.format(self.name))

--- a/src/wordpress/plugins/models.py
+++ b/src/wordpress/plugins/models.py
@@ -262,6 +262,28 @@ class WPPluginConfigInfos:
             # Add try catch if exception ?
             self.tables = plugin_config['tables']
 
+        # If there's a post install script to execute
+        if 'post_install_script' in plugin_config:
+            # Creating full path to install script
+            self.post_install_script = os.path.join(settings.PLUGINS_CONFIG_BASE_FOLDER,
+                                                    plugin_config['post_install_script'])
+            # Checking if script exists
+            if not os.path.isfile(self.post_install_script):
+                error_message = "Post install script for '{}' not found ({})".format(
+                              self.plugin_name,
+                              self.post_install_script)
+                logging.error(error_message)
+                raise Exception(error_message)
+
+            # If post install script is not executable, there will be a problem later...
+            if not os.access(self.post_install_script, os.X_OK):
+                error_message = "Post install script is not executable ({})".format(self.post_install_script)
+                logging.error(error_message)
+                raise Exception(error_message)
+
+        else:
+            self.post_install_script = None
+
         # defining if we have to use a dedicated configuration class for plugin
         self.config_class = plugin_config.get('config_class', settings.WP_DEFAULT_PLUGIN_CONFIG)
 


### PR DESCRIPTION
Equivalent 2018 de #961 

Il a été constaté que le plugin ewww-image-optimizer (#947  ) qui a besoin de binaires pour bien fonctionner, installe les binaires en question dans la bon dossier (en fonction de la plateforme (OS) sur lequel on est. Et cette installation n'est effectuée que quand on va sur la page de configuration du plugin dans wp-admin (semblerait-il). Du coup, comme la page a été cachée aux utilisateurs, la "finalisation" de l'installation n'était jamais faite...
Donc, ajout de la possibilité d'exécuter un script après qu'un plugin ait été installé en étendant les fonctionnalités du fichier YAML de configuration du plugin. Le dossier d'installation du WordPress est d'office passé en paramètre au script afin qu'il puisse savoir "où" il se trouve.
Il suffit de mettre une entrée `post_install_script:` dans le fichier YAML avec le chemin relatif jusqu'à celui-ci depuis le dossier `../data/plugins/`. Ceci sera documenté dans Confluence