### PR TITLE
Remove all plugin update notices

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_disable_updates_automatic.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_disable_updates_automatic.php
@@ -27,4 +27,12 @@ add_filter( 'auto_update_theme', '__return_false' );
 // disable transalations updates
 add_filter( 'auto_update_translation', '__return_false' );
 
+// disable plugin update cues
+add_filter('user_has_cap', 'epfl_cannot_update_plugins', 10, 3);
+
+function epfl_cannot_update_plugins ($allcaps, $caps, $args) {
+    unset($allcaps['update_plugins']);
+    return $allcaps;
+}
+
 ?>


### PR DESCRIPTION
Pretend nobody has permission to perform updates (which is kind of the truth)

**From issue**: oral-tradition requirement not to show the update bar for forked plug-in "remote-content-shortcode"

**High level changes:**

No plugin update bars are visible in /wp-admin/plugins.php or anywhere

**Low level changes:**

Filter out the `update_plugins` capability from everyone's capability set.
