### PR TITLE
EPFL Plugin: Use transient to cache WebService calls

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.22
+ * @version: 1.23
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -44,7 +44,7 @@ Class Utils
      * @param cache_time_sec : Nb of sec during which we have to cache information in transient
      * @return decoded JSON data
      */
-    public static function get_items(string $url, $cache_time_sec=60) {
+    public static function get_items(string $url, $cache_time_sec=300) {
 
 
         /* Caching mechanism is only used when :

--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -44,11 +44,15 @@ Class Utils
      * @param cache_time_sec : Nb of sec during which we have to cache information in transient
      * @return decoded JSON data
      */
-    public static function get_items(string $url, $cache_time_sec=300) {
+    public static function get_items(string $url, $cache_time_sec=60) {
 
-        /* If caching has to be used (user is not logged in) and URL can be cached in transient,
-           we have a look to see if we have something already cached */
-        if(!is_user_logged_in() && $cache_time_sec > 0)
+
+        /* Caching mechanism is only used when :
+         - No user is logged.
+         - A user is logged in and he is in admin panel
+         - cache time is greater than 0
+         */
+        if((!is_user_logged_in() || (is_user_logged_in() && is_admin())) && $cache_time_sec > 0)
         {
             /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
             limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */

--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -48,8 +48,8 @@ Class Utils
 
 
         /* Caching mechanism is only used when :
-         - No user is logged.
-         - A user is logged in and he is in admin panel
+         - No user is logged in
+         - A user is logged in AND he is in admin panel
          - cache time is greater than 0
          */
         if((!is_user_logged_in() || (is_user_logged_in() && is_admin())) && $cache_time_sec > 0)

--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -40,11 +40,27 @@ Class Utils
 
     /**
      * Call API
-     * @param url  : the fetchable url
-     * @param args : array('timeout' => 10), see https://codex.wordpress.org/Function_Reference/wp_remote_get
+     * @param url            : the fetchable url
+     * @param cache_time_sec : Nb of sec during which we have to cache information in transient
      * @return decoded JSON data
      */
-    public static function get_items(string $url) {
+    public static function get_items(string $url, $cache_time_sec=300) {
+
+        /* If caching has to be used (user is not logged in) and URL can be cached in transient,
+           we have a look to see if we have something already cached */
+        if(!is_user_logged_in() && $cache_time_sec > 0)
+        {
+            /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
+            limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */
+            $transient_id = 'epfl_'.md5($url);
+
+            /* If we have an URL call result in DB, */
+            if ( false !== ( $data = get_transient($transient_id) ) )
+            {
+                 /* We return result */
+                 return json_decode($data);
+            }
+        }
 
         $start = microtime(true);
         $response = wp_remote_get($url);
@@ -64,6 +80,15 @@ Class Utils
                 error_log("Webservice " . $url . " doesn't seem to be returning JSON");
                 return False;
             } else {
+
+                /* If we have to store result in a transient,
+                (this time, we don't check if user is logged in or not so futur calls from unlogged users will
+                use cache directly)*/
+                if($cache_time_sec > 0)
+                {
+                    set_transient($transient_id, $data, $cache_time_sec);
+                }
+
                 return json_decode($data);
             }
         }


### PR DESCRIPTION
1. Caching des résultats de requêtes sur les webservices depuis le plugin EPFL (uniquement si le résultat du webservice n'est pas une erreur)
1. Durée de cache de 5min par défaut.
1. Cache utilisé uniquement si:
- L'utilisateur n'est pas connecté sur le site (partie visiteur)
- L'utilisateur est connecté sur le site (partie admin)
Ceci permet d'éditer une page en bénéficiant du cache pour que ça soit plus rapide et de voir le résultat (même avec Preview) sans que le cache soit utilisé. 

Il peut juste y avoir un effet de bord dans le cas où l'utilisateur édite en mode "visuel" et que les données renvoyées par un webservice (même URL donc) changent. Dans ce cas-là, c'est le cache local qui sera affiché. Mais dès que le mode "Preview" est utilisé, ce sont les bonnes données. A priori, ce cas de figure devrait être très peu rencontré donc c'est acceptable.