### PR TITLE
Don't use 'get_home_path()' because won't work with symlinks (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.3
+ * @version: 1.4
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -73,7 +73,10 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
         require_once(ABSPATH. 'wp-admin/includes/misc.php');
     }
 
-    $htaccess = get_home_path().".htaccess";
+    /* In the past, we were using get_home_path() func to have path to .htaccess file. BUT, with WordPress symlinking
+      funcionality, get_home_path() returns path to WordPress images files = /wp/
+      So, to fix this, we access .htaccess file using a relative path from current file. */
+    $htaccess = dirname(__FILE__).'/../../.htaccess';
 
     $redirect_list = extract_from_markers( $htaccess, JAHIA_REDIRECT_MARKER);
 

--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     0.13
+ * Version:     0.14
  * Author:      Lucien Chaboudez
  * Author URI:  mailto:lucien.chaboudez@epfl.ch
  */
@@ -185,8 +185,10 @@ class Settings extends \EPFL\SettingsBase
    */
    function update_htaccess($insertion, $at_beginning=false)
    {
-
-      $filename = get_home_path().'.htaccess';
+      /* In the past, we were using get_home_path() func to have path to .htaccess file. BUT, with WordPress symlinking
+      funcionality, get_home_path() returns path to WordPress images files = /wp/
+      So, to fix this, we access .htaccess file using a relative path from current file. */
+      $filename = dirname(__FILE__).'/../../../.htaccess';
       $marker = 'EPFL-Intranet';
 
       return insert_with_markers($filename, $marker, $insertion);


### PR DESCRIPTION
INC0289387

Equivalent 2018 de #1010 

Pour les (mu-)plugins suivant, l'utilisation de `get_home_path()` lorsque le site était symlinké ne fonctionnait pas correctement car il renvoyait `/wp` ... ces 2 plugins utilisent ceci pour pouvoir modifier le fichier `.htaccess` (et donc il y a besoin du chemin jusqu'au fichier).
- epfl-intranet (plugin)
- EPFL_Jahia_Redirect (mu-plugin)

Modification pour utiliser un chemin relatif par rapport au chemin jusqu'au fichier du plugin qui exécutait ce code avant. 