### PR TITLE
Modification des scripts de migration

### DIFF
--- a/src/jahia2wp-utils/archivage_sites_prod.sh
+++ b/src/jahia2wp-utils/archivage_sites_prod.sh
@@ -5,6 +5,9 @@ read -p "Quel est l'url du site? " url
 #Deplacer les fichiers du site
 mv /srv/subdomains/${site}.epfl.ch/htdocs /srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
 
+#Modifier le fichier wp-config.php
+sed -i "s/subdomains\/${site}.epfl.ch\/htdocs\//sandbox\/archive-wp.epfl.ch\/htdocs\/${site}/" wp-config.php
+
 #Editer le fichier .htacess dans subdomains
 mkdir /srv/subdomains/${site}.epfl.ch/htdocs
 echo "# BEGIN WordPress-Redirects-After-Ventilation" > /srv/subdomains/${site}.epfl.ch/htdocs/.htaccess

--- a/src/jahia2wp-utils/intlabs_to_prodlabs_restore.sh
+++ b/src/jahia2wp-utils/intlabs_to_prodlabs_restore.sh
@@ -40,6 +40,9 @@ then
 	#Deplacer les fichiers du site
 	mv /srv/subdomains/${site}.epfl.ch/htdocs /srv/sandbox/archive-wp.epfl.ch/htdocs/${site}
 
+	#Modifier le fichier wp-config.php
+	sed -i "s/subdomains\/${site}.epfl.ch\/htdocs\//sandbox\/archive-wp.epfl.ch\/htdocs\/${site}/" wp-config.php
+
 	#Editer le fichier .htacess dans subdomains
 	mkdir /srv/subdomains/${site}.epfl.ch/htdocs
 	echo "# BEGIN WordPress-Redirects-After-Ventilation" > /srv/subdomains/${site}.epfl.ch/htdocs/.htaccess

--- a/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
@@ -14,10 +14,12 @@ then
 	#Deplacer les fichiers dans le bon repertoire
 	mv /tmp/_srv_subdomains_$site.epfl.ch_htdocs/srv/subdomains/$site.epfl.ch/htdocs /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
-	#Modifier la valeur dans le fichier wp-config.php du site sur INT par db-wwp.epfl.ch par test-db-wwp.epfl.ch
+	#Modifier le fichier wp-config.php
 	cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
 	sed -i 's/db-wwp.epfl.ch/test-db-wwp.epfl.ch/g' /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php
+	
+	sed -i "s/subdomains\/${site}.epfl.ch\/htdocs\//int\/migration-wp.epfl.ch\/htdocs\/labs\/${site}/g" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php
 
 	#Creation de la base vide
 	DB_USER=`grep DB_USER /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_PASSWORD=`grep DB_PASSWORD /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_NAME=`grep DB_NAME /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && mysql -h test-db-wwp.epfl.ch -u oswproot --password=Pei8vao6Teiv -e "CREATE USER '$DB_USER' IDENTIFIED BY '$DB_PASSWORD';CREATE DATABASE $DB_NAME;GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER';"
@@ -54,42 +56,44 @@ then
 	
 	#Desintallations des plugins 2010
 	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site enlighter
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-FAQ
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-faq
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-google-forms
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-grid
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience-search
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-map
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-memento
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-news
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-people
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-scheduler
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Snippet
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-snippet
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-tableau
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-toggle
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-twitter
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-video
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-xml
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Share
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-buttons
 	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site shortcodes-ultimate
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-FAQ
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-faq
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-google-forms
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-grid
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience-search
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-map
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-memento
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-news
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-people
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-scheduler
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Snippet
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-snippet
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-tableau
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-toggle
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-twitter
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-video
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-xml
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Share
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-buttons
 
 	#Installer plugins 2018
-	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=epfl --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-plugin
+	wp plugin activate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl
+	wp plugin activate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site wp-media-folder
 
-	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=wp-media-folder --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-plugin
-
+	#Mettre les parametres du plugin wp-media-folder
+	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=wp-media-folder --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-options
+	
 	#Fix plugins 2010 -> 2018
 	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py shortcode-fix int https://migration-wp.epfl.ch/labs/$site/ 
 
-	#Mettre le resultat de la requete SQL dans un fichier .txt
-        wp db query 'SELECT ID, post_date, post_content, post_title, post_name, post_status FROM wp_posts WHERE post_content like "%[epfl_infoscience %" and post_type="page" and post_status = "publish"' --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} > /tmp/contenu_des_pages_${site}.txt
-        
 	#Optimiser les images
         wp ewwwio optimize all --noprompt --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}
         wp media regenerate --only-missing --yes --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}
+	
+	#Mettre le resultat de la requete SQL dans un fichier .txt
+        wp db query 'SELECT ID, post_date, post_content, post_title, post_name, post_status FROM wp_posts WHERE post_content like "%[epfl_infoscience %" and post_type="page" and post_status = "publish"' --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} > /tmp/contenu_des_pages_${site}.txt
 
 	#Savoir quelles sont les pages qui contiennent l'ancien plugin infoscience
         myfile="/tmp/contenu_des_pages_${site}.txt"


### PR DESCRIPTION
1. Modification du chemin de "WP_CONTENT_DIR" pour les scripts "archivage_sites_prod.sh", "intlabs_to_prodlabs_restore.sh" et "subdomains_to_intlab_restore.sh"

1. Désactivation des plugins au lieu de les désinstaller et mettre la configuration du plugin wp-media-folder sans l'installer sur "subdomains_to_intlab_restore.sh". 