### PR TITLE
Use intermediate ZIP file to install theme using WP-CLI (2018)

### DIFF
--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -114,20 +114,22 @@ class WPMuPluginConfig(WPConfig):
         self.path = os.path.join(self.dir_path, plugin_name)
 
     def install(self):
-        # copy files from jahia2wp/data/wp/wp-content/mu-plugins into domain/htdocs/folder/wp-content/mu-plugins
         src_path = os.path.sep.join([settings.WP_FILES_PATH, self.PLUGINS_PATH, self.name])
-        shutil.copyfile(src_path, self.path)
+
+        folder_param = ""
 
         # If we also have a folder to copy
         if self.plugin_folder:
-            src_path = os.path.sep.join([settings.WP_FILES_PATH, self.PLUGINS_PATH, self.plugin_folder])
-            target_path = os.path.join(self.dir_path, self.plugin_folder)
-            shutil.copytree(src_path, target_path)
+            folder_param = "--folder={}".format(os.path.sep.join([settings.WP_FILES_PATH,
+                                                                  self.PLUGINS_PATH,
+                                                                  self.plugin_folder]))
 
-        logging.debug("%s - Plugins - %s: Copied file from %s to %s",
-                      repr(self.wp_site),
-                      self.name, src_path,
-                      self.path)
+        # Generating MU-plugin install command.
+        # This command is not standard in WP-CLI, following package as to be installed :
+        # https://github.com/epfl-idevelop/wp-cli
+        self.run_wp_cli("mu-plugin install {} {}".format(src_path, folder_param))
+
+        logging.debug("%s - MU-Plugins - %s: Installed", repr(self.wp_site), self.name)
 
     def uninstall(self):
         if os.path.exists(self.path):

--- a/src/wordpress/themes.py
+++ b/src/wordpress/themes.py
@@ -121,7 +121,10 @@ class WPThemeConfig(WPConfig):
             command = "theme install {} {} ".format(force_option, zip_full_path)
             self.run_wp_cli(command)
 
+            # Cleaning ZIP file
+            os.remove(zip_full_path)
+
         os.chdir(initial_working_dir)
 
-        # clean the extracted mess and generated zip files, aka correct folders and remove unused one
+        # clean the extracted mess, aka correct folders and remove unused one
         shutil.rmtree(os.path.join(self.base_path, zip_base_name))


### PR DESCRIPTION
Correspondance 2018 de #1001 

- Afin de pouvoir bénéficier des modifications de WP-CLI (qui vont arriver bientôt) pour l'installation des thèmes lorsque ceux-ci sont à disposition dans l'image WordPress, il a fallu modifier la manière de faire pour l'installation au sein du code Python.
Maintenant, au lieu de simplement copier les fichiers du thème au bon endroit, on rezip ceux-ci et on utilise la commande `wp theme install ..` pour faire le job. Ceci permet de passer par le code modifié dans WP-CLI et qui check la présence du thème dans l'image.
- Utilisation d'une nouvelle commande WP-CLI pour ajouter `wp mu-plugin install <pathToFile> [--folder=<pathToFolder>]`. Celle-ci permet d'installer un MU-Plugin (et son potentiel dossier associé) en gérant les symlinks. 
*NOTE* Elle ne sera disponible qu'une fois la PR https://github.com/epfl-idevelop/wp-cli/pull/2 mergée et l'image mgmt reconstruite.