### PR TITLE
Activate plugin before configuring it (2010)

### DIFF
--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -552,9 +552,16 @@ class WPGenerator:
                     else:
                         logging.info("%s - Plugins - %s: Already installed!", repr(self), plugin_name)
 
-                # By default, after installation, plugin is deactivated. So if it has to stay deactivated,
-                # we skip the "change state" process
+                # We activate plugin to be able to configure it
+                plugin_config.set_state(forced_state=True)
+
+                # Configure plugin
+                plugin_config.configure(force=force_options)
+
+                # Here, plugin is activated because it was needed to configure it. So if it has to be deactivated,
+                # we skip the "change state" process and force deactivation
                 if deactivated_plugins and plugin_name in deactivated_plugins:
+                    plugin_config.set_state(forced_state=False)
                     logging.info("%s - Plugins - %s: Deactivated state forced...", repr(self), plugin_name)
 
                 else:
@@ -565,9 +572,6 @@ class WPGenerator:
                         logging.info("%s - Plugins - %s: Activated!", repr(self), plugin_name)
                     else:
                         logging.info("%s - Plugins - %s: Deactivated!", repr(self), plugin_name)
-
-                # Configure plugin
-                plugin_config.configure(force=force_options)
 
         if strict_plugin_list:
             installed_plugins = []


### PR DESCRIPTION
Equivalent 2018 de #1013 

Dans le cas où on déciderait d'installer un plugin ET que celui-ci reste désactivé ET qu'il faille mettre de la configuration pour le plugin, cela pouvait amener à une erreur car il n'est souvent pas possible (voir impossible, difficile à dire car aucune batterie de tests n'a été effectuée...) de le configurer sans qu'une erreur soit générée.
Donc, une fois installé, le plugin est activé de force afin de pouvoir être configuré et s'il doit être désactivé, il l'est juste après.