### PR TITLE
Fix "wait 30 minutes" bug on External Menus → Refresh button

### DIFF
--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1637,10 +1637,10 @@ class MenuItemController extends CustomPostTypeController
             // Poor man's thread join in PHP
             $join_deadline_seconds = 15;
             for($i = 0; $i < $join_deadline_seconds; $i++) {
-                wp_cache_flush();
-                $cached = get_transient($transient_name);
-                if ($cached !== "WAITING") {
-                    return $cached;
+                wp_cache_flush();  // Transients are cached in RAM by default
+                $transient = get_transient($transient_name);
+                if ($transient !== "WAITING") {
+                    return $transient;
                 } else {
                     sleep(1);
                 }

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1621,16 +1621,38 @@ class MenuItemController extends CustomPostTypeController
     /**
      * Invoked first by the wp-admin refresh button
      */
-    static function ajax_enumerate () {
-        $transient_name = 'epfl-menus-all-external-item-ids';
-        if (false !== ($cached = get_transient($transient_name))) {
-            // don't fetch cached data if we are in debug mode
-            if (!(defined('WP_DEBUG') && (WP_DEBUG)))
-            {
-                return $cached;
-            }
+    static function ajax_enumerate ($opts = array()) {
+        if (! array_key_exists("retryToken", $opts)) {
+            throw new \Error("Old client code no longer supported");
         }
 
+        if (! ($retryToken = $opts["retryToken"])) {
+            $freshRetryToken = substr(md5(microtime()), 0, 5);
+            return array('retryToken' => $freshRetryToken);
+        }
+
+        $transient_name = "epfl-menus-all-external-item-ids-$retryToken";
+
+        if (false !== get_transient($transient_name)) {
+            // Poor man's thread join in PHP
+            $join_deadline_seconds = 15;
+            for($i = 0; $i < $join_deadline_seconds; $i++) {
+                wp_cache_flush();
+                $cached = get_transient($transient_name);
+                if ($cached !== "WAITING") {
+                    return $cached;
+                } else {
+                    sleep(1);
+                }
+            }
+            error_log(get_called_class() . "::ajax_enumerate(): " .
+                      "timed out joining computation $retryToken " .
+                      "after $join_deadline_seconds seconds");
+            http_response_code(504);
+            die();
+        }
+
+        set_transient($transient_name, "WAITING", 300);
         // The Varnish-side limit is 30 seconds, however the
         // client-side AJAX app is prepared to deal with 504's
         set_time_limit(120);


### PR DESCRIPTION
**From issue**: Unfiled - Misbehaving Refresh button in External Menus list

**High level changes:**

1. The Refresh button does not time out anymore (it retries 504's on its own)
1. The Refresh button has a separate transient per click; no need to wait 30 minutes for it to resume working anymore.

**Low level changes:**

- First AJAX POST to the MenuItemController::ajax_enumerate endpoint
  returns a nonce (called `retryToken` in the code)
- JavaScript does any number of queries, passing this nonce, until one
  of them returns something other than a 504
- Server-side, the first query starts the computation (and may or may
  not terminate within the CloudFlare deadline) and saves it to a
  transient; subsequent queries attempt to "thread-join" the first
  one, using the `retryToken` to retrieve the transient
- First call takes the critical section by writing "WAITING" into the
  trtansient, which the subsequent calls can detect and go into
  "thread-join mode". Entering the critical section is not an atomic
  update, but since (a well-behaved) client won't issue parallel
  queries with the same `retryToken` this doesn't matter.

