### PR TITLE
Add --nosymlink option

### DIFF
--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -45,13 +45,15 @@ class WPPluginConfig(WPConfig):
         command_output = self.run_wp_cli(command)
         return False if command_output is True else self.name in command_output
 
-    def install(self, force_reinstall=False):
+    def install(self, force_reinstall=False, no_symlink=False):
         if self.config.zip_path is not None:
             param = self.config.zip_path
         else:
             param = self.name
         force_option = "--force" if force_reinstall else ""
-        command = "plugin install {} {} ".format(force_option, param)
+        no_symlink_option = "--nosymlink" if no_symlink else ""
+
+        command = "plugin install {} {} {}".format(force_option, no_symlink_option, param)
         self.run_wp_cli(command)
 
         # If we used a ZIP and it was generated 'on the fly', we do some cleaning
@@ -113,10 +115,12 @@ class WPMuPluginConfig(WPConfig):
         # set full path, down to file
         self.path = os.path.join(self.dir_path, plugin_name)
 
-    def install(self):
+    def install(self, no_symlink=False):
         src_path = os.path.sep.join([settings.WP_FILES_PATH, self.PLUGINS_PATH, self.name])
 
         folder_param = ""
+
+        no_symlink_option = "--nosymlink" if no_symlink else ""
 
         # If we also have a folder to copy
         if self.plugin_folder:
@@ -127,7 +131,7 @@ class WPMuPluginConfig(WPConfig):
         # Generating MU-plugin install command.
         # This command is not standard in WP-CLI, following package as to be installed :
         # https://github.com/epfl-idevelop/wp-cli
-        self.run_wp_cli("mu-plugin install {} {}".format(src_path, folder_param))
+        self.run_wp_cli("mu-plugin install {} {} {}".format(src_path, folder_param, no_symlink_option))
 
         logging.debug("%s - MU-Plugins - %s: Installed", repr(self.wp_site), self.name)
 

--- a/src/wordpress/themes.py
+++ b/src/wordpress/themes.py
@@ -73,7 +73,7 @@ class WPThemeConfig(WPConfig):
         else:
             return self.run_wp_cli('option add epfl:theme_faculty {}'.format(self.faculty))
 
-    def install(self, force_reinstall=False):
+    def install(self, force_reinstall=False, no_symlink=False):
         """
         Install and activate 2018 theme
 
@@ -101,6 +101,9 @@ class WPThemeConfig(WPConfig):
         # to theme directory...)
         os.chdir(os.path.join(self.base_path, zip_base_name))
 
+        force_option = "--force" if force_reinstall else ""
+        no_symlink_option = "--nosymlink" if no_symlink else ""
+
         for theme_name in ['wp-theme-2018', 'wp-theme-light']:
 
             logging.debug("Installing theme %s...", theme_name)
@@ -117,8 +120,7 @@ class WPThemeConfig(WPConfig):
 
             theme_zip.close()
 
-            force_option = "--force" if force_reinstall else ""
-            command = "theme install {} {} ".format(force_option, zip_full_path)
+            command = "theme install {} {} {} ".format(force_option, no_symlink_option, zip_full_path)
             self.run_wp_cli(command)
 
             # Cleaning ZIP file


### PR DESCRIPTION
Ajout d'une option `--nosymlink` pour plusieurs commandes de `jahia2wp.py`, afin de faire en sorte de pouvoir générer/updater un site sans que des symlinks soient mis en place. Ceci doit pouvoir être fait dans le cadre où on doit générer un site unmanaged.

Là encore (comme dans la PR https://github.com/epfl-idevelop/wp-cli/pull/6), l'option pourrait s'appeler `--no-symlink` et cette fois-ci cela ne poserait pas de problème avec Python (à priori, pas testé) mais suis resté sur `--nosymlink` en un mot car je voulais rester aligné avec l'option ajoutée à WP-CLI.

**NOTE**
Il a été décidé avec Emma, Greg et Julien, de ne pas reporter cette PR dans la branche "release" (version 2010) car on ne créait plus de sites 2010 et que de toute façon il n'y avait pas de besoin de pouvoir en créer des "non-symlinké"