### PR TITLE
New 'epfl_study_plan' shortcode

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.21
+ * @version: 1.22
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -28,6 +28,7 @@ require_once 'shortcodes/epfl-contact/epfl-contact.php';
 require_once 'shortcodes/epfl-tableau/epfl-tableau.php';
 require_once 'shortcodes/epfl-google-forms/epfl-google-forms.php';
 require_once 'shortcodes/epfl-servicenow-search/epfl-servicenow-search.php';
+require_once 'shortcodes/epfl-study-plan/epfl-study-plan.php';
 require_once 'menus/epfl-menus.php';
 // Disabled due to 'epfl-intranet' plugin use
 //require_once 'preprod.php';

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-study-plan/epfl-study-plan.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-study-plan/epfl-study-plan.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Simple display a "remote_content" shortcode with correct URL and
+ * specific <div> around to have wanted width for display
+ */
+function epfl_study_plan_process_shortcode( $atts, $content = null ) {
+
+    $atts = shortcode_atts( array(
+            'plan' => ''
+            ), $atts );
+    $plan = sanitize_text_field($atts['plan']);
+
+    $url = "https://isa.epfl.ch/pe/".$plan;
+    ob_start();
+
+?>
+
+<div class="container my-3">[remote_content url="<?PHP echo $url; ?>" find="~content~" replace="study-plan table-like"]</div>
+
+<?php
+
+    return do_shortcode(ob_get_clean());
+}
+
+add_action( 'init', function() {
+  // define the shortcode
+  add_shortcode('epfl_study_plan', __NAMESPACE__ . '\epfl_study_plan_process_shortcode');
+});


### PR DESCRIPTION
Demande de @lvenries pour ajouter un shortcode `epfl_study_plan` prenant paramètre le plan d'étude (attribut `plan`) qui n'est au final que le nom de la page HTML que l'on veut...
Par derrière on réutilise simplement `remote_content` en l'encapsulant dans un `<div>` avec les classes adéquates pour qu'il ait la bonne largeur.

Vala à quoi ça ressemble
![image](https://user-images.githubusercontent.com/11942430/55875122-853a7900-5b94-11e9-93b9-34d40551cfbf.png)
