### PR TITLE
Add new site category for Library

### DIFF
--- a/data/plugins/specific/Library/EPFL-Library-Plugins/config-plugin.yml
+++ b/data/plugins/specific/Library/EPFL-Library-Plugins/config-plugin.yml
@@ -1,0 +1,2 @@
+src: ../wp/wp-content/plugins/EPFL-Library-Plugins
+activate: yes

--- a/data/plugins/specific/Library/plugin-list.yml
+++ b/data/plugins/specific/Library/plugin-list.yml
@@ -1,0 +1,3 @@
+plugins:
+  - name: EPFL-Library-Plugins
+    config: !include EPFL-Library-Plugins/config-plugin.yml


### PR DESCRIPTION
- La bibliothèque ayant terminé son plugin, création d'une catégorie de site pour celle-ci afin que le plugin puisse être installé.

**Ce qu'il reste à faire**
- Modifier la source de vérité pour mettre la bonne catégorie de site (faut le faire où exactement?)
- Faire une PR dans wp-ops pour intégrer le plugin à l'installation de l'image.