### PR TITLE
Fix .htaccess path generation, fix file protection for EPFL-Intranet (2018)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.4
+ * @version: 1.5
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -75,8 +75,9 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
 
     /* In the past, we were using get_home_path() func to have path to .htaccess file. BUT, with WordPress symlinking
       funcionality, get_home_path() returns path to WordPress images files = /wp/
-      So, to fix this, we access .htaccess file using a relative path from current file. */
-    $htaccess = dirname(__FILE__).'/../../.htaccess';
+      So, to fix this, we access .htaccess file using WP_CONTENT_DIR which is defined in wp-config.php file. We just
+       have to remove 'wp-content'  */
+    $htaccess = str_replace("wp-content", ".htaccess", WP_CONTENT_DIR);
 
     $redirect_list = extract_from_markers( $htaccess, JAHIA_REDIRECT_MARKER);
 

--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Intranet
  * Description: Use EPFL Accred to allow website access only to specific group(s) or just force to be authenticated
- * Version:     0.15
+ * Version:     0.16
  * Author:      Lucien Chaboudez
  * Author URI:  mailto:lucien.chaboudez@epfl.ch
  */

--- a/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/epfl-intranet.php
@@ -187,9 +187,10 @@ class Settings extends \EPFL\SettingsBase
    {
 
       /* In the past, we were using get_home_path() func to have path to .htaccess file. BUT, with WordPress symlinking
-      funcionality, get_home_path() returns path to WordPress images files = /wp/
-      So, to fix this, we access .htaccess file using a relative path from current file. */
-      $filename = dirname(__FILE__).'/../../../.htaccess';
+      functionality, get_home_path() returns path to WordPress images files = /wp/
+      So, to fix this, we access .htaccess file using WP_CONTENT_DIR which is defined in wp-config.php file. We just
+       have to remove 'wp-content' '*/
+      $filename = str_replace("wp-content", ".htaccess", WP_CONTENT_DIR);
 
       $marker = 'EPFL-Intranet';
 

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -3,7 +3,8 @@
     if ( ! defined( 'ABSPATH' ) )
 	    define( 'ABSPATH', dirname( __FILE__ ) . '/../../../../' );
 
-    require_once('../../../../wp-load.php');
+    // TODO: maybe we want to shoot the above two lines.
+    require_once(dirname($_SERVER["SCRIPT_FILENAME"]) . '../../../../wp-load.php');
 
     if (!is_user_logged_in())
     {

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -2,7 +2,9 @@
 
     /* We have to define this to avoid any problems coming from WordPress website being symlinked. If we let
      wp-load.php do the job, it will build ABSPATH with /wp/ and this will leads to an error when we will use
-     wp_upload_dir() function because it will return upload directory in WordPress image */
+     wp_upload_dir() function because it will return upload directory in WordPress image
+
+     TODO: Fixme better if possible*/
     if ( ! defined( 'ABSPATH' ) )
         /* We use SCRIPT_FILENAME instead of __FILE__ because the first one is the full path from "real" website and
          not from WordPress image. Then we remove last directories to have a full path (without any ../..) to build

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -7,7 +7,9 @@
         /* We use SCRIPT_FILENAME instead of __FILE__ because the first one is the full path from "real" website and
          not from WordPress image. Then we remove last directories to have a full path (without any ../..) to build
          ABSPATH. If we use /../../ to build ABSPATH, this will be a mix between an absolute path and a relative path
-         and PHP will interpret relative path from WordPress image so it won't point to wanted directory */
+         and PHP will interpret relative path from WordPress image so it won't point to wanted directory.
+         We also can't use WP_CONTENT_DIR to know where we are because "wp-config.php" is not loaded before current
+         script is called (this is a standalone script)*/
 	    define( 'ABSPATH',str_replace("wp-content/plugins/epfl-intranet/inc", "", dirname($_SERVER["SCRIPT_FILENAME"]) ));
 
     require_once(ABSPATH . 'wp-load.php');

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -1,17 +1,23 @@
 <?PHP
-    /* We have to define this to avoid any problems coming from WordPress website being symlinked */
-    if ( ! defined( 'ABSPATH' ) )
-	    define( 'ABSPATH', dirname( __FILE__ ) . '/../../../../' );
 
-    // TODO: maybe we want to shoot the above two lines.
-    require_once(dirname($_SERVER["SCRIPT_FILENAME"]) . '../../../../wp-load.php');
+    /* We have to define this to avoid any problems coming from WordPress website being symlinked. If we let
+     wp-load.php do the job, it will build ABSPATH with /wp/ and this will leads to an error when we will use
+     wp_upload_dir() function because it will return upload directory in WordPress image */
+    if ( ! defined( 'ABSPATH' ) )
+        /* We use SCRIPT_FILENAME instead of __FILE__ because the first one is the full path from "real" website and
+         not from WordPress image. Then we remove last directories to have a full path (without any ../..) to build
+         ABSPATH. If we use /../../ to build ABSPATH, this will be a mix between an absolute path and a relative path
+         and PHP will interpret relative path from WordPress image so it won't point to wanted directory */
+	    define( 'ABSPATH',str_replace("wp-content/plugins/epfl-intranet/inc", "", dirname($_SERVER["SCRIPT_FILENAME"]) ));
+
+    require_once(ABSPATH . 'wp-load.php');
 
     if (!is_user_logged_in())
     {
        $upload_dir = wp_upload_dir();
-       echo $upload_dir['baseurl'] . '/' . $_GET[ 'file' ];
        wp_redirect( wp_login_url( $upload_dir['baseurl'] . '/' . $_GET[ 'file' ]));
        exit();
+
     }
 
     list($basedir) = array_values(array_intersect_key(wp_upload_dir(), array('basedir' => 1)))+array(NULL);


### PR DESCRIPTION
Equivalent 2010 de #1038 

- Modification de la manière de générer le chemin d'accès au fichier `.htaccess` pour que cela fonctionne correctement avec les symlinks. Les plugins EPFL-Intranet et Mu-plugin EPFL_Jahia_redirect sont concernés
- Modification de la manière de générer `ABSPATH` dans le fichier `protect-medias.php` du plugin EPFL-Intranet pour que ça fonctionne correctement avec les symlinks