### PR TITLE
MU-Plugin: epfl-jahia-redirect - Gutenberg fix (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,9 +2,10 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.2
+ * @version: 1.3
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
+
 
 define('JAHIA_REDIRECT_MARKER', 'Jahia-Page-Redirect');
 
@@ -62,6 +63,15 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
 
     /* If function doesn't exists, it means it can be a REST request so we don't do anything */
     if(!function_exists('get_home_path')) return;
+
+    /* Function 'extract_from_markers' is not available anymore in Gutenberg when calling 'post_updated' filter.
+    But this happens only if we have 'MainWP Child' plugin enabled... otherwise, it works... don't understand why
+
+    So if it doesn't exists, workaround is to include file in which it is contained. */
+    if(!function_exists('extract_from_markers'))
+    {
+        require_once(ABSPATH. 'wp-admin/includes/misc.php');
+    }
 
     $htaccess = get_home_path().".htaccess";
 


### PR DESCRIPTION
Equivalent 2010 de #980 

Avec Gutenberg d'activé, si on a le plugin `MainWP-Child` d'activé, ça a pour effet d'altérer le fonctionnement du mu-plugin `EPFL-jahia-redirect`. En effet, pour une raison inconnue, le fichier  `wp-admin/includes/misc.php` n'est plus inclus dans WP et donc la fonction `extract_with_markers` n'est pas disponible et on obtiens une erreur 500 lorsque l'on essaie de sauvegarder une page web.

Ajout d'un check pour si la fonction `extract_with_markers` existe et si ce n'est pas le cas, le fichier contenant sa définition est inclus.