### PR TITLE
Load wp-load.php without setting ABSPATH

### DIFF
--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -2,19 +2,9 @@
 
     /* We have to define this to avoid any problems coming from WordPress website being symlinked. If we let
      wp-load.php do the job, it will build ABSPATH with /wp/ and this will leads to an error when we will use
-     wp_upload_dir() function because it will return upload directory in WordPress image
+     wp_upload_dir() function because it will return upload directory in WordPress image */
 
-     TODO: Fixme better if possible*/
-    if ( ! defined( 'ABSPATH' ) )
-        /* We use SCRIPT_FILENAME instead of __FILE__ because the first one is the full path from "real" website and
-         not from WordPress image. Then we remove last directories to have a full path (without any ../..) to build
-         ABSPATH. If we use /../../ to build ABSPATH, this will be a mix between an absolute path and a relative path
-         and PHP will interpret relative path from WordPress image so it won't point to wanted directory.
-         We also can't use WP_CONTENT_DIR to know where we are because "wp-config.php" is not loaded before current
-         script is called (this is a standalone script)*/
-	    define( 'ABSPATH',str_replace("wp-content/plugins/epfl-intranet/inc", "", dirname($_SERVER["SCRIPT_FILENAME"]) ));
-
-    require_once(ABSPATH . 'wp-load.php');
+    require_once(dirname($_SERVER["SCRIPT_FILENAME"], 5) . '/wp-load.php');
 
     if (!is_user_logged_in())
     {

--- a/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
+++ b/data/wp/wp-content/plugins/epfl-intranet/inc/protect-medias.php
@@ -1,9 +1,4 @@
 <?PHP
-
-    /* We have to define this to avoid any problems coming from WordPress website being symlinked. If we let
-     wp-load.php do the job, it will build ABSPATH with /wp/ and this will leads to an error when we will use
-     wp_upload_dir() function because it will return upload directory in WordPress image */
-
     require_once(dirname($_SERVER["SCRIPT_FILENAME"], 5) . '/wp-load.php');
 
     if (!is_user_logged_in())


### PR DESCRIPTION
After https://github.com/epfl-idevelop/wp-ops/pull/94 this works as
intended also on a symlinked site

**From issue**: INC0293322

**High level changes:**

None visible

**Low level changes:**

Simplified code