### PR TITLE
Infoscience search, set limit by default to 100; remove empty trailing spaces

### DIFF
--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -7,12 +7,12 @@
  * Version: 1.9
  * Author: Julien Delasoie
  * Author URI: https://people.epfl.ch/julien.delasoie?lang=en
- * Contributors: 
+ * Contributors:
  * License: Copyright (c) 2018 Ecole Polytechnique Federale de Lausanne, Switzerland
 */
 
 set_include_path(get_include_path() . PATH_SEPARATOR . dirname( __FILE__) . '/lib');
- 
+
 require_once 'utils.php';
 require_once 'shortcake-config.php';
 require_once 'render.php';
@@ -64,7 +64,7 @@ define("INFOSCIENCE_SEARCH_URL", "https://infoscience.epfl.ch/search?");
         'pattern' => ['p1', $sanitize_pattern_field],
         'field' => ['f1', $convert_fields],
         'limit' => ['rg', function($value) {
-            return ($value === '') ? '1000' : $value;
+            return ($value === '') ? '100' : $value;
         }],
         'sort' => ['so', function($value) {
             return ($value === 'asc') ? 'a' : 'd';
@@ -108,7 +108,7 @@ function epfl_infoscience_search_generate_url_from_attrs($attrs) {
     $url = INFOSCIENCE_SEARCH_URL;
 
     $default_parameters = array(
-        'as' => '1',  # advanced search 
+        'as' => '1',  # advanced search
         'ln' => 'en',  #TODO: dynamic language
         'of' => 'xm',  # template format
         'sf' => 'year', # year sorting
@@ -157,7 +157,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         # or Content 2
         'pattern' => '',
         'field' => 'any',  # "any", "author", "title", "year", "unit", "collection", "journal", "summary", "keyword", "issn", "doi"
-        'limit' => 1000,  # 10,25,50,100,250,500,1000
+        'limit' => 100,
         'sort' => 'desc',  # "asc", "desc"
         # Advanced content
         'collection' => '',
@@ -169,7 +169,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         'operator3' => 'and',  # "and", "or", "and_not"
         # Presentation
         'format' => 'short',  # "short", "detailed"
-        'summary' => 'false', 
+        'summary' => 'false',
         'thumbnail' => "false",  # "true", "false"
         'group_by' => '', # "", "year", "doctype"
         'group_by2' => '', # "", "year", "doctype"
@@ -195,16 +195,16 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
 
     $attributes['group_by'] = InfoscienceGroupBy::sanitize_group_by($attributes['group_by']);
     $attributes['group_by2'] = InfoscienceGroupBy::sanitize_group_by($attributes['group_by2']);
-        
+
     $attributes['debug'] = strtolower($attributes['debug']) === 'true' ? true : false;
     $attributes['debug_data'] = strtolower($attributes['debug_data']) === 'true' ? true : false;
     $attributes['debug_template'] = strtolower($attributes['debug_template']) === 'true' ? true : false;
-    
+
     # Unset element unused in url, with backup first
     $before_unset_attributes = $attributes;
 
     $format = $attributes['format'];
-    unset($attributes['format']);    
+    unset($attributes['format']);
 
     $summary = $attributes['summary'];
     unset($attributes['summary']);
@@ -251,7 +251,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
 
     if ($url) {
         $url = trim($url);
-        # assert it is an infoscience one : 
+        # assert it is an infoscience one :
         if (preg_match('#^https?://infoscience.epfl.ch/#i', $url) !== 1) {
             $error = new WP_Error( 'not found', 'The url passed is not an Infoscience url', $url );
             return Utils::render_user_msg("Infoscience search shortcode: Please check the url");
@@ -273,7 +273,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
 
             # set default if not already set :
             if (!array_key_exists('rg', $query) || empty($query['rg'])) {
-                $query['rg'] = '1000';
+                $query['rg'] = '100';
             }
 
             #empty or not, the limit attribute has the last word
@@ -297,10 +297,10 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         # We may use http_build_query($query, null, '&amp;'); when provided urls are overencoded
         # looks fine at the moment
         $query = http_build_query($query, null);
-        
+
         # from foo[1]=bar1&foo[2]=bar2 to foo[]=bar&foo[]=bar2
         $url = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $query);
-        
+
         $url = INFOSCIENCE_SEARCH_URL . urldecode($url);
     } else {
         # no direct url were provided, build the custom one ourself
@@ -322,7 +322,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         # fetch language
         # if you can, use the method
         # use function EPFL\Language\get_current_or_default_language;
-        
+
         $default_lang = 'en';
         $allowed_langs = array('en', 'fr');
         $language = $default_lang;
@@ -339,7 +339,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
     $cache_key = md5(serialize($cache_define_by));
 
     $page = wp_cache_get( $cache_key, 'epfl_infoscience_search');
-    
+
     # not in cache ?
     if ($page === false || $debug_data || $debug_template){
         $start = microtime(true);
@@ -401,7 +401,7 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         do_action('epfl_stats_webservice_call_duration', $url, 0, true);
         // Use cache
         return $page;
-    }        
+    }
  }
 
 // Load .mo file for translation

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/shortcake-config.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/shortcake-config.php
@@ -3,8 +3,8 @@
 require_once 'utils.php';
 
 Class InfoscienceSearchShortCakeConfig
-{   
-    private static function get_field_options() 
+{
+    private static function get_field_options()
     {
         return array (
             array('value' => 'any', 'label' => esc_html__('Any field', 'epfl-infoscience-search')),
@@ -18,19 +18,6 @@ Class InfoscienceSearchShortCakeConfig
             array('value' => 'abstract', 'label' => esc_html__('Abstract', 'epfl-infoscience-search')),
             array('value' => 'keyword', 'label' => esc_html__('Keyword', 'epfl-infoscience-search')),
             array('value' => 'doi', 'label' => esc_html__('DOI', 'epfl-infoscience-search')),
-        );
-    }
-
-    private static function get_limit_options() 
-    {
-        return array (
-            array('value' => '10', 'label' => '10'),
-            array('value' => '25', 'label' => '25'), 
-            array('value' => '50', 'label' => '50'),
-            array('value' => '100', 'label' => '100'),
-            array('value' => '250', 'label' => '250'),
-            array('value' => '500', 'label' => '500'),
-            array('value' => '1000', 'label' => '1000'),
         );
     }
 
@@ -50,7 +37,7 @@ Class InfoscienceSearchShortCakeConfig
        );
     }
 
-    private static function get_format_options() 
+    private static function get_format_options()
     {
         return array (
             array('value' => 'short', 'label' => esc_html__('Short', 'epfl-infoscience-search')),
@@ -58,23 +45,23 @@ Class InfoscienceSearchShortCakeConfig
        );
     }
 
-    private static function get_summary_options() 
+    private static function get_summary_options()
     {
         return array (
             array('value' => 'false', 'label' => esc_html__('Hide', 'epfl-infoscience-search')),
             array('value' => 'true', 'label' => esc_html__('Show', 'epfl-infoscience-search')),
        );
-    }    
+    }
 
-    private static function get_thumbnail_options() 
+    private static function get_thumbnail_options()
     {
         return array (
             array('value' => 'false', 'label' => esc_html__('Hide', 'epfl-infoscience-search')),
             array('value' => 'true', 'label' => esc_html__('Show', 'epfl-infoscience-search')),
        );
-    }    
+    }
 
-    private static function get_group_by_options() 
+    private static function get_group_by_options()
     {
         return array (
             array('value' => '', 'label' => ''),
@@ -103,7 +90,7 @@ Class InfoscienceSearchShortCakeConfig
         ?>
     <script type="text/html" id="tmpl-epfl-shortcode-ui-field">
         <# if (data.title) { #>
-            <# if ( 'true' == data.is_toggle ){ #> 
+            <# if ( 'true' == data.is_toggle ){ #>
                 <h3 class="infoscience_search_toggle_header"><a href="#">[-] {{ data.title }}</a></h3>
             <# } else { #>
                 <h2>{{ data.title }}</h2>
@@ -120,7 +107,7 @@ Class InfoscienceSearchShortCakeConfig
 
     <script type="text/html" id="tmpl-epfl-shortcode-ui-field-checkbox">
         <# if (data.title) { #>
-            <# if ( 'true' == data.is_toggle ){ #> 
+            <# if ( 'true' == data.is_toggle ){ #>
                 <h3 class="infoscience_search_toggle_header"><a href="#">[-] {{ data.title }}</a></h3>
             <# } else { #>
                 <h2>{{ data.title }}</h2>
@@ -136,7 +123,7 @@ Class InfoscienceSearchShortCakeConfig
 
     <script type="text/html" id="tmpl-epfl-shortcode-ui-field-select">
         <# if (data.title) { #>
-            <# if ( 'true' == data.is_toggle ){ #> 
+            <# if ( 'true' == data.is_toggle ){ #>
                 <h3 class="infoscience_search_toggle_header"><a href="#">[-] {{ data.title }}</a></h3>
             <# } else { #>
                 <h2>{{ data.title }}</h2>
@@ -163,25 +150,25 @@ Class InfoscienceSearchShortCakeConfig
 			<p class="description">{{{ data.description }}}</p>
 		<# } #>
 	</div>
-    </script>  
+    </script>
         <?php
         //@formatter:on
     }
-    
+
     public static function load_epfl_infoscience_search_wp_admin_style($hook) {
         wp_enqueue_style('epfl-infoscience-search-shortcake-style.css', plugins_url('css/epfl-infoscience-search-shortcake-style.css', __FILE__));
     }
 
     public static function load_epfl_infoscience_search_wp_admin_js($hook) {
         wp_enqueue_script( 'epfl-infoscience-search-shortcake-javascript', plugin_dir_url( __FILE__ ) . 'js/epfl-infoscience-search-shortcake.js', 1.1, array( 'shortcode-ui' ) );
-    }    
+    }
 
-    public static function config() 
+    public static function config()
     {
         # add custom epfl style
         add_action( 'enqueue_shortcode_ui', array('InfoscienceSearchShortCakeConfig', 'load_epfl_infoscience_search_wp_admin_js'));
         add_action( 'admin_enqueue_scripts', ['InfoscienceSearchShortCakeConfig', 'load_epfl_infoscience_search_wp_admin_style'], 99);
-        add_action( 'print_shortcode_ui_templates', array('InfoscienceSearchShortCakeConfig', 'shortcode_ui_epfl_field_template'));      
+        add_action( 'print_shortcode_ui_templates', array('InfoscienceSearchShortCakeConfig', 'shortcode_ui_epfl_field_template'));
 
         $documentation_url = "https://infoscience.epfl.ch/help/search-tips?ln=en";
 
@@ -230,7 +217,7 @@ Class InfoscienceSearchShortCakeConfig
                         'type'          => 'epfl-text',
                         'meta'        => array(
                             'placeholder' => 'Infoscience/Research',
-                        ),                            
+                        ),
                     ),*/
                     # Advanced content, dynamically hidden with javascript
                     array(
@@ -252,7 +239,7 @@ Class InfoscienceSearchShortCakeConfig
                         'encode'        => 'true',
                         'meta'        => array(
                             'placeholder' => 'Search key',
-                        ),  
+                        ),
                     ),
                     array(
                         'label'         => esc_html__('Third search text'),
@@ -264,7 +251,7 @@ Class InfoscienceSearchShortCakeConfig
                         'attr'          => 'field3',
                         'type'          => 'epfl-select',
                         'options'       => InfoscienceSearchShortCakeConfig::get_field_options(),
-                    ),                        
+                    ),
                     array(
                         'attr'          => 'pattern3',
                         'type'          => 'epfl-text',
@@ -288,7 +275,7 @@ Class InfoscienceSearchShortCakeConfig
                         'attr'          => 'limit',
                         'type'          => 'epfl-text',
                         'meta'        => array(
-                            'placeholder' => '1000',
+                            'placeholder' => '100',
                         ),
                     ),
                     array(
@@ -297,7 +284,7 @@ Class InfoscienceSearchShortCakeConfig
                         'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_summary_options(),
                         'value' => 'false',
-                    ),                        
+                    ),
                     array(
                         'label'         => esc_html__('Thumbnail', 'epfl-infoscience-search'),
                         'attr'          => 'thumbnail',
@@ -311,7 +298,7 @@ Class InfoscienceSearchShortCakeConfig
                         'type'          => 'radio',
                         'options'       => InfoscienceSearchShortCakeConfig::get_sort_options(),
                         'value'         => 'desc',
-                    ),                        
+                    ),
                     array(
                         'label'         => esc_html__('Group by', 'epfl-infoscience-search') . ' (1)',
                         'attr'          => 'group_by',


### PR DESCRIPTION
Set default limit publications for infoscience search plugin to 100