### PR TITLE
Native blocks

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -69,6 +69,10 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'core/spacer',
         'core/separator',
         'core/shortcode',
+        'core/freeform',
+        'core/list',
+        'core/image',
+        'core/file',
     );
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -63,6 +63,12 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'core/paragraph',
         'core/heading',
         'core/gallery',
+        'core/classic',
+        'core/rss',
+        'core/table',
+        'core/spacer',
+        'core/separator',
+        'core/shortcode',
     );
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only


### PR DESCRIPTION
Voici la liste des blocs natifs ajoutés :
- classic
- rss
- table
- spacer
- separator
- shortcode
- list
- image
- file

Remarque: Pour que classic soit présent dans la liste des blocs à ajouter il faut ajouter le bloc 'core/freedom'
