### PR TITLE
Ignore symlink while doing inventory - 2018

### DIFF
--- a/src/wordpress/config.py
+++ b/src/wordpress/config.py
@@ -82,8 +82,15 @@ class WPConfig:
             dir_names = sorted(dir_names)
             for dir_name in dir_names:
                 logging.debug('checking %s/%s', parent_path, dir_name)
+
                 try:
                     from_path = os.path.join(parent_path, dir_name)
+
+                    # We may have 'wp' symlink inside WordPress installation, we don't have to follow it.
+                    if os.path.islink(from_path):
+                        logging.debug("path %s is symlink, skipping", from_path)
+                        continue
+
                     wp_site = WPSite.from_path(from_path)
                     if wp_site is None:
                         continue


### PR DESCRIPTION
Equivalent 2018 de  #1049

Depuis peu, on a un symlink `wp` dans chaque dossier de site. Celui-ci est "suivi" par l'inventaire et la procédure de backup (via `backup-inventory`) essaie ensuite de sauvegarder le site et ça part en erreur pour le site.
Cette PR check si le dossier qu'on essaie de contrôler pour savoir si c'est un site WordPress est un symlink et si c'est le cas, on skip pour éviter les problèmes.
