### PR TITLE
Fix from scipers or units

### DIFF
--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-people/epfl-people.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-people/epfl-people.php
@@ -68,7 +68,13 @@ function epfl_people_2018_process_shortcode( $attributes, $content = null )
     return Utils::render_user_msg("People shortcode: Please check required parameters");
   }
 
-  ("" !== $units) ? $parameter['units'] = $units : $parameter['scipers'] = $scipers;
+  if ("" !== $units) { 
+    $parameter['units'] = $units;
+    $from = 'units';
+  } else {
+    $parameter['scipers'] = $scipers;
+    $from = 'scipers';
+  } 
 
   if ("" !== $function) { 
     $function = str_replace(",", "+or+", $function);
@@ -118,7 +124,7 @@ function epfl_people_2018_process_shortcode( $attributes, $content = null )
 
   try
   {
-    do_action_ref_array("epfl_people_action", [$persons, $columns]);
+    do_action_ref_array("epfl_people_action", [$persons, $columns, $from]);
     return ob_get_contents();
   }
   finally


### PR DESCRIPTION
**From issue**: #xx

**High level changes:**

1. Le shortcode people fonctionne soit à partir d'une liste de scipers soit à partir d'une unité. 
Lors du choix de la liste de scipers, une personne peut être accréditée dans plusieurs unités. 
Chaque unité possède un ordre permettant d'avoir une "priorité" d'accréditation entre les différentes unités accréditées. 
Pour afficher les données, dans le cas d'un sciper, on prend l'unité d'ordre 1 alors que dans le cas d'une unité on doit prendre l'unité quelque soit son ordre. 
Il est donc important de passer l'info unité ou sciper côté thème

**Low level changes:**

1. None

**Targetted version**: x.x.x
