### PR TITLE
Modification des scripts subdomains_to_intlabs

### DIFF
--- a/src/jahia2wp-utils/subdomains_to_intlab_backup.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_backup.sh
@@ -14,7 +14,7 @@ then
 	python ../jahia2wp.py backup subdomains https://$site.epfl.ch
 	echo "fin backup : " $site
 
-	scp -r -P 32222 -o StrictHostKeyChecking=no /backups/temp/_srv_subdomains_$site.epfl.ch_htdocs www-data@test-ssh-wwp.epfl.ch:/tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs
+	scp -r -P 32222 -o StrictHostKeyChecking=no /backups/temp/_srv_subdomains_$site.epfl.ch_htdocs www-data@test-ssh-wwp.epfl.ch:/tmp/_srv_subdomains_$site.epfl.ch_htdocs
 
 	rm -rf /backups/temp/_srv_subdomains_$site.epfl.ch_htdocs
 

--- a/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
@@ -44,10 +44,10 @@ then
 	chmod +x theme_2018.py)
 
 	(cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-content/themes
-	python /tmp/theme_2018/theme_2018.py theme_2018 https://github.com/epfl-idevelop/wp-theme-2018/tree/dev/wp-theme-2018)
+	python /tmp/theme_2018/theme_2018.py wp-theme-2018 https://github.com/epfl-idevelop/wp-theme-2018/tree/dev/wp-theme-2018)
 
 	#Activer le theme 2018
-	wp theme activate theme_2018 --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	wp theme activate wp-theme-2018 --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
 	#Suppression de theme_2018.py
 	rm -r /tmp/theme_2018

--- a/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
@@ -7,12 +7,12 @@ if [ ${#site} != 0 ]
 
 then
 	#Restauration des fichiers dans le repertoire du site
-	cd /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/
+	cd /tmp/_srv_subdomains_$site.epfl.ch_htdocs/
 
-	tar xzvf /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/*_full.tar.gz -C /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs
+	tar xzvf /tmp/_srv_subdomains_$site.epfl.ch_htdocs/*_full.tar.gz -C /tmp/_srv_subdomains_$site.epfl.ch_htdocs
 
 	#Deplacer les fichiers dans le bon repertoire
-	mv /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/srv/subdomains/$site.epfl.ch/htdocs /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	mv /tmp/_srv_subdomains_$site.epfl.ch_htdocs/srv/subdomains/$site.epfl.ch/htdocs /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
 	#Modifier la valeur dans le fichier wp-config.php du site sur INT par db-wwp.epfl.ch par test-db-wwp.epfl.ch
 	cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
@@ -22,10 +22,10 @@ then
 	#Creation de la base vide
 	DB_USER=`grep DB_USER /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_PASSWORD=`grep DB_PASSWORD /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_NAME=`grep DB_NAME /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && mysql -h test-db-wwp.epfl.ch -u oswproot --password=Pei8vao6Teiv -e "CREATE USER '$DB_USER' IDENTIFIED BY '$DB_PASSWORD';CREATE DATABASE $DB_NAME;GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER';"
 	
-	wp db import /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/*.sql --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	wp db import /tmp/_srv_subdomains_$site.epfl.ch_htdocs/*.sql --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
 	#Suppression de l'importation des backups
-	rm -rf /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs
+	rm -rf /tmp/_srv_subdomains_$site.epfl.ch_htdocs
 
 	#Changement de .htaccess
 	sed -i "s|RewriteBase /|RewriteBase /labs/$site|g" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/.htaccess
@@ -87,6 +87,10 @@ then
 	#Mettre le resultat de la requete SQL dans un fichier .txt
         wp db query 'SELECT ID, post_date, post_content, post_title, post_name, post_status FROM wp_posts WHERE post_content like "%[epfl_infoscience %" and post_type="page" and post_status = "publish"' --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} > /tmp/contenu_des_pages_${site}.txt
         
+	#Optimiser les images
+        wp ewwwio optimize all --noprompt --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}
+        wp media regenerate --only-missing --yes --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}
+
 	#Savoir quelles sont les pages qui contiennent l'ancien plugin infoscience
         myfile="/tmp/contenu_des_pages_${site}.txt"
         while IFS=$'\t' read -r -a myArray


### PR DESCRIPTION
1. Suppression du répertoire "lab-import" pour faire tout directement dans le répertoire "tmp" dans les scripts subdomains_to_intlabs_backup.sh et subdomains_to_intlabs_restore.sh

1. Ajout des 2 commandes pour optimiser les images des sites dans le script subdomains_to_intlabs_restore.sh

1. Changement du nom du thème (de theme_2018 à wp-theme-2018) pour l'installation du thème de intlabs vers prodlabs