### PR TITLE
Handle double newlines in epfl introduction, transform in <p>

### DIFF
--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -1642,7 +1642,7 @@ class GutenbergBlocks(Shortcodes):
                             {
                                 'shortcode': 'gray',
                                 'block': 'grayBackground',
-                                'bool': True,                                
+                                'bool': True
                             }]
 
 

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -141,6 +141,7 @@ class GutenbergBlocks(Shortcodes):
     def _add_paragraph(self, content, page_id, extra_attr):
         """
         Put content into a paragraph (<p> if not already into it)
+        Replace \n with </p><p>
 
         :param content: content to add into paragraph if needed
         :param page_id: Page ID
@@ -150,6 +151,28 @@ class GutenbergBlocks(Shortcodes):
         if not content.strip().startswith("<p>"):
             # We replace new lines with </p><p>
             content = content.replace("\n", "\\u003c/p\\u003e\\u003cp\\u003e")
+            
+            content = self._handle_html(content, page_id, extra_attr)
+            # We add <p> and </p> but encoded with unicode 
+            content = '\\u003cp\\u003e{}\\u003c/p\\u003e'.format(content)
+
+        return content
+
+
+    def _add_paragraph_for_double_n(self, content, page_id, extra_attr):
+        """
+        Put content into a paragraph (<p> if not already into it)
+        Replace \n\n with </p><p>
+
+        :param content: content to add into paragraph if needed
+        :param page_id: Page ID
+        :param extra_attr: (optional) dict with extra attributes values needed by func
+        """
+
+        if not content.strip().startswith("<p>"):
+
+            # We replace new lines with </p><p>
+            content = content.replace("\n\n", "\\u003c/p\\u003e\\u003cp\\u003e")
             
             content = self._handle_html(content, page_id, extra_attr)
             # We add <p> and </p> but encoded with unicode 
@@ -1611,11 +1634,15 @@ class GutenbergBlocks(Shortcodes):
 
         # Attribute description to recover correct value from each shortcode calls
         attributes_desc = [ 'title',
-                            'content',
+                            {
+                                'shortcode': 'content',
+                                'block': 'content',
+                                'apply_func': '_add_paragraph_for_double_n'
+                            },
                             {
                                 'shortcode': 'gray',
                                 'block': 'grayBackground',
-                                'bool': True
+                                'bool': True,                                
                             }]
 
 


### PR DESCRIPTION
Dans le shortcode, quand il y avait `\n\n` pour le `content` d'un epfl-introduction, c'était automatiquement transformé en `<p>` par WordPress donc l'affichage se faisait bien. Mais avec Gutenberg, le comportement n'est plus le même...
Modification de la transformation de shortcode en bloc pour faire en sorte que les `\n\n` soient transformés en `<p>` afin que le comportement soit ensuite le même. 

**NOTE**
Ne fonctionnera que quand la PR https://github.com/epfl-idevelop/wp-gutenberg-epfl/pull/93 pour gérer les `<p>` (et le HTML) dans EPFL-Introduction aura été mergée et intégrée à l'image WP