### PR TITLE
Fix toggle html tags

### DIFF
--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -36,8 +36,8 @@ $content = str_replace("--></p>", "-->", $content);
 $content = shortcode_unautop($content);
 
 // Replacement to have "correct" unicode encoded strings
-$content = str_replace("\\\\u003cp\\\\u003e", "\\u003cp\\u003e", $content);
-$content = str_replace("\\\\u003c/p\\\\u003e", "\\u003c/p\\u003e", $content);
+$content = str_replace("\\\\u003c", "\\u003c", $content);
+$content = str_replace("\\\\u003e", "\\u003e", $content);
 
 
 // Save the new content inside temporary file

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -342,6 +342,9 @@ class GutenbergBlocks(Shortcodes):
                 # We have to use content as value
                 if 'use_content' in attr_desc and attr_desc['use_content']:
                     final_value = self._get_content(call).strip()
+                    # Changing < and >
+                    final_value = final_value.replace('<', '\\u003c').replace('>', '\\u003e')
+
 
                 # If code above didn't found the value,
                 if final_value is None:


### PR DESCRIPTION
- Dans le cas où on utilise le "contenu" d'un shortcode, on remplace les `<` et `>` par les caractères unicodes correspondants (mais devant ensuite être dés-escapés via PHP car pas possible de le faire avec Python...)
- Mise à jour du code `call-autop` pour qu'il soit un peu plus générique
