### PR TITLE
Fix and improve inventory (2018)

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -42,7 +42,7 @@ Usage:
   jahia2wp.py rotate-backup-inventory   <path>          [--dry-run] [--debug | --quiet]
   jahia2wp.py veritas               <csv_file>                      [--debug | --quiet]
   jahia2wp.py fan-global-sitemap    <csv_file> <wp_path>            [--debug | --quiet]
-  jahia2wp.py inventory             <path>                          [--debug | --quiet]
+  jahia2wp.py inventory             <path> [--skip-users]           [--debug | --quiet]
   jahia2wp.py shortcode-list        <path> [--out-csv=<out_csv>]    [--debug | --quiet]
   jahia2wp.py shortcode-details     <path> <shortcode>              [--debug | --quiet]
     [--out-csv=<out_csv>]
@@ -873,7 +873,7 @@ def backup_many(csv_file, **kwargs):
 @dispatch.on('backup-inventory')
 def backup_inventory(path, **kwargs):
     logging.info("Backup from inventory...")
-    for site_details in WPConfig.inventory(path):
+    for site_details in WPConfig.inventory(path, skip_users=True):
         if site_details.valid == settings.WP_SITE_INSTALL_OK:
             logging.info("Running backup for %s", site_details.url)
             try:
@@ -1016,10 +1016,10 @@ def shortcode_fix_many(csv_file, shortcode_name=None, **kwargs):
 
 
 @dispatch.on('inventory')
-def inventory(path, **kwargs):
+def inventory(path, skip_users=False, **kwargs):
     logging.info("Building inventory...")
     print(";".join(['path', 'valid', 'url', 'version', 'db_name', 'db_user', 'admins']))
-    for site_details in WPConfig.inventory(path):
+    for site_details in WPConfig.inventory(path, skip_users):
         print(";".join([
             site_details.path,
             site_details.valid,

--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -276,8 +276,9 @@ class WPConfig:
 
             # fetch all values
             raw_infos = self.run_wp_cli('user list --format=csv')
+            # If no user found, we initialise an empty list
             if not raw_infos:
-                raise ValueError("Could not get list of users for {}".format(self.wp_site.path))
+                raw_infos = []
 
             # reformat output from wp cli
             self._user_infos = {}


### PR DESCRIPTION
Equivalent 2018 de #1002 

L'inventaire foire lorsqu'il n'y a plus aucun utilisateur qui existe dans un site (ça peut arriver si quelqu'un s'amuse à virer tout le monde...). Donc exception, l'inventaire sort et comme le backup utilise l'inventaire pour faire le job, ben le backup n'allait pas jusqu'au bout...
Quelques modifications donc:
- Ajout de la gestion d'une liste d'utilisateurs vide (on ne propage plus d'erreur)
- Ajout d'un paramètre à `jahia2wp.py inventory` en l'état de `--skip-users` afin de ne pas rechercher les utilisateurs si on en n'a pas besoin (ça fait gagner 1sec par site environ)
- Désactivation de la recherche des utilisateurs pour l'inventaire fait pour le backup (vu que pas besoin de ceux-ci).
- Ajout de la possibilité de ne pas faire de "retry" pour une commande WP-CLI. Ceci a été utilisé pour la fonction qui défini si un WordPress est installé ( `wp core is-installed`). Si pas installé, ça générait une erreur et on faisait X retry pour rien... 