### PR TITLE
Fix infoscience search cache without langage

### DIFF
--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -327,26 +327,29 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
         'sort' => $attributes['sort'],
     ];
 
-    # add language to cache definer if a group_by doctype is used
-    if ($group_by === 'doctype' || ($group_by === 'year' && $group_by2 === 'doctype')) {
-        # fetch language
-        # if you can, use the method
-        # use function EPFL\Language\get_current_or_default_language;
+    # fetch language
+    # if you can, use the method
+    # use function EPFL\Language\get_current_or_default_language;
 
-        $default_lang = 'en';
-        $allowed_langs = array('en', 'fr');
-        $language = $default_lang;
-        /* If Polylang installed */
-        if(function_exists('pll_current_language'))
-        {
-            $current_lang = pll_current_language('slug');
-            // Check if current lang is supported. If not, use default lang
-            $language = (in_array($current_lang, $allowed_langs)) ? $current_lang : $default_lang;
-        }
-        $cache_define_by['language'] = $language;
+    $default_lang = 'en';
+    $allowed_langs = array('en', 'fr');
+    $language = $default_lang;
+    /* If Polylang installed */
+    if(function_exists('pll_current_language'))
+    {
+        $current_lang = pll_current_language('slug');
+        // Check if current lang is supported. If not, use default lang
+        $language = (in_array($current_lang, $allowed_langs)) ? $current_lang : $default_lang;
     }
 
+    $cache_define_by['language'] = $language;
+
     $cache_key = md5(serialize($cache_define_by));
+
+    if (is_admin()){
+        # invalidate the cache if we are editing the page
+        delete_transient( $cache_key );
+    }
 
     $page = get_transient($cache_key);
 

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -19,6 +19,7 @@ require_once 'render.php';
 require_once 'marc_converter.php';
 require_once 'group_by.php';
 require_once 'mathjax-config.php';
+require_once(ABSPATH . 'wp-admin/includes/screen.php');
 
 define("INFOSCIENCE_SEARCH_URL", "https://infoscience.epfl.ch/search?");
 
@@ -346,15 +347,16 @@ function epfl_infoscience_search_process_shortcode($provided_attributes = [], $c
 
     $cache_key = md5(serialize($cache_define_by));
 
-    if (is_admin()){
+    # check if we are here for some cache invalidation
+    if (is_admin() && current_user_can( 'edit_pages' )) {
         # invalidate the cache if we are editing the page
-        delete_transient( $cache_key );
+        delete_transient($cache_key);
     }
 
     $page = get_transient($cache_key);
 
     # not in cache ?
-    if ($page === false || $debug_data || $debug_template || is_admin()) {
+    if ($page === false || $debug_data || $debug_template) {
         $start = microtime(true);
         $response = wp_remote_get( $url, ['timeout' => 20] );
         $end = microtime(true);

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: EPFL Infoscience search shortcode
  * Plugin URI: https://github.com/epfl-idevelop/jahia2wp
  * Description: provides a shortcode to search and dispay results from Infoscience
- * Version: 1.9
+ * Version: 1.10
  * Author: Julien Delasoie
  * Author URI: https://people.epfl.ch/julien.delasoie?lang=en
  * Contributors:

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/renderers/common/links-bar.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/renderers/common/links-bar.php
@@ -1,5 +1,5 @@
 <?php
-if ($thumbnail && 
+if ($thumbnail &&
     isset($publication['url']) &&
     isset($publication['url']['icon']) &&
     $publication['url']['icon'][0]) {
@@ -10,18 +10,18 @@ if ($thumbnail &&
 	<p></p>
 	<p class="infoscience_links">
     <?php
-        echo '<a class="infoscience_link_detailed" href="https://infoscience.epfl.ch/record/'. $publication['record_id'][0] . '"?ln=en" target="_blank">' . esc_html__("Detailed record", "epfl_infoscience") . '</a>';
+        echo '<a class="infoscience_link_detailed" href="https://infoscience.epfl.ch/record/'. $publication['record_id'][0] . '"?ln=en" target="_blank">' . esc_html__("Detailed record", "epfl-infoscience-search") . '</a>';
 
         if (isset($publication['url']['fulltext']) &&
             $publication['url']['fulltext'][0]) {
             echo ' - ';
-            echo '<a class="infoscience_link_fulltext" href="'. $publication['url']['fulltext'][0] . '" target="_blank">'. esc_html__("Full text", "epfl_infoscience") .'</a>';
+            echo '<a class="infoscience_link_fulltext" href="'. $publication['url']['fulltext'][0] . '" target="_blank">'. esc_html__("Full text", "epfl-infoscience-search") .'</a>';
         }
 
         if (isset($publication['doi']) &&
             $publication['doi']) {
             echo ' - ';
-            echo '<a class="infoscience_link_official" href="https://dx.doi.org/'. $publication['doi'][0] . '" target="_blank">' . esc_html__("View at publisher", "epfl_infoscience") . '</a>';
+            echo '<a class="infoscience_link_official" href="https://dx.doi.org/'. $publication['doi'][0] . '" target="_blank">' . esc_html__("View at publisher", "epfl-infoscience-search") . '</a>';
         }
     ?>
 	</p>


### PR DESCRIPTION
- Comme nous cachions le rendu final de la page, la langue doit faire partie de la clé du cache, car les boutons "notice détaillé" font parti du rendu
- Fix le nom du fichier de traduction
- Le cache devient invalide dès que l'on édite la page, afin d'avoir un mécanisme d'invalidation de cache minimal