### PR TITLE
Stats: New way to log webservices calls (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-Stats
  * Description: Provide a filter to allow others plugins to log duration of their external call to webservices
- * @version: 1.4
+ * @version: 1.5
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  **/
 

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -7,10 +7,12 @@ use Prometheus\CollectorRegistry;
 /*
     Save a webservice call duration including source page and timestamp on which call occurs
 
-    @param $url         -> Webservice URL call
-    @param $duration    -> webservice call duration (seconds with microseconds)
+    @param $url             -> Webservice URL call
+    @param $duration        -> webservice call duration (seconds with microseconds)
+    @param $in_local_cache  -> TRUE|FALSE to tell if info was retrieved from local cache (transient) or not.
+                                If TRUE, we set $duration to 0.
 */
-function epfl_stats_webservice_call_duration($url, $duration)
+function epfl_stats_webservice_call_duration($url, $duration, $in_local_cache=false)
 {
     /* If we are in CLI mode, it's useless to update in APC because it's the APC for mgmt container and not httpd
     container */
@@ -29,11 +31,12 @@ function epfl_stats_webservice_call_duration($url, $duration)
                        "priority"       => "INFO",
                        "verb"           => "GET",
                        "code"           => "200",
+                       "localcache"     => ($in_local_cache) ? "hit" : "miss",
                        "src"            => home_url( $wp->request ),
                        "targethost"     => $target_host,
                        "targetpath"     => $url_details['path'],
                        "targetquery"    => (array_key_exists('query', $url_details)) ? $url_details['query'] : "",
-                       "responsetime"   => floor($duration*1000));
+                       "responsetime"   => ($in_local_cache) ? 0 : floor($duration*1000));
 
     $log_file = '/webservices/logs/ws_call_log.'.gethostname().'.'.date("Ymd");
     /* We write in file only if we can open it */

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -24,33 +24,24 @@ function epfl_stats_webservice_call_duration($url, $duration)
     $target_host  = $url_details['scheme']."://".$url_details['host'];
     if(array_key_exists('port', $url_details) && $url_details['port'] != "") $target_host .= ":".$url_details['port'];
 
-    $query = (array_key_exists('query', $url_details))?$url_details['query']:"";
+    /* Generating date/time in correct format: yyyy-MM-dd'T'HH:mm:ss.SSSZZ (ex: 2019-03-27T12:46:14.078Z ) */
+    $log_array = array("@timegenerated" => date("Y-m-d\TH:i:s.v\Z"),
+                       "priority"       => "INFO",
+                       "verb"           => "GET",
+                       "code"           => "200",
+                       "src"            => home_url( $wp->request ),
+                       "targethost"     => $target_host,
+                       "targetpath"     => $url_details['path'],
+                       "targetquery"    => (array_key_exists('query', $url_details)) ? $url_details['query'] : "",
+                       "responsetime"   => floor($duration*1000));
 
-    $adapter = new Prometheus\Storage\APC();
-
-    $registry = new CollectorRegistry($adapter);
-
-    /* To count time we spend waiting for web services (will disappear in a near future) */
-    $counter = $registry->registerCounter('wp',
-                                      'epfl_shortcode_duration_milliseconds',
-                                      'How long we spend waiting for Web services overall, in milliseconds',
-                                       ['src', 'target_host', 'target_path', 'target_query']);
-
-    $counter->incBy(floor($duration*1000), [home_url( $wp->request ),
-                                            $target_host,
-                                            $url_details['path'],
-                                            $query]);
-
-    /* To count number of calls to web services */
-    $counter = $registry->registerCounter('wp',
-                                      'epfl_shortcode_ws_call_total',
-                                      'Number of Web service call',
-                                       ['src', 'target_host', 'target_path', 'target_query']);
-
-    $counter->inc([home_url( $wp->request ),
-                  $target_host,
-                  $url_details['path'],
-                  $query]);
+    $log_file = '/webservices/logs/ws_call_log.'.gethostname().'.'.date("Ymd");
+    /* We write in file only if we can open it */
+    if(($h = fopen($log_file, 'a'))!==false)
+    {
+        fwrite($h, json_encode($log_array)."\n");
+        fclose($h);
+    }
 
 }
 // We register a new action so others plugins can use it to log webservice call duration

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -48,7 +48,7 @@ function epfl_stats_webservice_call_duration($url, $duration, $in_local_cache=fa
 
 }
 // We register a new action so others plugins can use it to log webservice call duration
