### PR TITLE
Handle symlinks during 'clean' command (2010)

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -645,13 +645,21 @@ class WPGenerator:
             for dir_path in settings.WP_DIRS:
                 path = os.path.join(self.wp_site.path, dir_path)
                 if os.path.exists(path):
-                    shutil.rmtree(path)
+                    # Directory removal is different if it is symlinked
+                    if os.path.islink(path):
+                        os.unlink(path)
+                    else:
+                        shutil.rmtree(path)
 
             # clean files
             for file_path in settings.WP_FILES:
                 path = os.path.join(self.wp_site.path, file_path)
                 if os.path.exists(path):
-                    os.remove(path)
+                    # File removal is different if it is symlinked
+                    if os.path.islink(path):
+                        os.unlink(path)
+                    else:
+                        os.remove(path)
 
         # handle case where no wp_config found
         except (ValueError, subprocess.CalledProcessError) as err:


### PR DESCRIPTION
Equivalent 2010 de #995 

Les commandes `shutil.rmtree(path)` et `os.remove(path)` ne permettent pas de gérer les symlinks donc un test a été ajouté pour savoir si ce qu'on voulait supprimer était un symlink et si c'est le cas, on passe par `os.unlink` pour faire le job
