### PR TITLE
Fix autop gallery

### DIFF
--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -10,7 +10,7 @@ $index_start = strpos($content, "<!-- wp:gallery");
 $index_end = strpos($content, "<!-- /wp:gallery -->") + strlen("<!-- /wp:gallery -->");
 $length_gallery = $index_end - $index_start;
 
-if ($index_start != FALSE) {
+if ($index_start !== FALSE) {
     // Keep gallery HTML
     $gallery_content = substr($content, $index_start, $length_gallery);
 
@@ -22,7 +22,7 @@ if ($index_start != FALSE) {
 // Add auto <p>
 $content = wpautop( $content );
 
-if ($index_start != FALSE) {
+if ($index_start !== FALSE) {
     // Search pattern $substitute
     $index_start = strpos($content, $substitute);
 


### PR DESCRIPTION
Si la page ne contient que le shortcode gallery il y avait un bug dans la gestion de l'autop.
En effet, puisque j'utilisais un != au lieu de !== (voir le code de la PR) le index_start était = 0 si la page ne comportait que le shortcode gallery et l'exécution du fait ne passait pas dans les 2 if du traitement particulier de la gallery ....
