### PR TITLE
Mu-Plugin: EPFL Jahia Redirect - v1.7 (2010)

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Jahia redirection updater
  * Description: Update Jahia redirection (if any) in .htaccess file when a page permalink is updated
- * @version: 1.6
+ * @version: 1.7
  * @copyright: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland
  */
 
@@ -47,6 +47,76 @@ function jahia_redirection_comment_trashed_pages($redirect_list)
     return $redirect_list;
 }
 
+
+/*
+    GOAL: Returns full slug to page. This means having the WordPress install folder (if any)
+            with the path to page including its parent.
+
+    IN  : $page -> Object containing the page for which we want full slug    
+*/
+function jahia_redirection_get_page_full_slug($page)
+{
+    /* Building page slug, ex: avengers/thor */
+    $page_slug = $page->post_name;
+    while($page->post_parent != '0')
+    {
+        $page = get_page($page->post_parent);
+        $page_slug = $page->post_name . '/'. $page_slug;
+    }
+    
+    /* Getting WP installation subfolder (if any), ex: marvel */
+    $site_folder_path = preg_replace('/(^https?:\/\/.*\/)|(\/$)/U', '', get_option('siteurl'));
+
+    /* WP is installed in a subfolder */
+    if($site_folder_path != "")
+    {
+        /* we need to build a "full" path, ex: /marvel */
+        $site_folder_path = '/'.$site_folder_path;
+    }
+
+    /* Generating relative path to page from root folder, ex: /marvel/avengers/thor
+    This is the new path to access the page */
+    return $site_folder_path.'/'.$page_slug;
+}
+
+
+
+/*
+    GOAL: Go through redirection list and comment the one have saved page slug as source.
+        This is done to avoid :
+        - wrong redirection (we want one existing page and we're redirected to another)
+        - infinite loops between several redirections
+
+    IN  : $redirect_list        -> Array with redirections present in .htaccess file
+    IN  : $after_page_full_slug -> Full slug (including install dir) to access page after saving
+ */
+function jahia_redirection_comment_wrong_redirect($redirect_list, $after_page_full_slug)
+{
+
+    /* Looping through redirections to check if we have one with the new path as source */
+    for($i=0; $i<sizeof($redirect_list); $i++)
+    {
+        list($redirect, $code, $source, $target) = explode(" ", $redirect_list[$i]);
+
+        /* If we found the new path as a redirection source */
+        if($source == $after_page_full_slug)
+        {
+            /* If line is not already commented */
+            if($redirect_list[$i][0] != '#')
+            {
+                /* We comment it */
+                $redirect_list[$i] = '#'.$redirect_list[$i].
+                                    ' # This line is commented to avoid infinite loop or wrong redirect because a page using this source has been created/modified.';
+            }
+            /* Source can only be present one time in redirection list so we can skip others redirection */
+            break;
+        }
+    }
+
+    return $redirect_list;    
+}
+
+
 /*
     GOAL : Update .htaccess redirection file
 
@@ -76,7 +146,7 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
     /* In the past, we were using get_home_path() func to have path to .htaccess file. BUT, with WordPress symlinking
       funcionality, get_home_path() returns path to WordPress images files = /wp/
       So, to fix this, we access .htaccess file using WP_CONTENT_DIR which is defined in wp-config.php file. We just
-      have to remove 'wp-content'  */
+       have to remove 'wp-content'  */
     $htaccess = str_replace("wp-content", ".htaccess", WP_CONTENT_DIR);
 
     $redirect_list = extract_from_markers( $htaccess, JAHIA_REDIRECT_MARKER);
