### PR TITLE
People fix timeout 5secondes

### DIFF
--- a/data/wp/wp-content/plugins/epfl/lib/utils.php
+++ b/data/wp/wp-content/plugins/epfl/lib/utils.php
@@ -44,7 +44,7 @@ Class Utils
      * @param cache_time_sec : Nb of sec during which we have to cache information in transient
      * @return decoded JSON data
      */
-    public static function get_items(string $url, $cache_time_sec=300) {
+    public static function get_items(string $url, $cache_time_sec=300, $timeout=5) {
 
 
         /* Caching mechanism is only used when :
@@ -69,7 +69,7 @@ Class Utils
         }
 
         $start = microtime(true);
-        $response = wp_remote_get($url);
+        $response = wp_remote_get($url, array( 'timeout' => $timeout ));
         $end = microtime(true);
 
         // Logging call

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-people/epfl-people.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-people/epfl-people.php
@@ -97,7 +97,7 @@ function epfl_people_2018_process_shortcode( $attributes, $content = null )
   $url = add_query_arg($parameter, $url);
   
   // retrieve the data in JSON
-  $items = Utils::get_items($url);
+  $items = Utils::get_items($url, $cache_time_sec=300, $timeout=15);
 
   if (false === $items) {
     return Utils::render_user_msg("People shortcode: Error retrieving items");


### PR DESCRIPTION
On avait un problème avec certaines requêtes people qui prenaient plus de 5 secondes. Le timeout par défaut de [wp_remote_get](https://codex.wordpress.org/Function_Reference/wp_remote_get)() 