### PR TITLE
shortcode to block -> fix autop

### DIFF
--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -30,6 +30,16 @@ if ($index_start !== FALSE) {
     $content = substr_replace($content, $gallery_content, $index_start, strlen($substitute));
 }
 
+$content = str_replace("<p><!-- ", "<!-- ", $content);
+$content = str_replace("--></p>", "-->", $content);
+
+$content = shortcode_unautop($content);
+
+// Replacement to have "correct" unicode encoded strings
+$content = str_replace("\\\\u003cp\\\\u003e", "\\u003cp\\u003e", $content);
+$content = str_replace("\\\\u003c/p\\\\u003e", "\\u003c/p\\u003e", $content);
+
+
 // Save the new content inside temporary file
 file_put_contents($filename, $content);
 

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -135,6 +135,8 @@ class GutenbergBlocks(Shortcodes):
         """
 
         if not content.strip().startswith("<p>"):
+            # We replace new lines with </p><p>
+            content = content.replace("\n", "\\u003c/p\\u003e\\u003cp\\u003e")
             # We add <p> and </p> but encoded with unicode 
             content = '\\u003cp\\u003e{}\\u003c/p\\u003e'.format(content)
 

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -125,7 +125,6 @@ class GutenbergBlocks(Shortcodes):
         return "{}T{}".format(date, time)
 
 
-
     def _add_paragraph(self, content, page_id, extra_attr):
         """
         Put content into a paragraph (<p> if not already into it)
@@ -136,8 +135,8 @@ class GutenbergBlocks(Shortcodes):
         """
 
         if not content.strip().startswith("<p>"):
-
-            content = "<p>{}</p>".format(content)
+            # We add <p> and </p> but encoded with unicode 
+            content = '\\u003cp\\u003e{}\\u003c/p\\u003e'.format(content)
 
         return content
 

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -339,7 +339,7 @@ class GutenbergBlocks(Shortcodes):
 
                 # We have to use content as value
                 if 'use_content' in attr_desc and attr_desc['use_content']:
-                    final_value = self._get_content(call)
+                    final_value = self._get_content(call).strip()
 
                 # If code above didn't found the value,
                 if final_value is None:
@@ -554,7 +554,11 @@ class GutenbergBlocks(Shortcodes):
 
         # Attribute description to recover correct value from each shortcode calls
         attributes_desc = [ 'units',
-                            'scipers',
+                            {
+                                'shortcode': 'scipers',
+                                'block': 'scipers',
+                                'force_string': True
+                            },
                             {
                                 'shortcode': 'columns',
                                 'block': 'columns',

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -1241,6 +1241,8 @@ class Shortcodes():
                             self.wp_config.run_wp_cli("post update {} --skip-plugins --skip-themes {} ".format(
                                 post_id, content_filename))
 
+                            break
+
                         except Exception as e:
                             if try_no < settings.WP_CLI_AND_API_NB_TRIES - 1:
                                 logging.error("fix_site() error. Retry %s in %s sec...",


### PR DESCRIPTION
- Suppression des `<p>` ajouté autour des blocks par `wpautop(..)`
- Utilisation de caractères unicode `\\u003cp\\u003e` pour encoder `<p>` quand on ajoute celui-ci autour de la valeur d'un attribut qui va aller dans du RichText. Ceci permet d'éviter que WordPress se marche sur le sachet en voulant "renettoyer" les `<p>` après coup.. risque de péter des choses...
- Astuce PHP pour transformer `\\u003cp\\u003e` en `\u003cp\u003e` après avoir passé `wpautop(..)` et cie parce que pas trouvé comment faire en Python pour gérer correctement ces caractères unicodes... 
- Utilisation de `shortcode_unautop(..)` pour virer les `<p>` ajoutés autour des shortcodes pas transformés en blocks.
- Nettoyage (`strip(..)`) du contenu d'un shortcode lorsqu'il est utilisé pour être mis dans un attribut. Ceci a pour but de virer les `\n` qui sont au début et à la fin du contenu.
- Remplacement des `\n` qui sont au milieu du contenu d'un shortcode pour mettre `</p><p>` dans le cas où il faudrait mettre ce contenu entre `<p>`
- Correction de bugs :
  - `epfl_people_2018`. Le sciper était pris comme un "int" dans le cas où il n'y avait qu'une seule value. Changement de la config pour forcer à utiliser un "string"
  - Sauvegarde de la page après modification. On faisait ceci X fois à cause de la boucle qui testait si erreur... du coup, ajout d'un `break` après avoir fait le job.