@@ -84,58 +154,70 @@ function update_jahia_redirections($post_id, $post_after, $post_before){
     /* If no redirection in .htaccess file, */
     if(sizeof($redirect_list)==0) return;
 
+    $before_page_full_slug = jahia_redirection_get_page_full_slug($post_before);
+    $after_page_full_slug = jahia_redirection_get_page_full_slug($post_after);
+
     /* We first comment redirections on trashed pages if any */
     $redirect_list = jahia_redirection_comment_trashed_pages($redirect_list);
 
-    /* If permalink is still the same */
-    if($post_before->post_name == $post_after->post_name) return;
+    /* Trying to remove wrong redirections and infinite loop. This code is not in the for loop below because it has to 
+    be executed event if saved page slug doesn't change */
+    $redirect_list = jahia_redirection_comment_wrong_redirect($redirect_list, $after_page_full_slug);
 
-    /* Looping through redirections to update if necessary */
-    for($i=0; $i<sizeof($redirect_list); $i++)
+    /* If permalink is different */
+    if($before_page_full_slug != $after_page_full_slug)
     {
-        /* If current entry matches */
-        if(preg_match('/\/'.$post_before->post_name.'\/$/', $redirect_list[$i])===1)
+
+        /* Looping through redirections to update if necessary */
+        for($i=0; $i<sizeof($redirect_list); $i++)
         {
-            /* We create new .htaccess line */
-            $new_line = preg_replace('/\/'.$post_before->post_name.'\/$/', "/".$post_after->post_name."/", $redirect_list[$i]);
-
-            list($redirect, $code, $source, $target) = explode(" ", $new_line);
-            /* if source and target are the same (we have to add / at the end of source because it doesn't finish with / like $target do) */
-            if($source."/" == $target) 
+            /* If current entry matches */
+            if(preg_match('#'.$before_page_full_slug.'/$#', $redirect_list[$i])===1)
             {
-               /* We comment line because if we let it, we will have an infinite loop*/
-               $redirect_list[$i] = '#'.$redirect_list[$i]. 
-                                    ' # Target has changed and became same as source so this line was commented, just to keep a trace of what happened';
-            }
-            else
-            {
-               $redirect_list[$i] = $new_line;
-            }
+                
+                /* We create new .htaccess line */
+                $new_line = preg_replace('#'.$before_page_full_slug.'/$#', $after_page_full_slug."/", $redirect_list[$i]);
 
-
-            /* If page is now in trash, */
-            if($post_before->post_status != 'trash' && $post_after->post_status == 'trash')
-            {
-                /* We comment the line so redirection won't be done on trashed page but information will still
-                be available in .htaccess in case we restore the page from trash */
-                if($redirect_list[$i][0] != '#')
+                list($redirect, $code, $source, $target) = explode(" ", $new_line);
+                /* if source and target are the same (we have to add / at the end of source because it doesn't finish with / like $target do) */
+                if($source."/" == $target) 
                 {
-                    $redirect_list[$i] = '#'.$redirect_list[$i];
+                    if($redirect_list[$i][0] != '#')
+                    {
+                        /* We comment line because if we let it, we will have an infinite loop*/
+                        $redirect_list[$i] = '#'.$redirect_list[$i]. 
+                                            ' # Target has changed and became same as source so this line was commented, just to keep a trace of what happened';
+                    }
                 }
-            }
-            /* If page was restored from trash */
-            else if($post_before->post_status == 'trash' && $post_after->post_status != 'trash')
-            {
-                /* If line is commented, we remove comment */
-                if($redirect_list[$i][0] == '#')
+                else /* Source and target are not the same */
                 {
-                    $redirect_list[$i] = substr($redirect_list[$i],1);
+                    $redirect_list[$i] = $new_line;
                 }
+
+                /* If page is now in trash, */
+                if($post_before->post_status != 'trash' && $post_after->post_status == 'trash')
+                {
+                    /* We comment the line so redirection won't be done on trashed page but information will still
+                    be available in .htaccess in case we restore the page from trash */
+                    if($redirect_list[$i][0] != '#')
+                    {
+                        $redirect_list[$i] = '#'.$redirect_list[$i];
+                    }
+                }
+                /* If page was restored from trash */
+                else if($post_before->post_status == 'trash' && $post_after->post_status != 'trash')
+                {
+                    /* If line is commented, we remove comment */
+                    if($redirect_list[$i][0] == '#')
+                    {
+                        $redirect_list[$i] = substr($redirect_list[$i],1);
+                    }
+                }
+
             }
 
         }
-
-    }
+    } 
 
     /* .htaccess update */
     insert_with_markers( $htaccess, JAHIA_REDIRECT_MARKER, $redirect_list );


### PR DESCRIPTION
Equivalent 2010 de #1054

- Les mises à jour des slugs changeant des pages ne prenaient pas en compte la position de la page dans l'arborescence... seule la dernière partie du slug était modifiée (sans le parent) donc ça pouvait amener à une 404 dans le cas où l'ancienne URL d'accès (venant de Jahia) était utilisée.
- Ajout de la gestion des redirections incorrectes, y compris boucles infinies en regardant qu'on ne réutilise pas la source d'une redirection dans le `.htaccess` comme étant un slug de page (slug avec les parents donc). Si ce cas de figure survient, la ligne de redirection est mise en commentaire dans le `.htaccess`
- Corrections mineures d'indentation fausse