-add_action('epfl_stats_webservice_call_duration', 'epfl_stats_webservice_call_duration', 10, 2);
+add_action('epfl_stats_webservice_call_duration', 'epfl_stats_webservice_call_duration', 10, 3);
 
 
 /*

--- a/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL Infoscience search shortcode
  * Plugin URI: https://github.com/epfl-idevelop/jahia2wp
  * Description: provides a shortcode to search and dispay results from Infoscience
- * Version: 1.7
+ * Version: 1.8
  * Author: Julien Delasoie
  * Author URI: https://people.epfl.ch/julien.delasoie?lang=en
  * Contributors: 
@@ -327,6 +327,8 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
             return Utils::render_user_msg("Infoscience search shortcode: Please check the url");
         }
     } else {
+        // we tell we're using the cache
+        do_action('epfl_stats_webservice_call_duration', $url, 0, true);
         // Use cache
         return $page;
     }        

--- a/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience/epfl-infoscience.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL Infoscience shortcode
  * Plugin URI: https://github.com/jaepetto/EPFL-SC-Infoscience
  * Description: provides a shortcode to dispay results from Infoscience
- * Version: 1.4
+ * Version: 1.5
  * Author: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
  * Contributors: LuluTchab, GregLeBarbar
@@ -66,6 +66,8 @@ function epfl_infoscience_process_shortcode( $attributes, $content = null )
 
         }
     } else {
+        // We tell we're using the cache
+        do_action('epfl_stats_webservice_call_duration', $url, 0, true);
         // Use cache
         return $result;
     }

--- a/data/wp/wp-content/plugins/epfl-memento/epfl-memento.php
+++ b/data/wp/wp-content/plugins/epfl-memento/epfl-memento.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: EPFL Memento shortcode
  * Description: provides a shortcode to display events feed
- * @version: 1.5
+ * @version: 1.6
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  *
  * Text Domain: epfl-memento

--- a/data/wp/wp-content/plugins/epfl-memento/utils.php
+++ b/data/wp/wp-content/plugins/epfl-memento/utils.php
@@ -16,6 +16,29 @@ Class EventUtils
      */
     public static function get_items(string $url) {
 
+
+        /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
+        limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */
+        $transient_id = 'epfl_'.md5($url);
+
+
+        /* Caching mechanism is only used when :
+         - No user is logged in
+         - A user is logged in AND he is in admin panel
+         */
+        if((!is_user_logged_in() || (is_user_logged_in() && is_admin())))
+        {
+
+            /* If we have an URL call result in DB, */
+            if ( false !== ( $data = get_transient($transient_id) ) )
+            {
+                /* We tell result has been recovered from transient cache  */
+                do_action('epfl_stats_webservice_call_duration', $url, 0, true);
+                /* We return result */
+                return json_decode($data);
+            }
+        }
+
         $start = microtime(true);
         $response = wp_remote_get( $url );
         $end = microtime(true);
@@ -27,7 +50,9 @@ Class EventUtils
             $header = $response['headers']; // array of http header lines
             $data = $response['body']; // use the content
             if ( $header["content-type"] === "application/json" ) {
-                    return json_decode($data);
+
+                set_transient($transient_id, $data, 300);
+                return json_decode($data);
             }
         }
     }

--- a/data/wp/wp-content/plugins/epfl-news/epfl-news.php
+++ b/data/wp/wp-content/plugins/epfl-news/epfl-news.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL News shortcode
  * Description: provides a shortcode to display news feed
- * @version: 1.3
+ * @version: 1.4
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl-news/utils.php
+++ b/data/wp/wp-content/plugins/epfl-news/utils.php
@@ -16,6 +16,28 @@ Class NewsUtils
      */
     public static function get_items(string $url) {
 
+        /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
+            limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */
+        $transient_id = 'epfl_'.md5($url);
+
+
+        /* Caching mechanism is only used when :
+         - No user is logged in
+         - A user is logged in AND he is in admin panel
+         */
+        if((!is_user_logged_in() || (is_user_logged_in() && is_admin())))
+        {
+
+            /* If we have an URL call result in DB, */
+            if ( false !== ( $data = get_transient($transient_id) ) )
+            {
+                /* We tell result has been recovered from transient cache  */
+                do_action('epfl_stats_webservice_call_duration', $url, 0, true);
+                /* We return result */
+                return json_decode($data);
+            }
+        }
+
         $start = microtime(true);
         $response = wp_remote_get( $url );
         $end = microtime(true);
@@ -25,11 +47,13 @@ Class NewsUtils
 
 
         if (is_array($response)) {
-                $header = $response['headers']; // array of http header lines
-                $data = $response['body']; // use the content
-                if ( $header["content-type"] === "application/json" ) {
-                        return json_decode($data);
-                }
+            $header = $response['headers']; // array of http header lines
+            $data = $response['body']; // use the content
+            if ( $header["content-type"] === "application/json" ) {
+
+                set_transient($transient_id, $data, 300);
+                return json_decode($data);
+            }
         }
     }
 }

--- a/data/wp/wp-content/plugins/epfl-people/epfl-people.php
+++ b/data/wp/wp-content/plugins/epfl-people/epfl-people.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL People shortcode
  * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
  * Description: provides a shortcode to display results from People
- * Version: 1.4
+ * Version: 1.5
  * Author: Emmanuel JAEP
  * Author URI: https://people.epfl.ch/emmanuel.jaep?lang=en
  * Contributors: LuluTchab, GregLeBarbar
@@ -75,6 +75,8 @@ function epfl_people_process_shortcode( $attributes, $content = null )
             epfl_people_log( $error );
         }
     } else {
+        // we tell we're using the cache
+        do_action('epfl_stats_webservice_call_duration', $url, 0, true);
         // Use cache
         return $result;
     }


### PR DESCRIPTION
Equivalent 2010 de #977 

1. On arrête d'additionner le temps passé à attendre des appels de webservices ainsi que de compter les appels. 
1. Ajout d'un log dans un emptydir (container filebeat) fourni par C2C. Les infos sont mises dedans au format JSON. Elles seront relues par C2C et mises dans Kibana.
1. On fait la différence entre les appels de WebService dont le résultat est retourné depuis le cache et ceux dont l'appel est réellement fait.
1. Modification des différents plugins pour aussi logguer les appels même si la réponse a pu être récupérée depuis le cache.
1. Ajout de l'utilisation du transient cache sur certains plugins.