### PR TITLE
Support wp-cli version 1.5

### DIFF
--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -220,7 +220,10 @@ class WPConfig:
             # reformat output from wp cli
             self._config_infos = {}
             for infos in Utils.csv_string_to_dict(raw_infos):
-                self._config_infos[infos['key']] = infos['value']
+                if 'key' in infos:  # wp-cli version <= 1.4
+                    self._config_infos[infos['key']] = infos['value']
+                else:
+                    self._config_infos[infos['name']] = infos['value']
 
             logging.debug("%s - config => %s", repr(self.wp_site), self._config_infos)
 


### PR DESCRIPTION
**From issue**: N/A

**High level changes:**

`jahia2wp` now supports [WP-CLI](https://github.com/wp-cli/wp-cli/) version 1.5.

**Low level changes:**

Work around upstream column rename SNAFU in `wp config get --format=csv`