### PR TITLE
EPFL-Intranet: Fix media protection when site is symlinked (2010)

### DIFF
--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     0.12
+ * Version:     0.13
  * Author:      Lucien Chaboudez
  * Author URI:  mailto:lucien.chaboudez@epfl.ch
  */

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -1,7 +1,8 @@
 <?PHP
+    /* We have to define this to avoid any problems coming from WordPress website being symlinked */
+    if ( ! defined( 'ABSPATH' ) )
+	    define( 'ABSPATH', dirname( __FILE__ ) . '/../../../../' );
     require_once('../../../../wp-load.php');
-
-
 
     if (!is_user_logged_in())
     {


### PR DESCRIPTION
Equivalent 2010 de #1005 

Si le site est symlinké, lorsque l'on inclus `wp-load.php` (qui est un symlink) au sein du script qui protège les médias, la constante `ABSPATH` va être incorrectement définie et donc le média protégé ne pourra pas être accédé.
Ajout de la définition de `ABSPATH` avec la bonne valeur au début du fichier qui protège les médias.