### PR TITLE
Plugin: EPFL - Add video URL redirection caching for 1 week

### DIFF
--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL
  * Description: Provides many epfl shortcodes
- * @version: 1.24
+ * @version: 1.25
  * @copyright: Copyright (c) 2017 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-video/epfl-video.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-video/epfl-video.php
@@ -11,6 +11,18 @@ require_once 'shortcake-config.php';
 
 function epfl_video_get_final_video_url($url)
 {
+
+    /* Generating unique transient ID. We cannot directly use URL (and replace some characters) because we are
+    limited to 172 characters for transient identifiers (https://codex.wordpress.org/Transients_API) */
+    $transient_id = 'epfl_'.md5($url);
+
+    /* If we have an URL call result in DB, */
+    if ( false !== ( $data = get_transient($transient_id) ) )
+    {
+        /* We return result */
+        return $data;
+    }
+
     $ch = curl_init();
     // the url to request
     curl_setopt( $ch, CURLOPT_URL, $url );
@@ -36,6 +48,9 @@ function epfl_video_get_final_video_url($url)
     }
     // close the resource
     curl_close( $ch );
+
+    /* Caching result for 1 week because it won't change a lot  */
+    set_transient($transient_id, $res, 3600*24*7);
 
     return $res;
 }


### PR DESCRIPTION
**From issue**: INC0285178

Equivalent de #991 

Le shortcode `epfl_video` faisait un appel `curl` pour voir si l'URL donnée pour la vidéo n'était pas redirigée ailleurs et c'est ensuite l'URL "finale" qui était utilisée pour le reste du traitement et l'affichage.
Sur une page mentionnée dans INC0285178, il y avait pléthore de vidéos et donc beaucoup d'appels à faire pour récupérer l'URL finale. Le chargement de la page prenait environ 50s. 
Le mécanisme des transients a été utilisé pour cacher l'URL "finale" (pour une URL source donnée) pendant 1 semaine (vu qu'à priori ça ne va pas changer tous les jours...). Il y aura donc toujours un temps de chargement important dans le cas où rien ne serait dans les transients mais si ceux-ci sont présent, on passe de 50s à 5s de temps de chargement de la page.


