### PR TITLE
EPFL-Stats - new log format (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL-Stats
  * Description: Provide a filter to allow others plugins to log duration of their external call to webservices
- * @version: 1.5
+ * @version: 1.6
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 

--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -3,7 +3,7 @@
  * Plugin Name: EPFL Functions
  * Plugin URI: 
  * Description: Must-use plugin for the EPFL website.
- * Version: 0.0.9
+ * Version: 0.0.10
  * Author: Aline Keller
  * Author URI: http://www.alinekeller.ch
  */
@@ -238,7 +238,7 @@ add_shortcode('colored-box', 'colored_box');
 /* CloudFlare doesn't like the Polylang cookie (or any cookie);
  * however, we still want the homepage to use it (and bypass all
  * caches). */
-$current_url = $_SERVER["SCRIPT_URL"];
+$current_url = array_key_exists('SCRIPT_URL', $_SERVER)? $_SERVER["SCRIPT_URL"] : "" ;
 if ($current_url != "/") {
     define('PLL_COOKIE', false);
 }

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -38,7 +38,7 @@ function epfl_stats_webservice_call_duration($url, $duration, $in_local_cache=fa
                        "targetquery"    => (array_key_exists('query', $url_details)) ? $url_details['query'] : "",
                        "responsetime"   => ($in_local_cache) ? 0 : floor($duration*1000));
 
-    $log_file = '/webservices/logs/ws_call_log.'.gethostname().'.'.date("Ymd");
+    $log_file = '/call_logs/ws_call_log.'.gethostname().'.log';
     /* We write in file only if we can open it */
     if(($h = fopen($log_file, 'a'))!==false)
     {

--- a/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
+++ b/data/wp/wp-content/mu-plugins/epfl-stats/epfl-stats.php
@@ -52,7 +52,7 @@ add_action('epfl_stats_webservice_call_duration', 'epfl_stats_webservice_call_du
 
 
 /*
-    Save a webservice call duration including source page and timestamp on which call occurs
+    Save a generic duration for an action belonging to a given category
 
     @param $category        -> stat category (ex: menu, ...)
     @param $action          -> action in category (ex sync-menu, rebuild-menu, ...)


### PR DESCRIPTION
Equivalent 2018 de #1026 

- Modification de la localisation (et du nom) du fichier log utilisé pour enregistrer les temps d'appel aux webservices
- Ajout d'un nouveau fichier log pour enregistrer des choses plus génériques
- Ajout d'une nouvelle action dans WP pour enregistrer ces infos plus génériques
- Petite correction dans `epfl-functions.php` afin de supprimer un `PHP Notice` si on faisait du WP-CLI

**NOTE**
A merger en même temps que https://github.com/epfl-idevelop/wp-ops/pull/81