### PR TITLE
Rollback

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -49,5 +49,5 @@ plugins:
     config: !include coming-soon/config-plugin.yml
   - name: wp-gutenberg-epfl
     config: !include wp-gutenberg-epfl/config-plugin.yml
-  - name: epfl-menus
-    config: !include epfl-menus/config-plugin.yml
+  # - name: epfl-menus
+  #   config: !include epfl-menus/config-plugin.yml

--- a/data/wp/wp-content/plugins/epfl/epfl.php
+++ b/data/wp/wp-content/plugins/epfl/epfl.php
@@ -32,8 +32,13 @@ require_once 'shortcodes/epfl-labs-search/epfl-labs-search.php';
 require_once 'shortcodes/epfl-polylex-search/epfl-polylex-search.php';
 require_once 'shortcodes/epfl-study-plan/epfl-study-plan.php';
 require_once 'shortcodes/epfl-magistrale/epfl-magistrale.php';
+require_once 'menus/epfl-menus.php';
 // Disabled due to 'epfl-intranet' plugin use
 //require_once 'preprod.php';
+
+if (class_exists('\WP_CLI')) {
+    require_once 'menus/wpcli.php';
+}
 
 // load .mo file for translation
 function epfl_load_plugin_textdomain() {

--- a/data/wp/wp-content/plugins/epfl/lib/admin-controller.php
+++ b/data/wp/wp-content/plugins/epfl/lib/admin-controller.php
@@ -1,0 +1,575 @@
+<?php
+
+/**
+ * Abstract base classes and utility classes for controllers in the
+ * wp-admin area.
+ */
+
+namespace EPFL\AdminController;
+
+
+if (! defined('ABSPATH')) {
+    die('Access denied.');
+}
+
+/**
+ * Manage pop-up errors or notices at the top of admin pages
+ *
+ * Use WordPress transients to persist the errors, so that they can
+ * be shown after the browser navigates to another page. Errors are
+ * per-user and per-page (as materialized by the $slug argument
+ * to @link publish and subscribe)
+ *
+ * This is a "pure static" class; no instances are ever constructed.
+ */
+
+class TransientError
+{
+    /**
+     * Persist $error to disk to be fetched and displayed soon by
+     * @link subscribe.
+     *
+     * @param $slug The "channel" for errors, to distinguish among
+     *              several error contexts (e.g. per post, or per page).
+     *              Note that errors are further isolated per user,
+     *              i.e. a logged-in user won't see someone else's errors
+     *              even if they are published with the same $slug.
+     */
+    static function publish ($slug, $error) {
+        $transient_key = static::_privatify_slug($slug);
+        $errors = get_transient($transient_key);
+        if (! $errors) {
+            $errors = array();
+        } elseif (! is_array($errors)) {
+            $errors = array($errors);
+        }
+
+        $errors[] = $error;
+        set_transient($transient_key, $errors,
+                      45);  // Seconds before it self-destructs
+    }
+
+    /**
+     * Add slag to $slug so that our transients are private per user,
+     * and don't collide with other Wordpress transients.
+     */
+    static function _privatify_slug ($slug) {
+        $me = get_current_user_id();
+        return "epfl:TransientError:$me:$slug";
+    }
+
+    /**
+     * Show any and all errors stashed with @link publish.
+     *
+     * Will only render errors from the same logged-in user,
+     * *and* having the same $slug set at @link publish time.
+     *
+     * @param $slug A unique string to classify errors across multiple
+     *              channels (e.g. admin pages); must match the $slug
+     *              parameter passed to @link publish to recover these
+     *              errors and them only.
+     *
+     * @param $render_callback The render function to pass the errors to.
+     *                         Defaults to @link render
+     */
+    static function subscribe ($slug, $render_callback = NULL) {
+        $thisclass = get_called_class();
+        if (! $render_callback) {
+            $render_callback = array($thisclass, 'render');
+        }
+        if (doing_action('admin_notices')) {
+            $thisclass::_do_fetch_and_render($slug, $render_callback);
+        } else {
+            add_action(
+                'admin_notices',
+                array(get_called_class(), 
+                      function() use ($thisclass, $slug, $render_callback) {
+                          $thisclass::_do_fetch_and_render(
+                              $slug, $render_callback);
+                      }));
+        }
+    }
+
+    private static function _do_fetch_and_render ($slug, $render_callback) {
+        $transient_key = static::_privatify_slug($slug);
+        if ($errors = get_transient($transient_key)) {
+            foreach ($errors as $error) {
+                call_user_func($render_callback, $error);
+            }
+            delete_transient($transient_key);
+        }
+    }
+
+    /**
+     * The default renderer for admin notices managed by this class
+     *
+     * @param $error Either a string, or an array with keys 'level'
+     * and 'msg'.
+     */
+    static function render ($error) {
+        if (! is_array($error)) {
+            $error = array(
+                'level' => 'error',
+                'msg' => $error
+            );
+        }
+            ?>
+    <div class="notice notice-<?php echo $error['level'] ?> is-dismissible">
+        <p><?php echo $error['msg']; ?></p>
+    </div><?php
+    }
+}
+
+/**
+ * Abstract base class for all controller classes
+ */
+abstract class Controller
+{
+    /**
+     * Arrange for a nonfatal error to be shown in a so-called "admin
+     * notice."
+     *
+     * This notice will be put up on any page for which the @link
+     * is_active method returns true.
+     */
+    static protected function admin_notice ($msg, $level = 'notice') {
+        TransientError::publish(
+            static::_get_transient_errors_slug(), array(
+                'level' => $level,
+                'msg' => $msg));
+    }
+
+    static private function _get_transient_errors_slug () {
+        return 'Transients-' . get_called_class();
+    }
+
+    static protected function admin_error ($msg) {
+        static::admin_notice($msg, 'error');
+    }
+
+    static function hook () {
+        $thisclass = get_called_class();
+        add_action('admin_notices', function() use ($thisclass) {
+            if (! $thisclass::is_active()) return;
+            TransientError::subscribe(
+                static::_get_transient_errors_slug($thisclass));
+        });
+    }
+
+    /**
+     * @return true iff the current page pertains to this controller.
+     */
+    static abstract protected function is_active ();
+}
+
+/**
+ * Abstract base class for the controller of a model class that
+ * consists of a custom post type that itself derives from abstract
+ * class @link TypedPost.
+ *
+ * This is a "pure static" class; no instances are ever constructed.
+ *
+ */
+abstract class CustomPostTypeController extends Controller
+{
+    /**
+     * @return The model class for this controller
+     */
+    abstract static function get_model_class ();
+
+    static function is_active () {
+        return array_key_exists('post_type', $_REQUEST)?$_REQUEST['post_type'] === static::get_post_type():false;
+    }
+
+    static function hook ()
+    {
+        parent::hook();
+        static::hook_meta_boxes();
+        add_action("admin_enqueue_scripts", array(get_called_class(), "_editor_css"));
+    }
+
+    static private function _belongs ($post_or_post_type) {
+        return static::get_model_class()::get($post_or_post_type);
+    }
+
+    static function _editor_css ($hook)
+    {
+        if (! ('post.php' === $hook &&
+               static::get_model_class()::get($_GET["post"])) ) return;
+        wp_register_style(
+            'ws-editor',
+            plugins_url( 'ws-editor.css', __DIR__ ) );
+        wp_enqueue_style('ws-editor');
+    }
+
+    static $_columns;
+    /**
+     * Add or mutate a column in the WP_List_Table list view in wp-admin
+     *
+     * By default, the class method "render_${slug}_column" will be called
+     * to render the contents of the column.
+     *
+     * @return _CustomPostTypeControllerColumn
+     */
+    static function column ($slug) {
+        if (! static::$_columns[$slug]) {
+            $_columns[$slug] = new _CustomPostTypeControllerColumn
+                             (get_called_class(), $slug);
+        }
+        return $_columns[$slug];
+    }
+
+    static function get_post_type ()
+    {
+        $model_class = static::get_model_class();
+        return $model_class::get_post_type();
+    }
+
+    /**
+     * Add a column in the list view that shows thumbnails
+     */
+    static function add_thumbnail_column ()
+    {
+        static::add_editor_css('
+td.column-thumbnail img {
+    max-width: 100%;
+    height: auto;
+}
+');
+        return static::column("thumbnail")
+            ->set_title(___( 'Thumbnail' ))
+            // Use of static::render_thumbnail_column() is the default
+            ->hook_after(1);
+    }
+
+    /**
+     * Echo what should be in the relevant <td> in the thumbnail column.
+     *
+     * The base class echoes a single <img> tag. Subclasses might want
+     * to echo something instead of, or in addition to that.
+     *
+     * @param $epfl_post An instance of the class returned by @link
+     * get_model_class
+     */
+    static function render_thumbnail_column ($epfl_post)
+    {
+        $img = get_the_post_thumbnail($epfl_post);
+        if (! $img) return;
+        echo $img;
+    }
+
+    static $_syncing_on_save = null;
+    /**
+     * Call ->sync() upon saving a TypedPost object.
+     *
+     * Call this method from the initialization code (e.g. a `hook`
+     * method) in order to enable this functionality for all instances
+     * of the @link get_model_class.
+     */
+    static function call_sync_on_save ()
+    {
+        $model_class = static::get_model_class();
+        add_action(
+            'save_post',  // *Not* save_post_$post_type, so that one
+                          // may ::call_sync_on_save() also from
+                          // within a save_meta_box_foo method
+            function ($post_id, $post, $is_update) use ($model_class) {
+                $model_obj = $model_class::get($post);
+                if (! $model_obj) return;
+                if (CustomPostTypeController::$_syncing_on_save === $post_id) {
+                    return;  // Break out of possible recursion
+                }
+                $syncing_on_save_orig = CustomPostTypeController::$_syncing_on_save;
+                try {
+                    CustomPostTypeController::$_syncing_on_save = $post_id;
+                    $model_obj->sync();
+                } finally {
+                    CustomPostTypeController::$_syncing_on_save = $syncing_on_save_orig;
+                };
+            }, 10, 3);
+    }
+
+    static function add_editor_css ($css)
+    {
+        add_action('admin_head', function () use ($css) {
+            echo "<style>$css</style>";
+        });
+    }
+
+    /**
+     * Hook the meta box business for this class.
+     *
+     * Note: This is typically not sufficient to enable metabox
+     * functionality. One must also call
+     * @link add_meta_box once or more, typically from the
+     * `register_meta_box_cb` callback passed to @link
+     * register_post_type.
+     */
+    static function hook_meta_boxes ()
+    {
+        add_action('edit_form_after_title',
+                   array(get_called_class(), 'meta_boxes_above_editor'));
+        add_action('edit_form_after_editor',
+                   array(get_called_class(), 'meta_boxes_after_editor'));
+        add_action(sprintf('save_post_%s', static::get_post_type()),
+                   array(get_called_class(), 'save_meta_boxes'), 10, 3);
+    }
+
+    /**
+     * Render all meta boxes configured to show up above the editor.
+     */
+    static function meta_boxes_above_editor ($post)
+    {
+        if (! static::_belongs($post)) return;
+        do_meta_boxes(get_current_screen(), 'above-editor', $post);
+    }
+
+    /**
+     * Render all meta boxes configured to show up after the editor.
+     */
+    static function meta_boxes_after_editor ($post)
+    {
+        if (! static::_belongs($post)) return;
+        do_meta_boxes(get_current_screen(), 'after-editor', $post);
+    }
+
+    /**
+     * Simpler version of the WordPress add_meta_box function
+     *
+     * @param $slug Unique name for this meta box. The render function
+     * is the method called "render_meta_box_$slug", and the save function
+     * is the method called "save_meta_box_$slug" (for the latter see
+     * @link save_meta_boxes)
+     *
+     * @param $title The human-readable title for the meta box
+     *
+     * @param $position The position to render the meta box at;
+     *        defaults to "above-editor" (see @link meta_boxes_above_editor).
+     *        Can be set to any legal value for the $priority argument
+     *        to the WordPress add_meta_box function, in particular "default"
+     *        to render the meta box after the editor.
+     */
+    static function add_meta_box ($slug, $title, $position = 'above-editor')
+    {
+        $callback = array(get_called_class(), "render_meta_box_$slug");
+        $meta_box_name = sprintf("%s-epfl-meta-box_%s", static::get_post_type(), $slug);
+        add_meta_box($meta_box_name, $title,
+                     function () use ($meta_box_name, $callback) {
+                         wp_nonce_field($meta_box_name, $meta_box_name);
+                         global $post;
+                         call_user_func($callback, $post);
+                     },
+                     null, $position);
+    }
+
+    static private $saved_meta_boxes = array();
+    /**
+     * Call the save_meta_box_$slug method for any and all meta box that is
+     * posting information.
+     *
+     * Any and all nonces present in $_REQUEST, for which a corresponding
+     * class method exists, are checked; then the class method is called,
+     * unless already done in this request cycle.
+     */
+    static function save_meta_boxes ($post_id, $post, $is_update)
+    {
+        // Bail if we're doing an auto save
+        if (defined( 'DOING_AUTOSAVE' ) && \DOING_AUTOSAVE) return;
+        foreach ($_REQUEST as $k => $v) {
+            $matched = array();
+            if (preg_match(sprintf('/%s-epfl-meta-box_([a-zA-Z0-9_]+)$/',
+                                   static::get_post_type()),
+                           $k, $matched)) {
+                $save_method_name = "save_meta_box_" . $matched[1];
+                if (method_exists(get_called_class(), $save_method_name)) {
+                    if (! wp_verify_nonce($v, $k)) {
+                        wp_die(___("Nonce check failed"));
+                    } elseif (! current_user_can('edit_post')) {
+                        wp_die(___("Permission denied: edit " . static::get_post_type()));
+                    } elseif (self::$saved_meta_boxes[$k]) {
+                        // Break out of silly recursion: we call
+                        // writer functions such as wp_insert_post()
+                        // and wp_update_post(), which call us back
+                        return;
+                    } else {
+                        self::$saved_meta_boxes[$k] = true;
+                        call_user_func(
+                            array(get_called_class(), $save_method_name),
+                            $post_id, $post, $is_update);
+                    }
+                }
+            }
+        }  // End foreach
+    }
+}
+
+/**
+ * A custom column in the WP_List_Table view
+ *
+ * By default, the class method "render_${slug}_column" will be called
+ * to render the contents of the column; but this can be changed by
+ * invoking @link set_renderer. (In both cases, the callback argument
+ * is the instance of the model class to render the column for.)
+ */
+class _CustomPostTypeControllerColumn
+{
+    /**
+     * "private" constructor, call ::column() in your
+     * @link CustomPostTypeController subclass instead.
+     */
+    function __construct ($owner_controller, $slug)
+    {
+        $this->owner = $owner_controller;
+        $this->slug  = $slug;
+
+        // Default settings:
+        $this->set_title($slug);
+        $this->set_renderer(array($owner_controller, "render_${slug}_column"));
+    }
+
+    function set_title ($translated_title)
+    {
+        $this->title = $translated_title;
+        return $this;  // Chainable
+    }
+
+    function add_css ($css)
+    {
+        // For compatibility with epfl-ws
+        $this->owner_controller->add_editor_css($css);
+        return $this;
+    }
+
+    function set_renderer ($callable)
+    {
+        $this->render = $callable;
+        return $this;
+    }
+
+    function make_sortable ($sort_opts)
+    {
+        $this->sort_opts = $sort_opts;
+        return $this;
+    }
+
+    function insert_after ($after) {
+        $this->insert_after = $after;
+        return $this;
+    }
+
+    function hook_after ($after) {
+        // For compatibility with epfl-ws
+        return $this->insert_after($after)->hook();
+    }
+
+    function hook ()
+    {
+        $post_type = $this->get_post_type();
+        add_action(
+            sprintf('manage_%s_posts_columns', $post_type),
+            array($this, '_filter_posts_columns'));
+
+        add_action(
+            sprintf('manage_%s_posts_custom_column', $post_type),
+            array($this, '_filter_manage_custom_column'),
+            10, 2);
+
+        // Sorting
+        add_action('pre_get_posts', array($this, '_action_pre_get_posts'));
+        add_filter(
+            sprintf('manage_edit-%s_sortable_columns', $post_type),
+            array($this, '_filter_manage_sortable_columns'));
+
+        return $this;   // Chainable, because why not?
+    }
+
+    protected function get_model_class ()
+    {
+        $controller_class = $this->owner;
+        return $controller_class::get_model_class();
+    }
+
+    protected function get_post_type ()
+    {
+        $model_class = $this->get_model_class();
+        return $model_class::get_post_type();
+    }
+
+    function _filter_posts_columns ($columns)
+    {
+        if (method_exists('WP_Posts_List_Table', 'column_' . $this->slug)) {
+            // We can override a built-in column, but we have to
+            // put it under another slug in order to fool
+            // WP_List_Table's method dispatch technique.
+            $newcolumns = array();
+            foreach ($columns as $col_slug => $descr) {
+                if ($col_slug === $this->slug) {
+                    // @link _filter_manage_custom_column is aware; also,
+                    // it just so happens that "column-$col_slug" will
+                    // still be part of the class= markup computed by
+                    // WP_List_Table::single_row_columns ☺
+                    $evading_slug = "epfl-overridden column-$col_slug";
+                    $newcolumns[$evading_slug] = $this->title;
+                } else {
+                    $newcolumns[$col_slug] = $descr;
+                }
+            }
+            return $newcolumns;
+        } elseif (is_int($this->insert_after)) {
+            // https://stackoverflow.com/a/3354804/435004
+            $newcolumns = array_merge(
+                array_slice($columns, 0, $this->insert_after, true),
+                array($this->slug => $this->title),
+                array_slice($columns, $this->insert_after,
+                            count($columns) - $this->insert_after, true));
+            return $newcolumns;
+        } elseif (is_string($this->insert_after)) {
+            $newcolumns = array();
+            foreach ($columns as $col_slug => $descr) {
+                $newcolumns[$col_slug] = $descr;
+                if ($col_slug === $this->insert_after) {
+                    $newcolumns[$this->slug] = $this->title;
+                }
+            }
+            return $newcolumns;
+        } else {
+            wp_die("Unsupported value for ->insert_after: " . var_export($this->insert_after, true));
+        }
+    }
+
+    function _filter_manage_custom_column ($column, $post_id)
+    {
+        // See $evading_slug in @link _filter_posts_columns
+        $column = preg_replace('/^epfl-overridden column-/', '', $column);
+        if ($column !== $this->slug) return;
+
+        $model_class = $this->get_model_class();
+        $epfl_post = $model_class::get($post_id);
+        if (! $epfl_post) return;
+
+        call_user_func($this->render, $epfl_post);
+    }
+
+    function _filter_manage_sortable_columns ($columns)
+    {
+        if (isset($this->sort_ops)) {
+            $columns[$this->slug] = $this->slug;
+        }
+        return $columns;
+    }
+
+    /**
+     * Honor requests to sort by this column
+     */
+    function _action_pre_get_posts ($query)
+    {
+        if ( ! is_admin() ) return;
+        if (! property_exists($this, 'sort_opts')) return;
+        if ($query->get( 'orderby' ) !== $this->slug) return;
+
+        // Here we could examine $this->sort_opts to support sorting
+        // by something other than a meta_key.
+        $query->set('orderby', 'meta_value');
+        $query->set('meta_key', $this->sort_opts['meta_key']);
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/auto-fields.php
+++ b/data/wp/wp-content/plugins/epfl/lib/auto-fields.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Model and controller for fields that *may not* be edited by users.
+ *
+ * The TL;DR of this module is that it manages the @link
+ * is_protected_meta filter in a persistent way (using WordPress
+ * options). Caller controller code may "blacklist" any and all meta
+ * fields to prevent them from appearing in the "Custom Fields" box at
+ * the bottom of the edit menu. A replacement meta box is provided to
+ * display the blacklisted meta fields in a read-only table.
+ */
+namespace EPFL\AutoFields;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+require_once(__DIR__ . '/i18n.php');
+use function EPFL\I18N\___;
+
+require_once(__DIR__ . '/this-plugin.php');
+use function EPFL\ThisPlugin\on_deactivate;
+
+/**
+ * Auto fields of a model class.
+ *
+ * An instance represents the auto fields associated to one model
+ * class. Whenever some code non-interactively updates attributes, it
+ * ought to call `AutoFields::of($model_class)->append($fields)`.
+ * The AutoFieldsController makes sure to make these fields un-editable.
+ */
+
+class AutoFields
+{
+    private function __construct ($for_class)
+    {
+        $this->model_class = $for_class;
+    }
+
+    /**
+     * Named constructor idiom.
+     */
+    static function of ($for_class) {
+        $thisclass = get_called_class();
+        return new $thisclass($for_class);
+    }
+
+    function get ()
+    {
+        $auto_fields = get_option($this->_get_option_key());
+        if (! $auto_fields) { $auto_fields = []; }
+        sort($auto_fields);
+        return $auto_fields;
+    }
+
+    /**
+     * Mark these fields as protected
+     */
+    function append ($fields)
+    {
+        $protected = $this->get();
+        $changed = false;
+        if (! is_array($fields)) {
+            $fields = [$fields];
+        }
+        foreach ($fields as $field) {
+            if (false === array_search($field, $protected)) {
+                array_push($protected, $field);
+                $changed = true;
+            }
+        }
+        if ($changed) {
+            update_option($this->_get_option_key(), $protected);
+        }
+    }
+
+    function clear () {
+        delete_option($this->_get_option_key());
+    }
+
+    const SLUG = "epfl_ws_protected_fields";
+
+    private function _get_option_key () {
+        return static::SLUG . "_" . sanitize_key($this->model_class);
+    }
+}
+
+/**
+ * Controller helper class for the admin area of classes that have AutoFields.
+ *
+ * An instance of this class deals with one specific model class, and
+ * arrange for its auto-fields to be shown read-only in the wp-admin
+ * edit pages for items of that model class. In order to achieve this,
+ * controller code is supposed to call @link hook and @link
+ * add_meta_boxes as indicated in their respective docstrings.
+ */
+class AutoFieldsController {
+    /**
+     * An instance of the class represents the auto-fields controller for
+     * one @param $model_class. Since the instance is stateless, it is fine to
+     * construct multiple, ephemeral instances at the different hook
+     * points in the controller.
+     *
+     * The following assumptions are made on @param $model_class:
+     *
+     * - The ::get() static function takes a post ID and returns NULL if there
+     *   is no instance of the class with that post ID (even if the post ID does
+     *   exist, but for a post that does not belong to the class)
+     */
+    function __construct ($model_class) {
+        $this->model_class = $model_class;
+    }
+
+    /**
+     * Should be called during the controller class' own
+     * initialization, i.e. its own "hook" method.
+     */
+    function hook ()
+    {
+        add_filter("is_protected_meta", array($this, "filter_is_protected_meta"), 10, 3);
+        on_deactivate(array($this, "clear"));
+    }
+
+    /**
+     * Should be called at WordPress `add_meta_boxes` time, e.g. from the
+     * model class' `register_meta_box_cb` parameter to @link register_post_type
+     */
+    function add_meta_boxes ()
+    {
+        add_meta_box("epfl_readonly_meta_" . $this->model_class,
+                     ___("Automatic Custom Fields"),
+                     array($this, "render_protected_meta_box"),
+                     null, 'normal', 'high');
+    }
+
+    function filter_is_protected_meta ($is_protected, $meta_key, $unused_meta_type)
+    {
+        global $post;
+        if ($this->model_class::get($post) &&
+            in_array($meta_key, AutoFields::of($this->model_class)->get())) {
+                return true;
+            } else {
+                return $is_protected;
+            }
+    }
+
+    function render_protected_meta_box ()
+    {
+        global $post;
+        if (! $this->model_class::get($post)) return;
+
+        $meta = get_post_meta($post->ID);
+        echo "<table>\n";
+        foreach (AutoFields::of($this->model_class)->get() as $key) {
+            echo "<tr><td>$key</td>\n";
+            // All meta keys are single-valued
+            $value = array_key_exists($key, $meta) ? $meta[$key][0] : NULL;
+            if (preg_match('/^.*-(.*?)$/', $key, $matched)
+                and method_exists($this, $method = ("render_meta_field_td_" .
+                                                    $matched[1])))
+            {
+                $this->$method($key, $value);
+            } else {
+                $this->render_meta_field_td($value);
+            }
+            echo "</tr>\n";
+        }
+        echo "</table>\n";
+    }
+
+    const MAX_RENDER_LENGTH = 120;
+
+    protected function _htmlify ($value, $max_length = NULL) {
+        if ($max_length === NULL) {
+            $max_length = static::MAX_RENDER_LENGTH;
+        }
+        if (strlen($value) > $max_length) {
+            $value = substr($value, 0, $max_length) . "...";
+        }
+        return htmlspecialchars($value);
+    }
+
+    function render_meta_field_td ($value) {
+        echo "<td>" . $this->_htmlify($value) . "</td>";
+    }
+
+
+    function render_meta_field_td_url ($key, $value) {
+        echo '<td><a href="' . $this->_htmlify($value, 500) .'">' . $this->_htmlify($value) . "</td>";
+    }
+
+    function render_meta_field_td_epoch ($key, $value) {
+        $this->render_meta_field_td($value);
+        if (! preg_match('/^[1-9][0-9]*$/', $value)) return;
+        $value_human = strftime('%c', $value);
+        echo "<td>$value_human</td>";
+    }
+
+    static protected $_json_button_count = 0;
+    function render_meta_field_td_json ($key, $value) {
+        $this->render_meta_field_td($value);
+        if (NULL !== json_decode($value)) {
+            $button_id = "autofields_json_button" . static::$_json_button_count++;
+            echo "<td><button id=\"$button_id\">" . ___("<code>console.log()</code> it"). "</button></td>\n";
+?>
+<script>
+jQuery(function($) {
+  $('#<?php echo $button_id; ?>').click(function(e) {
+    e.stopPropagation();
+    console.log('<?php echo "$key ="; ?>', JSON.parse("<?php echo static::escape_js_doublequoted($value); ?>"));
+    return false;
+  });
+});
+</script>
+<?php
+        }
+    }
+
+    static function escape_js_doublequoted ($value) {
+        return addslashes($value);
+    }
+
+    function clear ()
+    {
+        AutoFields::of($this->model_class)->clear();
+        return $this;  // Chainable
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/i18n.php
+++ b/data/wp/wp-content/plugins/epfl/lib/i18n.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EPFL\I18N;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+const TEXTDOMAIN = 'epfl';
+
+function ___ ($text) {
+    return __($text, TEXTDOMAIN);
+}
+
+function __x ($text, $context) {
+    return _x($text, $context, TEXTDOMAIN);
+}
+
+function __e ($text) {
+    return _e($text, TEXTDOMAIN);
+}
+
+function __n ($text, $plural, $number) {
+    return _n($text, $plural, $number, TEXTDOMAIN);
+}
+
+
+function esc_html___ ($text) {
+    return esc_html__($text, TEXTDOMAIN);
+}
+
+function get_current_language () {
+    return function_exists('pll_current_language') ? pll_current_language() : NULL;
+}

--- a/data/wp/wp-content/plugins/epfl/lib/model.php
+++ b/data/wp/wp-content/plugins/epfl/lib/model.php
@@ -1,0 +1,682 @@
+<?php
+
+/**
+ * A set of abstract base classes targeted at model code
+ */
+
+namespace EPFL\Model;
+
+if (! defined('ABSPATH')) {
+    die('Access denied.');
+}
+
+use \WP_Query;
+
+class ModelException extends \Exception {
+    public function __construct ($e) {
+        if (is_wp_error($e)) {
+            parent::__construct(implode("\n", $e->get_error_messages()));
+            $this->wp_error = $e;
+        } else {
+            parent::__construct($e);
+        }
+    }
+
+    static function check ($e) {
+        if (is_wp_error($e)) {
+            $thisclass = get_called_class();
+            throw new $thisclass($e);
+        } else {
+            return $e;
+        }
+    }
+}
+
+class UnicityException extends ModelException {}
+
+
+/**
+ * Abstract base class for model objects based on the WPDB API.
+ */
+abstract class WPDBModel
+{
+    static function _prepare ($sql, $placeholders_array) {
+        $sql = preg_replace('/%T/', static::TABLE_NAME, $sql, 1);
+
+        if (count($placeholders_array)) {
+            global $wpdb;
+            $sql = call_user_func_array(
+                array($wpdb, 'prepare'),
+                array_merge(array($sql), $placeholders_array));
+        }
+
+        return $sql;
+    }
+
+    static function query ($sql, ...$placeholders) {
+        global $wpdb;
+        return $wpdb->query(static::_prepare($sql, $placeholders));
+    }
+
+    static function insert ($sql, ...$placeholders) {
+        global $wpdb;
+        $wpdb->query(static::_prepare($sql, $placeholders));
+        return $wpdb->insert_id;
+    }
+
+    static function get_results ($sql, ...$placeholders) {
+        global $wpdb;
+        return $wpdb->get_results(static::_prepare($sql, $placeholders));
+    }
+
+    static function get_var ($sql, ...$placeholders) {
+        global $wpdb;
+        return $wpdb->get_var(static::_prepare($sql, $placeholders));
+    }
+
+    static function hook () {
+        if (method_exists(get_called_class(), "create_tables")) {
+            require_once(__DIR__ . '/this-plugin.php');
+            \EPFL\ThisPlugin\on_activate(
+                array(get_called_class(), "create_tables"));
+        }
+        if (method_exists(get_called_class(), "drop_tables")) {
+            require_once(__DIR__ . '/this-plugin.php');
+            \EPFL\ThisPlugin\on_deactivate(
+                array(get_called_class(), "drop_tables"));
+        }
+    }
+
+    static protected function _as_db_results ($array_or_object) {
+        if (is_array($array_or_object)) {
+            $object = new \stdClass();
+            foreach ($array_or_object as $k => $v) {
+                $object->$k = $v;
+            }
+            return $object;
+        } else {
+            return $array_or_object;
+        }
+    }
+}
+
+/**
+ * Abstract base class for posts
+ *
+ * Since WP_Post is final (https://core.trac.wordpress.org/ticket/24672),
+ * the next best thing is a has-a relationship.
+ */
+abstract class Post
+{
+   /**
+    * Subclasses should define this method to return a Boolean
+    * indicating whether $this->ID points to a "real" instance
+    * of said subclass.
+    */
+    abstract protected function _belongs ();
+
+    /**
+     * Protected constructor
+     */
+    protected function __construct ($id)
+    {
+        $this->ID = $id;
+    }
+
+    /**
+     * Wrap one WP_Post in a Post instance
+     *
+     * @return an instance of this class or null
+     */
+    static function get ($post_or_post_id)
+    {
+        if (is_object($post_or_post_id)) {
+            $post_id = $post_or_post_id->ID;
+        } else {
+            $post_id = $post_or_post_id;
+        }
+
+        $theclass = get_called_class();
+        $that = new $theclass($post_id);
+        if (is_object($post_or_post_id)) {
+            $that->_wp_post = $post_or_post_id;
+        }
+        if (! $that->_belongs()) { return; }
+        return $that;
+    }
+
+    function wp_post ()
+    {
+        if (! property_exists($this, '_wp_post')) {
+            $this->_wp_post = get_post($this->ID);
+        }
+        return $this->_wp_post;
+    }
+
+    /**
+     * Metaprogrammed accessors e.g.
+     *
+     *    $mypost->meta()->get_myprop();
+     *
+     * These must be declared like this:
+     *
+     *    const META_ACCESSORS = array(
+     *      'myprop' => 'my-meta-slug'
+     *    )
+     *
+     * Or just
+     *
+     *    const META_ACCESSORS = array(
+     *      'myprop'
+     *    )
+     *
+     * There is a performance price, so if you don't want to pay for
+     * it, don't call this method - Instead, write ordinary accessors
+     * that wrap @link update_post_meta and @link get_post_meta. (And
+     * then if you want @link AutoFields functionality, you need to
+     * handle that explicitly as well.)
+     */
+    function meta () {
+        if (! isset($this->_meta)) {
+            $this->_meta = new _PostMeta(get_called_class(), $this->ID);
+        }
+        return $this->_meta;
+    }
+
+    /**
+     * Like @link wp_insert_post, but returns an instance of the class
+     * or throws a @link ModelException
+     */
+    public static function insert ($postarr) {
+        if (! $postarr['post_status']) {
+            $postarr['post_status'] = 'publish';
+        }
+        ModelException::check($id = wp_insert_post($postarr, true));
+        return static::get($id);
+    }
+
+    /**
+     * Like @link insert, but for an existing post object.
+     */
+    public function update ($postarr) {
+        $postarr['ID'] = $this->ID;
+        ModelException::check(wp_update_post($postarr, true));
+    }
+
+    public function get_language () {
+        if (! function_exists('pll_get_post_language')) {
+            return NULL;
+        }
+        return pll_get_post_language($this->ID);
+    }
+
+    public function set_language ($newlang) {
+        if (! function_exists('pll_set_post_language')) return;
+        return pll_set_post_language($this->ID, $newlang);
+    }
+
+    public function get_title () {
+        return $this->wp_post()->post_title;
+    }
+
+    public function set_title ($title) {
+        wp_update_post([
+            'ID' => $this->ID,
+            'post_title' =>  $title
+            ]
+        );
+    }
+
+    function error_log ($msg) {
+        error_log(get_called_class() . "::get($this->ID): " . $msg);
+    }
+
+    /**
+     * Iterate with $callback over all instances returned by $query.
+     *
+     * @param $wp_query An instance of @link WP_Query
+     *
+     * @param $callback A callable that will be called with each
+     *                  instance of this class in turn. The WordPress
+     *                  global variables will be updated as if within
+     *                  "The loop".
+     */
+    public static function foreach_query ($wp_query, $callback) {
+        $in_the_loop = new _InTheLoopHelper($wp_query);
+        try {
+            $in_the_loop->enter();
+
+            while ($wp_query->have_posts()) {
+                $wp_query->next_post();
+                if ($epfl_post = static::get($wp_query->post)) {
+                    call_user_func($callback, $epfl_post);
+                }
+            }
+        } finally {
+            $in_the_loop->leave();
+        }
+    }
+    
+    function __toString () {
+        return sprintf('<%s(%d)>', get_called_class(), $this->ID);
+    }
+}
+
+
+/**
+ * Metaprogrammed helper class for single-valued persistent instance
+ * accessors implemented on top of get_post_meta / update_post_meta.
+ */
+class _PostMeta {
+    private $_owner_class;
+    private $_post_id;
+    private $_meta;
+
+    function __construct ($owner_class, $post_id) {
+        $this->_owner_class    = $owner_class;
+        $this->_post_id        = $post_id;
+
+        $this->_meta_accessors = array();
+        foreach ($owner_class::META_ACCESSORS as $k => $v) {
+            if (is_int($k)) {
+                $this->_meta_accessors[$v] = $v;
+            } else {
+                $this->_meta_accessors[$k] = $v;
+            }
+        }
+    }
+
+    function __call ($name, $arguments) {
+        $cmd = substr($name, 0, 3);
+        $stem = substr($name, 4);
+        $meta_name = $this->_meta_accessors[$stem];
+        if (! $meta_name) {
+            throw new \Exception(
+                sprintf('Fatal error: Call to undefined method %s::%s',
+                        $this->_owner_class, $name));
+        }
+
+        if ($cmd === 'get') {
+            return get_post_meta($this->_post_id, $meta_name, true);
+        } elseif ($cmd === 'set') {
+            $this->_update_meta_auto_fields();
+            return $this->_update_post_meta($this->_post_id, $meta_name, $arguments[0]);
+        } elseif (substr($name, 0, 4) === 'del_') {
+            $this->_update_meta_auto_fields();
+            return delete_post_meta($this->_post_id, $meta_name);
+        } else {
+            throw new \Exception(
+                sprintf('Fatal error: Call to undefined method %s::%s',
+                        $this->_owner_class, $name));
+        }
+    }
+
+    /**
+     * Like Wordpress' @link update_post_meta, sans the wp_unslash
+     * monkey business
+     */
+    private function _update_post_meta ($id, $meta_key, $meta_value) {
+        $filter_name = "sanitize_post_meta_{$meta_key}";
+        $return_pristine_value = function(...$whatever) use ($meta_value) {
+                return $meta_value;
+            };
+        try {
+            add_filter($filter_name, $return_pristine_value);
+            return update_post_meta($id, $meta_key, $meta_value);
+        } finally {
+            remove_filter($filter_name, $return_pristine_value);
+        }
+    }
+
+    function has ($stem) {
+        return !! $this->_meta_accessors[$stem];
+    }
+
+    /**
+     * Automatically provide @link \EPFL\AutoFields\AutoFields functionality
+     * based on the META_ACCESSORS constant of the owner class.
+     *
+     * Called when writing through $my_model_object->meta()->set_foo(...)
+     * for all entries in META_ACCESSORS, regardless of which one we are
+     * currently writing to.
+     */
+    function _update_meta_auto_fields () {
+        if (isset($this->_meta_auto_fields_done)) return;
+        require_once(__DIR__ . '/auto-fields.php');
+        \EPFL\AutoFields\AutoFields::of($this->_owner_class)->append(
+            array_values($this->_meta_accessors));
+        $this->_meta_auto_fields_done = TRUE;
+    }
+}
+
+
+/**
+ * Abstract base class for posts that belong to a custom post type
+ */
+abstract class TypedPost extends Post
+{
+    /**
+     * @return the post_type slug for instances of this class
+     */
+    static abstract function get_post_type ();
+
+    function _belongs ()
+    {
+        return ($this->wp_post()->post_type ===
+                get_called_class()::get_post_type());
+    }
+
+    /**
+     * Iterate with $callback over all instances of this class.
+     */
+    public static function foreach ($callback) {
+        $wp_query = (new _WPQueryBuilder(static::get_post_type()))
+                  ->all()->wp_query();
+        return static::foreach_query($wp_query, $callback);
+    }
+
+    /**
+     * Overridden to create items of the correct post type.
+     */
+    public static function insert ($postarr) {
+        $postarr['post_type'] = static::get_post_type();
+        static::_inserted_or_deleted();
+        return parent::insert($postarr);
+    }
+
+    static function make_polylang_translatable () {
+        $post_type = static::get_post_type();
+        add_filter('pll_get_post_types',
+                   function($post_types) use ($post_type) {
+                       $post_types[] = $post_type;
+                       return $post_types;
+                   });
+    }
+
+    private static $all = array();  // Keyed by class name
+    static function all () {
+        $thisclass = get_called_class();
+        if (! array_key_exists($thisclass, TypedPost::$all)) {
+            TypedPost::$all[$thisclass] = array();
+            static::foreach(function($that) use ($thisclass) {
+                TypedPost::$all[$thisclass][] = $that;
+            });
+        }
+        return TypedPost::$all[$thisclass];
+    }
+
+    static private function _inserted_or_deleted () {
+        unset(TypedPost::$all[$thisclass]);
+    }
+}
+
+
+/**
+ * A class of Posts that can be referenced by some other kind of
+ * unique key than the WordPress post ID.
+ *
+ * The class provides "named constructors"
+ * @link get_by_unique_key and @link get_or_create (in addition to the
+ * parent class' @link get) which implement fetching/creating objects
+ * from an array containing the unique key, possiby composite (i.e.
+ * comprised of more than one value).
+ *
+ * 'Protected virtual' methods @link _query_by_unique_keys and @link
+ * _insert_by_unique_keys are provided to provide the default behavior
+ * of using Wordpress "post metas" to materialize the unique key(s)
+ * in-database. Specifically, the class-level constant
+ * META_PRIMARY_KEY shall be the name of a WordPress meta field or a
+ * list of same that make up the (possibly composite) "primary key".
+ * Subclasses may override both these methods to provide any mapping
+ * from the "primary key" to the database and back.
+ */
+abstract class UniqueKeyTypedPost extends TypedPost
+{
+    static function get_or_create (...$unique_keys)
+    {
+        if ($existing = static::_get_by_unique_keys($unique_keys)) {
+            return $existing;
+        } else {
+            return static::_insert_by_unique_keys($unique_keys);
+        }
+    }
+
+    static function all_except ($instances) {
+        $instances_by_primary_key = array();
+        foreach ($instances as $instance) {
+            $k = serialize($instance->get_unique_keys());
+            $instances_by_primary_key[$k] = $instance;
+        }
+
+        $retval = array();
+        foreach (static::all() as $instance) {
+            $k = serialize($instance->get_unique_keys());
+            if (! array_key_exists($k, $instances_by_primary_key)) {
+                $retval[] = $instance;
+            }
+        }
+
+        return $retval;
+    }
+
+    static function get_by_unique_key ($unique_key) {
+        return static::_get_by_unique_keys(array($unique_key));
+    }
+
+    static function get_by_unique_keys (...$unique_keys) {
+        return static::_get_by_unique_keys($unique_keys);
+    }
+
+    static protected function _get_by_unique_keys ($unique_keys) {
+        $result = static::_query_by_unique_keys($unique_keys)->result();
+        if ($result) {
+            $theclass = get_called_class();
+            return new $theclass($result->ID);
+        }
+    }
+
+    /**
+     * The piece of @link get_or_create that deals with the "get" part.
+     *
+     * The base class' implementation reads the META_PRIMARY_KEY and
+     * turns $unique_keys into a @link _WPQueryBuilder::by_meta query.
+     * A subclass may elect to override this method, as well as
+     * @link _insert_by_unique_keys, to map $unique_keys to/from the
+     * database in a different way.
+     */
+    static protected function _query_by_unique_keys ($unique_keys) {
+        return (new _WPQueryBuilder(static::get_post_type()))->by_meta(
+            static::_metaify($unique_keys));
+    }
+
+    /**
+     * The piece of @link get_or_create that deals with the "create" part.
+     *
+     * The base class' implementation reads the META_PRIMARY_KEY and
+     * turns $unique_keys into the "meta_input" parameter to
+     * @link wp_insert_post. A subclass may elect to override this
+     * method, as well as
+     * @link _query_by_unique_keys, to map $unique_keys to/from the
+     * database in a different way.
+     */
+    static protected function _insert_by_unique_keys ($unique_keys) {
+        return static::insert(array('meta_input' =>
+                                    static::_metaify($unique_keys)));
+    }
+
+    static protected function _metaify ($unique_keys) {
+        $meta = array();
+        foreach (static::_get_primary_key_names() as $k) {
+            $meta[$k] = array_shift($unique_keys);
+        }
+        return $meta;
+    }
+
+    static protected function _get_primary_key_names () {
+        $primary_keys = static::META_PRIMARY_KEY;
+        if (! is_array($primary_keys)) {
+            $primary_keys = array($primary_keys);
+        }
+        return $primary_keys;
+    }
+
+    function get_unique_keys () {
+        $unique_keys = array();
+        foreach (static::_get_primary_key_names() as $k) {
+            $unique_keys[$k] = get_post_meta($this->ID, $meta_name, true);
+        }
+    }
+}
+
+
+/**
+ * A helper class to prepare and invoke custom WP_Query objects.
+ */
+class _WPQueryBuilder
+{
+    function __construct ($query)
+    {
+        if (is_string($query)) {
+            $query = array('post_type' => $query);
+        }
+        $this->query = $query;
+    }
+
+    function by_meta ($meta_array)
+    {
+        if (! array_key_exists("meta_query", $this->query)) {
+            $this->query["meta_query"] = array('relation' => 'AND');
+        }
+
+        foreach ($meta_array as $k => $v) {
+            array_push($this->query["meta_query"], array(
+                'key'     => $k,
+                'value'   => $v,
+                'compare' => '='
+            ));
+        }
+
+        return $this;
+    }
+
+    private $_saved_query;
+    function wp_query ()
+    {
+        if (! $this->query) {
+            throw new Exception("->wp_query, ->result or ->results together may only be called once per _WPQueryBuilder object");
+        }
+        $query = $this->query;
+        unset($this->query);           // ->wp_query is a one-shot pistol
+        $this->_saved_query = $query;  // For ->moniker()'s use only
+
+        // Using Polylang's auto-filter-by-language feature in
+        // something called model.php, that focuses on primary keys,
+        // is a bad idea all around (e.g. think what happens when you
+        // disable the Polylang plugin?). But if caller insists we
+        // let them.
+        if (! array_key_exists('lang', $query)) {
+            $query['lang'] = '';
+        }
+        return new WP_Query($query);
+    }
+
+    function result ()
+    {
+        $results = $this->wp_query()->get_posts();
+        if (count($results) > 1) {
+            throw new UnicityException(sprintf(
+                "%s returned %d results (%s",
+                $this->moniker(), count($results),
+                var_export(array_map(function($post) { return $post->ID; }, $results),
+                          true)));
+        }
+        return $results[0];
+    }
+
+    function results ()
+    {
+        if (! $this->query["posts_per_page"]) {
+            $this->all();
+        }
+        return $this->wp_query()->get_posts();
+    }
+
+    function all ()
+    {
+        $this->query["posts_per_page"] = -1;
+        return $this;
+    }
+
+    function moniker ($set_it = null) {
+        if ($set_it !== null) {
+            $this->moniker = $set_it;
+            return $this;    // Chainable
+        } elseif ($this->moniker) {
+            return $this->moniker;
+        } else {
+            $q = ($this->query ? $this->query : $this->_saved_query);
+            return "<" . var_export($q, true) . ">";
+        }
+    }
+}
+
+
+/**
+ * A helper to help us pretend that we are @link in_the_loop .
+ *
+ * While there is no telling whether being "in the loop" will help us
+ * in any way whatsoever with procuring sex and/or drugs, it does help
+ * with WordPress avoiding a so-called "N+1 query problem" with
+ * thumbnails.
+ *
+ * To wit, post-thumbnail-template.php has code that goes like
+ *
+ * 		if ( in_the_loop() )
+ *			update_post_thumbnail_cache();
+ *
+ * This means a contrario that when not in_the_loop(), each and every
+ * call to get_the_post_thumbnail() and friends, results in a new
+ * query to the database.
+ *
+ * @see https://secure.phabricator.com/book/phabcontrib/article/n_plus_one/
+ * @see https://www.reddit.com/r/OutOfTheLoop/
+ */
+class _InTheLoopHelper
+{
+    /**
+     * Prepare to pretend that $wp_query is the main query (which is what
+     * in_the_loop() checks).
+     */
+    function __construct ($wp_query)
+    {
+        $this->wp_query = $wp_query;
+    }
+
+    /**
+     * Start pretending to be in the loop.
+     */
+    function enter ()
+    {
+        $this->_in_the_loop_orig = $this->wp_query->in_the_loop;
+        $this->wp_query->in_the_loop = true;
+
+        global $wp_query;
+        $this->_wp_query_orig = $wp_query;
+        $wp_query = $this->wp_query;
+    }
+
+    /**
+     * Stop pretending to be in the loop and restore all state (both
+     * global and in the $wp_query object passed to the constructor)
+     * as it was before @link enter.
+     *
+     * Should be called from a "finally" block.
+     */
+    function leave ()
+    {
+        $this->wp_query->in_the_loop = $this->_in_the_loop_orig;
+
+        global $wp_query;
+        $wp_query = $this->_wp_query_orig;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/pod.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pod.php
@@ -1,0 +1,244 @@
+<?php
+/* Copyright © 2018 École Polytechnique Fédérale de Lausanne, Switzerland */
+/* All Rights Reserved, except as stated in the LICENSE file. */
+
+namespace EPFL\Pod;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+use \Error;
+
+
+/**
+ * Model for EPFL-style Wordpress-in-Docker directory layout
+ *
+ * An instance represents one of the Wordpress sites in the same
+ * filesystem as this Wordpress.
+ */
+class Site {
+    protected function __construct ($path_under_htdocs) {
+        $this->path_under_htdocs = $path_under_htdocs;
+    }
+
+    function __toString () {
+        return "<\\EPFL\\Pod\\Site(\"$this->path_under_htdocs\")>";
+    }
+
+    static function this_site () {
+        $thisclass = get_called_class();
+        list($htdocs_path, $under_htdocs) = static::_htdocs_split();
+        $that = new $thisclass($under_htdocs);
+        $that->htdocs_path = $htdocs_path;
+        return $that;
+    }
+
+    static function root () {
+        [ $htdocs, $my_subdirs ] = static::_htdocs_split();
+        $path_components = explode('/', $my_subdirs);
+
+        for($under_htdocs = '';
+            true;
+            $under_htdocs = ($under_htdocs ? "$under_htdocs/" : "") .
+                            array_shift($path_components))
+        {
+            if (static::exists("$htdocs/$under_htdocs")) {
+                $thisclass = get_called_class();
+                return new $thisclass($under_htdocs);
+            }
+            if (! count($path_components)) {
+                throw new \Error('Unable to find root site from ' . WP_CONTENT_DIR);
+            }
+        }
+    }
+
+    /**
+     * True iff $path contains a Wordpress install.
+     *
+     * @param $path A path; if relative, it is interpreted relative to
+     *              PHP's current directory which is probably not what
+     *              you want.
+     */
+    static function exists ($path) {
+        if (! preg_match('#^/#', $path)) {
+            $path = static::_htdocs_split()[0] . "/$path";
+        }
+        return is_file("$path/wp-config.php");
+    }
+
+    /**
+     * @return A list of two elements, where the first is the absolute path
+     *         to the htdocs directory and the second is the relative path
+     *         from the htdocs directory to the directory containing
+     *         wp-config.php
+     */
+    static private function _htdocs_split () {
+        $wp_content_dir = preg_replace('#/+#', '/', WP_CONTENT_DIR);
+        if (! preg_match('#(^.*/htdocs)(/.*|)$#', $wp_content_dir, $matched)) {
+            throw new \Error('Unable to find htdocs in ' . $wp_content_dir);
+        }
+        $htdocs = $matched[1];
+        $below_htdocs = preg_replace('#^/#', '',
+                                     preg_replace('#/wp-content/?$#', '',
+                                                  $matched[2]));
+        return array($htdocs, $below_htdocs);
+    }
+
+    function get_path () {
+        $path = "/" . $this->path_under_htdocs;
+        if (! preg_match('#/$#', $path)) {
+            $path = "$path/";
+        }
+        return $path;
+    }
+
+    function get_url () {
+        return 'https://' . static::my_hostport() . $this->get_path();
+    }
+
+    /**
+     * Utility function to get our own serving address in host:port
+     * notation.
+     *
+     * @return A string of the form $host or $host:$port, parsed out
+     *         of the return value of @link site_url
+     */
+    static function my_hostport () {
+        return static::_parse_hostport(site_url());
+    }
+
+    static private function _parse_hostport ($url) {
+        $host = parse_url($url, PHP_URL_HOST);
+        $port = parse_url($url, PHP_URL_PORT);
+        return $port ? "$host:$port" : $host;
+    }
+
+    function make_absolute_url ($url) {
+        if (parse_url($url, PHP_URL_HOST)) {
+            return $url;
+        } elseif (preg_match('#^/#', $url)) {
+            $myhostport = static::my_hostport();
+            return "https://$myhostport$url";
+        } else {
+            return $this->get_url() . $url;
+        }
+    }
+
+    /**
+     * @return The part of $url that is relative to the site's root,
+     *         or NULL if $url is not "under" this site. (Note: being
+     *         part of any of the @link get_subsite s is not checked
+     *         here; such URLs will "count" as well.)
+     */
+    function make_relative_url ($url) {
+        if ($hostport = static::_parse_hostport($url)) {
+            if ($hostport === static::my_hostport()
+                || $hostport === "localhost:8443") {   // XXX TMPHACK
+                $url = preg_replace("#^https?://$hostport#", '', $url);
+            } else {
+                return NULL;
+            }
+        }
+        $count_replaced = 0;
+        $url = preg_replace(
+            '#^' . quotemeta($this->get_path()) . '#',
+            '/', $url, -1, $count_replaced);
+        if ($count_replaced) return $url;
+    }
+
+    function equals ($that) {
+        return $this->path_under_htdocs === $that->path_under_htdocs;
+    }
+
+    function is_root () {
+        return $this->equals($this->root());
+    }
+
+    /**
+     * The main root Site is the one at the root of the filesystem and
+     * has not a configurated root menu.
+     */
+    function is_main_root () {
+        return $this->is_root() && empty($this->get_configured_root_menu_url());
+    }
+
+    function get_subsites () {
+        if (! $this->htdocs_path) {
+            throw new \Error("Sorry, ->get_subsites() only works on ::this_site() for now");
+        }
+
+        return static::_get_subsites_recursive (
+            $this->htdocs_path, $this->path_under_htdocs);
+    }
+
+    /**
+     * @return The 'menu_root_provider_url' entry in epfl-wp-sites-config.ini , or NULL if no such URL is configured.
+     */
+    function get_configured_root_menu_url () {
+        return $this->get_pod_config('menu_root_provider_url');
+    }
+
+    static function _get_subsites_recursive ($htdocs_path, $path) {
+        $retvals = array();
+        foreach (scandir("$htdocs_path/$path") as $filename) {
+            if (preg_match('#^([.]|wp-)#', $filename)) continue;
+            $subdir = strlen($path) ? "$path/$filename" : $filename;
+            if (! is_dir("$htdocs_path/$subdir")) continue;
+            if (static::exists($subdir)) {
+                $thisclass = get_called_class();
+                $retvals[] = new $thisclass($subdir);
+            } else {
+                $retvals = array_merge($retvals, static::_get_subsites_recursive($htdocs_path, $subdir));
+            }
+        }
+        return $retvals;
+    }
+
+    /**
+     * Get a pod config value, or all config
+     *
+     * Configuration file should be in www.epfl.ch/htdocs/epfl-wp-sites-config.ini
+     *
+     * @return (String|bool) false if not found
+     */
+
+    static function get_pod_config ($key='') {
+        $ini_path = static::_get_wp_site_config_path();
+        if ($ini_path) {
+            $ini_array = parse_ini_file($ini_path);
+            if (!empty($key)) {
+                if (array_key_exists($key, $ini_array)){
+                    return $ini_array[$key];
+                }
+            } else {
+                return $ini_array;
+            }
+        }
+    }
+
+    static $_wp_site_config_path_cache = FALSE;
+    static function _get_wp_site_config_path () {
+        if (FALSE === static::$_wp_site_config_path_cache) {
+            [ $htdocs, $my_subdirs ] = static::_htdocs_split();
+
+            for(
+              $path_components = explode('/', $my_subdirs);
+              ;
+              array_pop($path_components))
+            {
+                $try_path = $htdocs . "/" . implode("/", $path_components) . "/epfl-wp-sites-config.ini";
+                if (file_exists($try_path)) {
+                    static::$_wp_site_config_path_cache = $try_path;
+                    break;
+                }
+                if (!count($path_components)) break;
+            }
+            if (FALSE === static::$_wp_site_config_path_cache) {
+              static::$_wp_site_config_path_cache = NULL;
+            }
+        }
+
+        return static::$_wp_site_config_path_cache;
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/polyfills.js
+++ b/data/wp/wp-content/plugins/epfl/lib/polyfills.js
@@ -1,0 +1,9 @@
+// http://trollarmy.wikia.com/wiki/File:IE-trollface.png
+if (!String.prototype.endsWith) {
+	String.prototype.endsWith = function(search, this_len) {
+		if (this_len === undefined || this_len > this.length) {
+			this_len = this.length;
+		}
+		return this.substring(this_len - search.length, this_len) === search;
+	};
+}

--- a/data/wp/wp-content/plugins/epfl/lib/pubsub.php
+++ b/data/wp/wp-content/plugins/epfl/lib/pubsub.php
@@ -1,0 +1,621 @@
+<?php
+
+/**
+ * Poor man's EAI with Web hooks and PHP/MySQL.
+ *
+ * Technically, the pubsub API is no true pubsub as it can only be
+ * used to convey a semaphore information with no payload, e.g.
+ * "something has just changed". Callers are expected to propagate the
+ * payload (e.g. to find out what exactly just changed) through some
+ * other mechanism, such as a separate REST API call.
+ *
+ * This module provides causality chaining, loop elimination, basic
+ * security with nonce-based webhook authentication (on top of
+ * SSL/TLS) and (still TODO) Prometheus-style monitoring.
+ */
+
+namespace EPFL\Pubsub;
+
+if (! defined('ABSPATH')) {
+    die('Access denied.');
+}
+
+use \WP_REST_Response;
+
+require_once(__DIR__ . '/rest.php');
+use \EPFL\REST\REST_API;
+use \EPFL\REST\RESTClient;
+use \EPFL\REST\RESTAPIError;
+use \EPFL\REST\RESTClientError;
+
+require_once(__DIR__ . '/model.php');
+use \EPFL\Model\WPDBModel;
+
+class TestWebhookFlowException extends \Exception {}
+class CausalityLoopError extends \Exception {}
+
+/**
+ * Controller for a subscription.
+ *
+ * Subscribers first call @link subscribe, to cause a POST query to be
+ * sent synchronously to the publisher, which persists the contact
+ * information in-database. Every time the publisher has data to send
+ * (see @link PublishController for details), our SubscribeController
+ * instance will call back every callable that was registered
+ * with @link add_listener.
+ *
+ * Since PHP is unable to persist closures, it is up to caller code to
+ * thereafter re-create / call @link add_listener on as many instances
+ * as there are subscription topics it is interested in, at the
+ * beginning of request cycle that could receive a webhook call
+ * (typically from a 'rest_api_init' action; see @link add_action).
+ */
+class SubscribeController
+{
+    /**
+     * @param $slug A unique persistent string for this subscribe controller,
+                    also used for loop elimination.
+     */
+    private function __construct ($slug) {
+        $this->slug = $slug;
+    
+        $this->listeners = [];
+    }
+
+    public static function by_namespace_and_slug($namespace, $slug) {
+        // Unfinished business - See TODO in on_REST_webhook()
+        // We should really add a column, which requires suitable
+        // legwork to manage live upgrades.
+        return static::by_slug("$namespace/$slug");
+    }
+
+    static private $subs = array();
+    private static function by_slug ($slug) {
+        if (! array_key_exists($slug, static::$subs)) {
+            static::$subs[$slug] = new SubscribeController($slug);
+        }
+        return static::$subs[$slug];
+    }
+
+    const WEBHOOK = 'pubsub/webhook';
+    const WEBHOOK_TEST = 'pubsub/webhook-test';
+
+    static function hook () {
+        $thisclass = get_called_class();
+
+        // Same entry points for all webhooks; demultiplexing is
+        // performed on the nonce.
+        REST_API::POST_JSON(
+            static::WEBHOOK, $thisclass, 'on_REST_webhook');
+        REST_API::POST_JSON(
+            static::WEBHOOK_TEST, $thisclass, 'on_REST_test_webhook');
+    }
+
+    /**
+     * Call $callable every time we receive a webhook response
+     * following a call to @link subscribe
+     *
+     * $callable is called with an instance of @link Causality as the sole
+     * parameter, meaning (since @link Causality instances don't have a
+     * user-supplied payload) that PubsubController cannot actually
+     * convey any data around. It is up to the caller code to procure
+     * any desired payload through another means, such as a subsequent
+     * REST API call in the other direction.
+     */
+    public function add_listener ($callable) {
+        $this->listeners[] = $callable;
+    }
+
+    public /* not really */
+    static function on_REST_webhook ($req) {
+        $sub = _Subscription::get_by_nonce($nonce = $req->get_param('nonce'));
+        if (! $sub) {
+            $error = "Webhook nonce is unknown here ($nonce)";
+            _Events::error_invalid_nonce($error, $nonce);
+            return new WP_REST_Response($error, 404);
+        }
+
+        _Events::request_webhook_received($sub->slug);
+
+        $that = static::by_slug($sub->get_slug());
+        $event = Causality::unmarshall($req->get_params())
+                 ->received($that->_get_received_marker());
+        $listeners = $that->listeners;
+        if (! count($listeners)) {
+            // TODO: we should clean these up. It is unwise to do so
+            // as a matter of course: we don't know that the listeners
+            // which are missing now, could be loaded on a different
+            // data flow.
+            // Hence there should be a way for SubscribeController
+            // callers to implement a cleanup policy based on the set
+            // of slugs that is private to them.
+
+            $error = "Looks like nobody is interested in $nonce";
+            _Events::error_invalid_nonce($error, $nonce);
+            return new WP_REST_Response($error, 404);
+        }
+        foreach ($listeners as $callable) {
+            call_user_func($callable, $event);
+        }
+        _Events::request_webhook_successful($sub->slug);
+    }
+
+    /**
+     * @return A string uniquely identifying this Web site, so as to
+     *         detect and prevent causality loops.
+     */
+    private function _get_received_marker () {
+        // TODO: If we could use WP nonces instead, that'd be great.
+        return site_url();
+    }
+
+    /**
+     * Subscribe to $remote_url using a newly minted nonce
+     *
+     * That change shall be persisted on the remote side (by @link
+     * PublishController), as well as on the local side (since from
+     * then on one should be constructing a SubscribeController
+     * instance with the same $slug on basically every request cycle).
+     *
+     * Set up a newly minted nonce (or renew it in case of subsequent
+     * calls). Before the subscription URL on the other side responds,
+     * expect a test query to /wp-json/epfl/v1/webhook-test using the
+     * same nonce.
+     */
+    public function subscribe ($remote_url) {
+        $sub = _Subscription::make_temporary($this->slug);
+        $callback_url = REST_API::get_entrypoint_url(
+            $sub->get_entrypoint_uri());
+
+        try {
+            @RESTClient::POST_JSON(
+                $remote_url,
+                array(
+                    "subscriber_id" => $this->_get_subscriber_id(),
+                    "callback_url"  => $callback_url));
+            $sub->expect_confirmed();
+        } finally {
+            $sub->cleanup();
+        }
+    }
+
+    public /* not really */
+    static function on_REST_test_webhook ($req) {
+        _Subscription::get_by_nonce($req->get_param('nonce'),
+                                    /* $confirmed = */ FALSE)
+            ->confirm();
+    }
+
+    private function _get_subscriber_id () {
+        return $this->slug . "@" . site_url();
+    }
+}
+
+SubscribeController::hook();
+
+
+/**
+ * Persistent records for subscriptions
+ *
+ * Note: what to do when a subscription gets an update (see @link
+ * SubscribeController::add_listener) cannot be persisted (it's code -
+ * and that's just not the way PHP rolls). The only thing we keep
+ * around is security information (i.e. the nonce, and its validation
+ * state).
+ */
+class _Subscription extends WPDBModel
+{
+    protected const TABLE_NAME = "epfl_pubsub_subscriptions";
+
+    static function create_tables () {
+        static::query("CREATE TABLE IF NOT EXISTS %T (
+  slug VARCHAR(100) NOT NULL,
+  nonce VARCHAR(100) NOT NULL,
+  confirmed BOOL NOT NULL
+);");
+    }
+
+    static function drop_tables () {
+        static::query("DROP TABLE IF EXISTS %T");
+    }
+    
+    protected function __construct ($slug, $nonce, $confirmed = TRUE) {
+        $this->slug = $slug;
+        $this->nonce = $nonce;
+        $this->confirmed = $confirmed;
+    }
+
+    public function get_slug () {
+        return $this->slug;
+    }
+
+    static function get_by_nonce ($nonce, $confirmed = TRUE) {
+        $confirmed_sql = $confirmed ? "TRUE" : "FALSE";
+        $results = static::get_results(
+            "SELECT slug FROM %T WHERE nonce = %s 
+             AND confirmed = $confirmed_sql",
+            $nonce);
+        if (! count($results)) return null;
+        $thisclass = get_called_class();
+        return new $thisclass($results[0]->slug, $nonce, $confirmed);
+    }
+
+    static function make_temporary ($slug) {
+        $thisclass = get_called_class();
+        return (new $thisclass($slug, $thisclass::_make_nonce(), false))
+            ->_insert();
+    }
+
+    static function _make_nonce () {
+        $strength_in_bytes = 42;  // Should be a multiple of 3, so that
+                                  // there are no extra =='s at the end
+                                  // of the base64'd string
+        $base64nonce = base64_encode(random_bytes($strength_in_bytes));
+        // Better avoid characters that mean something in a URL:
+        return str_replace(
+            array('+', '/', '='),
+            array('-', '*', '_'),
+            $base64nonce);
+    }
+
+    function _insert () {
+        // We only ever ->_insert() objects created with ->make_temporary()
+        $this->query('INSERT INTO %T (slug, nonce, confirmed)
+                      VALUES (%s, %s, FALSE);',
+                     $this->slug,
+                     $this->nonce);
+        return $this;
+    }
+
+    function get_entrypoint_uri () {
+        return SubscribeController::WEBHOOK . '?nonce=' . $this->nonce;
+    }
+
+    function confirm () {
+        if ($this->confirmed) {
+            throw new TestWebhookFlowException("Unexpected attempt to re-confirm $this->slug");
+        }
+        $this->query('BEGIN WORK');
+        try {
+            $count_changed = $this->query(
+                'UPDATE %T SET confirmed = TRUE
+                 WHERE confirmed = FALSE AND NONCE = %s',
+                $this->nonce);
+
+            if ($count_changed != 1) {
+                throw new TestWebhookFlowException(
+                    "Bad update count: slug $this->slug," .
+                    " expecting 1, got $count_changed");
+            }
+            $this->query('COMMIT WORK');
+            $this->confirmed = true;
+        } finally {
+            if (! $this->confirmed) {
+                $this->query('ROLLBACK WORK');
+            }
+        }
+    }
+
+    function expect_confirmed () {
+        $thisclass = get_called_class();
+        if ($thisclass::get_by_nonce($this->nonce)) {
+            $this->confirmed = true;
+            return;
+        }
+        throw new TestWebhookFlowException(
+            "No call to /webhook-test received for $this->slug at this time");
+    }
+
+    function cleanup () {
+        if (! $this->confirmed) return;
+        $this->query("DELETE FROM %T WHERE slug = %s AND nonce != %s",
+                     $this->slug, $this->nonce);
+    }
+
+    function __toString () {
+        return sprintf(
+            '<%s slug=%s nonce=%s confirmed=%s>',
+            get_called_class(),
+            $this->slug, $this->nonce, ($this->confirmed ? "TRUE" : "FALSE"));
+    }
+}
+
+_Subscription::hook();
+
+
+/**
+ * Controller for something you want to publish.
+ *
+ * An instance of this class represents "us" as the sender of some
+ * publish-subscribe feed. There can be as many such feeds as desired,
+ * distinguished by the $slug constructor parameter.
+ *
+ * To publish something (or more precisely, signal that something is
+ * available for consumption *somewhere else*) call one of @link
+ * initiate and @link forward, which provide causality chaining and
+ * spanning-tree style loop elimination.
+ */
+class PublishController
+{
+    function __construct ($subscribe_uri) {
+        $this->subscribe_uri = $subscribe_uri;
+    }
+
+    function serve_api () {
+        REST_API::POST_JSON(
+            $this->subscribe_uri, $this, 'on_REST_subscribe');
+    }
+
+    public /* not really */
+    function on_REST_subscribe ($req) {
+        $params = $req->get_params();
+        $subscriber_id = $params["subscriber_id"];
+        $callback_url  = $params["callback_url"];
+        _Events::request_subscribe_received($this->subscribe_uri, $subscriber_id, $callback_url);
+
+        if (! $callback_url) {
+            throw new RESTAPIError(400, "Cannot subscribe without a callback_url!");
+        }
+
+        $sub = _Subscriber::overwrite($this->subscribe_uri, $subscriber_id, $callback_url);
+        $test_url = preg_replace('_/webhook([&?]|$)_', '/webhook-test$1',
+                                 $callback_url);
+        if ($test_url != $callback_url) {
+            $sub->attempt_post($test_url, array(),
+                               /* $is_sync = */ TRUE);
+        }
+        // Otherwise assume the subscriber doesn't want a synchronous call
+        // to /webhook-test
+        _Events::request_subscribe_successful($this->subscribe_uri);
+   }
+
+    /**
+     * Forward $event to all subscribers
+     *
+     * Avoid loops by doing nothing if $event has already been seen
+     * by any given subscriber.
+     */
+    public function forward ($event) {
+        _Events::action_forward($this->subscribe_uri, $event);
+        $this->_do_forward($event);
+    }
+
+    /**
+     * Ping all subscribers from a new (cause-less) event
+     */
+    public function initiate () {
+        $event = Causality::start();
+        _Events::action_initiate($this->subscribe_uri, $event);
+        $this->_do_forward($event);
+    }
+
+    public function _do_forward ($event) {
+        foreach (_Subscriber::all_by_publisher_url($this->subscribe_uri)
+                 as $sub) {
+            if ($sub->has_seen($event)) continue;
+            $sub->attempt_post($sub->get_callback_url(), $event->marshall());
+            _Events::forward_sent($this->subscribe_uri, $event);
+        }
+    }
+}
+
+/**
+ * Persistent records for subscribers, with contact details and
+ * automated cleanup of failing subscribers
+ *
+ * An instance represents one subscriber, and besides it model duties
+ * it also knows how to do some controller things, namely to send the
+ * 'real' webhook (using an instance of @link Causality as the sole
+ * payload), and the test one (to synchronously check that two-way
+ * communication is working at @link SubscribeController::subscribe
+ * time).
+ */
+class _Subscriber extends WPDBModel
+{
+    private const DEAD_SUBSCRIBER_TIMEOUT_SECS = 86400 * 30;
+    protected const TABLE_NAME = "epfl_pubsub_subscribers";
+
+    static function create_tables () {
+        static::query("CREATE TABLE IF NOT EXISTS %T (
+  id INT4 NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  publisher_url VARCHAR(1024) NOT NULL,
+  subscriber_id VARCHAR(1024),
+  callback_url VARCHAR(1024),
+  last_attempt DATETIME,
+  failing_since DATETIME
+);");
+    }
+    // We never drop that table, even on plugin removal.
+
+    protected function __construct ($id, $details) {
+        $this->ID = 0 + $id;
+        assert($this->ID > 0);
+        $details = static::_as_db_results($details);
+        $this->subscriber_id = $details->subscriber_id;
+        $this->publisher_url = $details->publisher_url;
+        $this->callback_url  = $details->callback_url;
+        assert($this->subscriber_id && $this->publisher_url &&
+               $this->callback_url);
+        if ($details->last_attempt) {
+            $this->last_attempt = $details->last_attempt;
+        }
+        if ($details->failing_since) {
+            $this->failing_since = $details->failing_since;
+        }
+    }
+
+    function get_last_attempt () {
+        return $this->last_attempt;
+    }
+
+    function get_failing_since () {
+        return $this->failing_since;
+    }
+
+    function get_callback_url () {
+        return $this->callback_url;
+    }
+
+    static public function overwrite ($publisher_url, $subscriber_id, $callback_url) {
+        static::query("DELETE FROM %T
+                      WHERE subscriber_id = %s AND publisher_url = %s",
+                     $subscriber_id, $publisher_url);
+        $thisclass = get_called_class();
+        $id = static::insert(
+            "INSERT INTO %T (publisher_url, subscriber_id, callback_url)
+             VALUES (%s, %s, %s)",
+            $publisher_url, $subscriber_id, $callback_url);
+        return new $thisclass($id,
+            array(
+                'publisher_url' => $publisher_url,
+                'subscriber_id' => $subscriber_id,
+                'callback_url'  => $callback_url));
+    }
+
+    static function all_by_publisher_url ($publisher_url) {
+        $thisclass = get_called_class();
+        $objects = array();
+        foreach (static::get_results(
+                "SELECT id, publisher_url, subscriber_id, callback_url,
+                 UNIX_TIMESTAMP(last_attempt) AS last_attempt, UNIX_TIMESTAMP(failing_since) AS failing_since
+                 FROM %T
+                 WHERE publisher_url = %s",
+                $publisher_url) as $db_line) {
+            $objects[] = new $thisclass($db_line->id, $db_line);
+        }
+        return $objects;
+    }
+
+    public function has_seen ($event) {
+        return $event->has_in_path($this->subscriber_id);
+    }
+
+    public function attempt_post ($url, $payload, $is_sync = FALSE) {
+        // So technically there is controller code in there, but
+        // attempting to untangle it would create more coupling than
+        // it would save.
+        try {
+            if ($is_sync) {
+                @RESTClient::POST_JSON($url, $payload);
+            } else {
+                @RESTClient::POST_JSON_ff($url, $payload);
+            }
+            $this->mark_success();
+        } catch (RESTClientError $e) {
+            error_log("attempt_post failed on $this: " . $e);
+            $this->mark_failure();
+        }
+    }
+
+    public function mark_success () {
+        $this->last_attempt = time();
+        $this->failing_since = NULL;
+        $this->query(
+            "UPDATE %T SET last_attempt = FROM_UNIXTIME(%d),
+                           failing_since = NULL
+                 WHERE id = %d",
+            $this->last_attempt, $this->ID);
+    }
+
+    public function mark_failure () {
+        if (! $this->failing_since) {
+            $this->last_attempt = $this->failing_since = time();
+            $this->query(
+            "UPDATE %T SET failing_since = FROM_UNIXTIME(%d),
+                           last_attempt  = FROM_UNIXTIME(%d)
+                 WHERE id = %d",
+            $this->failing_since, $this->last_attempt, $this->ID);
+        } elseif (time() - $this->failing_since >
+                  self::DEAD_SUBSCRIBER_TIMEOUT_SECS) {
+            $this->query(
+                "DELETE FROM %T WHERE id = %d",
+                $this->ID);
+        } else {
+            $this->last_attempt = time();
+            $this->query(
+                "UPDATE %T SET last_attempt = FROM_UNIXTIME(%d)
+                 WHERE id = %d;",
+                $this->last_attempt, $this->ID);
+        }
+    }
+
+    function __toString () {
+        return sprintf('<%s %s>', get_called_class(), $this->ID);
+    }
+}
+
+_Subscriber::hook();
+
+
+
+/**
+ * A data structure used to prevent loops in pubsub propagation.
+ *
+ * Instances of this class are immutable. They contain the start event
+ * timestamp and a propagation path as a list of pubsub instance ID
+ * strings.
+ */
+class Causality
+{
+    static function unmarshall ($json) {
+        $thisclass = get_called_class();
+        $that = new $thisclass();
+        $data = is_string($json) ? json_decode($json) : $json;
+        $that->timestamp = $data->timestamp;
+        $that->path      = $data->path ? $data->path : [];
+        return $that;
+    }
+
+    function marshall () {
+        return json_encode(array(
+            'timestamp' => $this->timestamp,
+            'path'      => $this->path));
+    }
+
+    static function start () {
+        $thisclass = get_called_class();
+        $that = new $thisclass();
+        $that->timestamp = time();
+        $that->path = [];
+        return $that;
+    }
+
+    function has_in_path ($subscriber_id) {
+        return in_array($subscriber_id, $this->path);
+    }
+
+    /**
+     * @return A new Causality instance with $via_subscriber_id
+     *         appended to the path
+     */
+    function received ($via_subscriber_id) {
+        if ($this->has_in_path($via_subscriber_id)) {
+            throw new CausalityLoopError(
+                implode(" -> ", $this->path) .
+                " loops back to us: $via_subscriber_id");
+        }
+
+        $thisclass = get_called_class();
+        $that = new $thisclass();
+        $that->timestamp = $this->timestamp;
+        $that->path      = $this->path;
+        $that->path[]    = $via_subscriber_id;
+        return $that;
+    }
+}
+
+
+// TODO: unstub
+class _Events
+{
+    static function request_webhook_received ($slug) {}
+    static function request_webhook_successful ($slug) {}
+    static function request_subscribe_received ($slug, $subscriber_id, $callback_url) {}
+    static function request_subscribe_successful ($slug) {}
+    static function forward_sent ($slug, $event) {}
+    static function action_initiate ($slug, $event) {}
+    static function action_forward ($slug, $event) {}
+    static function error_invalid_nonce ($msg, $nonce) {
+        error_log($msg);
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/rest.php
+++ b/data/wp/wp-content/plugins/epfl/lib/rest.php
@@ -1,0 +1,542 @@
+<?php
+/* Copyright © 2018 École Polytechnique Fédérale de Lausanne, Switzerland */
+/* All Rights Reserved, except as stated in the LICENSE file. */
+
+/**
+ * Utilities for REST APIs in the EPFL plugin
+ */
+
+namespace EPFL\REST;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+use \WP_Error;
+use \Throwable;
+
+require_once(__DIR__ . '/pod.php');
+use \EPFL\Pod\Site;
+
+const _API_EPFL_PATH = 'epfl/v1';
+
+
+class RESTAPIError extends \Exception {
+    function __construct($http_code, $payload) {
+        if (is_string($payload)) {
+            $payload = array(
+                'status' => 'ERROR',
+                'msg'    => $payload
+            );
+        }
+        $this->status = $http_code;
+        $this->payload = $payload;
+        parent::__construct($this->payload['msg']);
+    }
+}
+
+/**
+ * Ancillary class used by @link REST_API::hook_polylang_lang_query_param
+ *
+ * An instance is constructed iff the normal Polylang construction process
+ * *doesn't* complete the way we would want it to. The job is thereafter
+ * to fix things up.
+ */
+class _ForcedPolylangChooser extends \PLL_Choose_Lang {
+    function __construct() {
+        global $polylang;
+        parent::__construct($polylang);
+        // Ensure that nav menus are diverted like they would be in
+        // a frontend page:
+        new \PLL_Frontend_Nav_Menu($polylang);
+     }
+}
+
+/**
+ * Static-only class for registering REST API endpoints
+ */
+class REST_API {
+    static function hook () {
+        get_called_class()::hook_polylang_lang_query_param();
+    }
+
+    /**
+     * Register a GET route that serves JSON.
+     *
+     * @param $path     A regex for paths that should be matched under
+     *                  /epfl/v1. Should start with a slash ('/'). May
+     *                  extract URL pieces using named regex patterns,
+     *                  e.g. '/mywhatever/(?P<id>[0-9]+)'; in which
+     *                  case the matched bits will be available in
+     *                  $callback as e.g. $data['id'], where $data is
+     *                  $callback's first argument. CAVEAT: plain old
+     *                  positional patterns (with parentheses) in the
+     *                  regex *cannot* be used for extraction!
+     *                  WP_REST_Server::dispatch() has this
+     *                  undocumented "feature" of dropping @link
+     *                  preg_match matches whose key is_int().
+     *
+     * @param $callback The function, method or class method that will
+     *                  be called to handle $path. (To pass a method
+     *                  or class method, use an array of size two; see
+     *                  "closures" the in PHP documentation.) Will be
+     *                  called as mycallback($req), where $req is an
+     *                  instance of @link WP_REST_Request . URL pieces
+     *                  matched by named regex patterns in $path will
+     *                  be available as e.g. $req['id'], while query
+     *                  parameters (after the question mark) are
+     *                  available as e.g. $req->get_param('myparam').
+     *                  Shall return a data structure that will be
+     *                  converted to JSON and served.
+     */
+    static function GET_JSON ($path, ...$callback) {
+        $thisclass = get_called_class();
+        static::_do_at_time(
+            'rest_api_init',
+            function() use ($thisclass, $path, $callback) {
+                register_rest_route(_API_EPFL_PATH, $path, array(
+                    'methods' => 'GET',
+                    'callback' => function($data) use ($thisclass, $callback) {
+                        return $thisclass::_call_and_APIfy($callback, $data);
+                    }
+                ));
+            });
+    }
+
+    static function POST_JSON ($path, ...$callback) {
+        $thisclass = get_called_class();
+        static::_do_at_time(
+            'rest_api_init',
+            function() use ($thisclass, $path, $callback) {
+                register_rest_route(_API_EPFL_PATH, $path, array(
+                    'methods' => 'POST',
+                    'callback' => function($data) use ($thisclass, $callback) {
+                        return $thisclass::_call_and_APIfy($callback, $data);
+                    }
+                ));
+            });
+    }
+
+    static private function _do_at_time ($action_name, $callable) {
+        if (did_action($action_name)) {
+            call_user_func($callable);
+        } else {
+            add_action($action_name, $callable);
+        }
+    }
+
+    /**
+     * Call $callback with parameters $param_list, and ensure that the
+     * result is either a JSONable structure or a @link WP_Error.
+     */
+    static function _call_and_APIfy ($cb, ...$params) {
+        try {
+            if ($cb[0] instanceof \Closure) {
+                $cb = $cb[0];
+            }
+
+            return call_user_func_array($cb, $params);
+        } catch (Throwable $t) {  // Non-goal: PHP5 support
+            error_log($t);
+            return get_called_class()::_serve_error($t);
+        }
+    }
+
+    /**
+     * @param Throwable $t
+     * @return WP_Error
+     */
+    static function _serve_error ($t) {
+        $t_class_slug = preg_replace('/^-/', '',
+                                     str_replace('\\', '-', get_class($t)));
+        if ($t instanceof RESTAPIError) {
+            return new \WP_REST_Response($t->payload, $t->status);
+        } else {
+            return new WP_Error("ERROR:$t_class_slug", $t->getMessage());
+        }
+    }
+
+    /**
+     * Have Polylang set the current language from the ?lang=XX query parameter.
+     *
+     * If the current query is not a wp-json query, do nothing. Otherwise,
+     * get Polylang to use $_REQUEST['lang'] by hook or by crook.
+     */
+    static function hook_polylang_lang_query_param () {
+        if (! static::_doing_rest_request()) return;
+
+        // The easy way: when Languages -> Settings -> URL
+        // modifications is set to "The language is set from the
+        // directory name in pretty permalinks", and except for the
+        // root site (see below), Polylang does the needful for
+        // AJAX-on-front requests.
+        add_filter('pll_is_ajax_on_front', function($isit) { return true; });
+
+        // The hard way: there is some code in PLL_Frontend::init() to
+        // short-circuit language detection entirely (regardless of
+        // Languages -> Settings -> URL modifications) if /wp-json/ is
+        // detected at the start of the URL. Ironically, the test is
+        // sort of buggy (only works on the root site). We can force
+        // the issue like this:
+        add_action('pll_no_language_defined', function() {
+            $chooser = new _ForcedPolylangChooser();
+            $chooser->init();
+        });
+    }
+
+    /**
+     * @return Whether the current query is for one of the REST handlers
+     *         registered with this class.
+     */
+    static function _doing_rest_request () {
+        return (false !== strpos($_SERVER['REQUEST_URI'],
+                                 '/wp-json/' . _API_EPFL_PATH));
+    }
+
+    /**
+     * @param $relative_path The path to a local entry point, relative to the
+     *              REST root (similar to parameters to @link GET_JSON
+     *              or @link POST_JSON)
+     *
+     * @param $base (Optional) The URL of the expected caller of $path,
+     *              or an instance of @link Site.
+     */
+    static function get_entrypoint_url ($relative_path, $base = NULL) {
+        if (! $base) {
+            $base = Site::this_site();
+        }
+
+        if ($base instanceof Site) {
+            $base = $base->get_url();
+        }
+
+        if (! (preg_match('#/$#', $base))) {
+            $base = "$base/";
+        }
+        return sprintf('%swp-json/%s/%s', $base,
+                       _API_EPFL_PATH, $relative_path);
+    }
+}
+
+REST_API::hook();
+
+class RESTClientError extends \Exception {}
+class RESTLocalError  extends RESTClientError {}
+class RESTSSLError    extends RESTClientError {}
+class RESTRemoteError extends RESTClientError {}
+
+class RESTClient
+{
+    function __construct () {}
+
+    function set_base_uri($base_uri) {
+        $this->base_uri = $base_uri;
+        return $this;  // Chainable
+    }
+
+    /**
+     * Retrieve and return a JSON datastructure using an HTTP GET request.
+     *
+     * This function may be called both as an instance method or
+     * a class method. Prepend "@" to a static call to get rid of
+     * the PHP notice.
+     */
+    function GET_JSON ($url) {
+        if (! isset($this)) {
+            return (new static())->GET_JSON($url);
+        }
+
+        $url = $this->_canonicalize_url($url);
+        return HALJSON::decode((new _RESTRequestCurl($url, 'GET'))->execute());
+    }
+
+    /**
+     * POST $data as JSON, await and return the answer (decoded from JSON)
+     *
+     * This function may be called both as an instance method or
+     * a class method. Prepend "@" to a static call to get rid of
+     * the PHP notice.
+     */
+    function POST_JSON ($url, $data) {
+        if (! isset($this)) {
+            return (new static())->POST_JSON($url, $data);
+        }
+
+        $url = $this->_canonicalize_url($url);
+        return HALJSON::decode((new _RESTRequestCurl($url, 'POST'))
+                               ->setup_POST($data)->execute());
+    }
+    /**
+     * Like @link POST_JSON, but "fire and forget" i.e. do not wait
+     * for a response.
+     *
+     * This function may be called both as an instance method or
+     * a class method. Prepend "@" to a static call to get rid of
+     * the PHP notice.
+     */
+    function POST_JSON_ff ($url, $data) {
+        if (! isset($this)) {
+            return (new static())->POST_JSON_ff($url, $data);
+        }
+
+        $url = $this->_canonicalize_url($url);
+        (new _RESTRequestSocketFireAndForget($url, 'POST'))
+            ->setup_POST($data)->execute();
+    }
+
+    function _canonicalize_url ($url) {
+        if (! preg_match('#^/#', parse_url($url, PHP_URL_PATH))) {
+            if ($this->base_uri) {
+                $url = $this->base_uri . $url;
+            } else {
+                throw new \Error("Cannot canonicalize root-less uri $url");
+            }
+        }
+        return Site::this_site()->make_absolute_url($url);
+    }
+}
+
+class _RESTRequestBase
+{
+    function __construct ($url, $method = 'GET') {
+        $this->url = $url;
+        $this->method = $method;
+
+        $this->headers = [];
+        $this->_add_header('Accept', 'application/json');
+    }
+
+    protected function _add_header ($header, $value) {
+        $this->headers[] = array($header, $value);
+    }
+
+    public function setup_POST ($data) {
+        $this->body = is_string($data) ? $data : json_encode($data);
+        $this->_add_header('Content-Type', 'application/json');
+        $this->_add_header('Content-Length', strlen($this->body));
+        return $this;  // Chainable
+    }
+
+    protected function _get_connect_to () {
+        if (! isset($this->_connect_to)) {
+            $host = parse_url($this->url, PHP_URL_HOST);
+            $port = parse_url($this->url, PHP_URL_PORT);
+            if (! $port) {
+                $port = (parse_url($this->url, PHP_URL_SCHEME) === "http") ?
+                         80 : 443;
+            }
+            $hostport = "$host:$port";
+
+            /**
+             * Filters the host:port to connect to while attempting to
+             * perform a REST API call.
+             *
+             * In order to bypass proxies and caches, it is possible
+             * to add a filter that rewrites a particular host:port to
+             * another one. In that case, the Host: header will still
+             * be sent as if from the original query.
+             */
+            $hostport_filtered = apply_filters("epfl_rest_rewrite_connect_to", $hostport, $this->url, $host, $port);
+
+            $exploded = explode(':', $hostport_filtered);
+            $this->_connect_to = (object) array(
+                    'is_altered'  => ($hostport_filtered !== $hostport),
+                    'hostport'    => $hostport_filtered,
+                    'host'        => $exploded[0]
+                );
+            if (count($exploded) > 1) {
+                $this->_connect_to->port = $exploded[1];
+            }
+        }
+        return $this->_connect_to;
+    }
+}
+
+class _RESTRequestCurl extends _RESTRequestBase {
+    function execute () {
+        $ch = curl_init($this->url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        if ($this->method === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+        }
+
+        $connect_to = $this->_get_connect_to();
+
+        if ($connect_to->is_altered) {
+            $host_orig = parse_url($this->url, PHP_URL_HOST);
+            $port_orig = parse_url($this->url, PHP_URL_PORT);
+            if (! $port_orig) {
+                $port_orig = (parse_url($this->url, PHP_URL_SCHEME) === "http") ?
+                           80 : 443;
+            }
+            $connectto = sprintf(
+                '%s:%d:%s',
+                $host_orig, $port_orig, $connect_to->hostport);
+            curl_setopt($ch, CURLOPT_CONNECT_TO, array($connectto));
+
+            # It is very likely that an altered connect-to be using
+            # a fake certificate:
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER,
+                        $connect_to->host != 'localhost');
+        }
+
+        $curl_headers = array();
+        foreach ($this->headers as $header) {
+            list($header, $value) = $header;
+            $curl_headers[] = "$header: $value";
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $curl_headers);
+
+        if (isset($this->body)) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $this->body);
+        }
+
+        $result = curl_exec($ch);
+
+        if (curl_getinfo($ch, CURLINFO_HTTP_CODE) == 200) {
+            return $result;
+        } else {
+            $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            if ($http_code === 0) {
+                $curl_error = curl_error($ch);
+                $msg = "$this->method $this->url: $curl_error";
+                $curl_errno = curl_errno($ch);
+                if (FALSE !== array_search($curl_errno,
+                                           array(CURLE_SSL_CERTPROBLEM,
+                                                 CURLE_SSL_CACERT))) {
+                    $e = new RESTSSLError($msg);
+                } else {
+                    $e = new RESTLocalError($msg);
+                }
+                $e->curl_error = $curl_error;
+                $e->curl_errno = $curl_errno;
+            } else {
+                $e = new RESTRemoteError(
+                    "$this->method $this->url: remote HTTP status code $http_code");
+                $e->http_code = $http_code;
+            }
+            throw $e;
+        }
+    }
+}
+
+class _RESTRequestSocketFireAndForget extends _RESTRequestBase {
+    function __construct ($url, $method = 'POST') {
+        parent::__construct($url, $method);
+
+        $this->_add_header('Connection', 'close');
+    }
+
+    function execute () {
+        $connect_to = $this->_get_connect_to();
+        $verify_cert = ((! $connect_to->is_altered) &&
+                        ($connect_to->host != 'localhost'));
+        $ssl_params = array('ssl' =>
+                            array('verify_peer'      => $verify_cert,
+                                  'verify_peer_name' => $verify_cert));
+
+        $tlscontext = stream_context_create($ssl_params);
+
+        $fd = stream_socket_client(
+            sprintf('tls://%s:%d', $connect_to->host, $connect_to->port),
+            $errno, $errstr,
+            ini_get("default_socket_timeout"),
+            STREAM_CLIENT_CONNECT,
+            $tlscontext);
+        if (! $fd) {
+            $e = new RESTLocalError("$this->method $this->url: $errstr");
+            $e->sock_errno = $errno;
+            throw $e;
+        }
+
+        $path = parse_url($this->url, PHP_URL_PATH);
+        if ($query = parse_url($this->url, PHP_URL_QUERY)) {
+            $path = "$path?$query";
+        }
+
+        $host = parse_url($this->url, PHP_URL_HOST);
+        if ($port = parse_url($this->url, PHP_URL_PORT)) {
+            $hostheader = "$host:$port";
+        } else {
+            $hostheader = "$host";
+        }
+
+        $headers  = "$this->method $path HTTP/1.1\r\n";
+        $headers  .= "Host: $hostheader\r\n";
+        foreach ($this->headers as $header) {
+            list($header, $value) = $header;
+            $headers .= "$header: $value\r\n";
+        }
+
+        $headers .= "\r\n";
+        fwrite($fd, $headers, strlen($headers));
+
+        if ($this->body) {
+            fwrite($fd, $this->body, strlen($this->body));
+        }
+
+        fclose($fd);
+    }
+}
+
+add_filter('epfl_rest_rewrite_connect_to', function($hostport, $url) {
+    if ($hostport === "www.epfl.ch:443") {
+        if (preg_match('#/labs#', $url)) {
+            return "httpd-labs:8443";
+        } else {
+            return "httpd-www:8443";
+        }
+    } elseif ($hostport === "jahia2wp-httpd:443") {  # "Old" jahia2wp dev env
+        return "jahia2wp-httpd:8443";
+    } elseif ($hostport === "wp-httpd:443") {        # wp-dev
+        return "wp-httpd:8443";
+    } else {
+        return $hostport;
+    }
+}, 10, 2);
+
+
+/**
+ * Parse the HAL links as per draft-kelly-json-hal-0X
+ * @see http://stateless.co/hal_specification.html
+ *
+ * Even though the HAL standardization initiative appears to have
+ * fizzled out, @link WP_REST_Server::add_link provides for
+ * emitting it - One just has to parse it client-side, so there.
+ */
+class HALJSON
+{
+    protected function __construct ($json) {
+        foreach (json_decode($json) as $k => $v) {
+            $this->$k = $v;
+        }
+    }
+
+    static function decode ($json) {
+        $thisclass = get_called_class();
+        if (preg_match('/^\s*[{]/s', $json)) {
+            return new $thisclass($json);
+        } else {
+            # No point in HALJSON'ing an array
+            return json_decode($json);
+        }
+    }
+
+    /**
+     * @return An URL or NULL
+     */
+    function get_link ($rel) {
+        $links = $this->_links->$rel;
+        if (! $links) {
+            return NULL;
+        }
+        if ($links[0]) {
+            return $links[0]->href;
+        } else {
+            return $links->href;
+        }
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/results.php
+++ b/data/wp/wp-content/plugins/epfl/lib/results.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * OWM (Object-Whatever Mapper) for the "model" module and more.
+ *
+ * Provide mixins to work on result lists.
+ */
+
+namespace EPFL\Results;
+
+/**
+ * "use" this trait in your class to get a find() method implemented
+ * in terms of an already existing all() method. Works both for a
+ * static ::all() method or a ->all() instance method.
+ */
+trait FindFromAllTrait
+{
+    /**
+     * @return A ResultSet instance
+     */
+    function find ($criteria_array) {
+        $found = array();
+        foreach ((isset($this) ? $this->all() : static::all()) as $that) {
+            foreach ($criteria_array as $k => $v) {
+                $matcher = _Matcher::make($v);
+                $getter = "get_$k";
+                if (method_exists($that, $getter)) {
+                    if (! $matcher->matches($that->$getter())) continue 2;
+                } elseif (method_exists($that, 'meta') and
+                          $that->meta()->has($k)) {
+                    if (! $matcher->matches($that->meta()->$getter())) continue 2;
+                } else {
+                    if (! $matcher->matches($that->$k)) continue 2;
+                }
+            }
+            $found[] = $that;
+        }
+        return new InMemoryResultSet($found);
+    }
+}
+
+// Some day, we will have various matching operators and the ability
+// to project them SQL-side.
+class _Matcher
+{
+    protected function __construct () {}
+
+    static function make($what) {
+        $thisclass = get_called_class();
+        $that = new $thisclass();
+        // For now, only matching for equality is supported.
+        $that->equals = $what;
+        return $that;
+    }
+
+    function matches ($value) {
+        return $value === $this->equals;
+    }
+
+    // TODO: Introduce some kind of way to ->apply(), or something,
+    // onto a _WPQueryBuilder. I guess one of them or us must be
+    // public, or something.
+}
+
+
+// Some day, we will have SQL-constructing ResultSet's.
+interface ResultSet
+{
+    public function all ();
+    public function first_preferred ($criteria_array);
+}
+
+
+class InMemoryResultSet implements ResultSet
+{
+    function __construct ($results) {
+        $this->results = $results;
+    }
+
+    use FindFromAllTrait;
+
+    function all () {
+        return $this->results;
+    }
+
+    function first_preferred ($criteria_array) {
+        $preferred = $this->find($criteria_array)->all();
+        if (count($preferred)) {
+            return $preferred[0];
+        } else if (count($this->results)) {
+            return $this->results[0];
+        } else {
+            return NULL;
+        }
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/lib/this-plugin.php
+++ b/data/wp/wp-content/plugins/epfl/lib/this-plugin.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Encapsulate and simplify a few plugin-related pieces of the WordPress API
+ */
+
+namespace EPFL\ThisPlugin;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+function topdir () {
+    return dirname(__DIR__);
+}
+
+/**
+ * @return The top-level PHP file of this plugin (wanted by e.g. @link plugins_url)
+ */
+function entry_point () {
+    return topdir() . "/epfl.php";
+}
+
+/**
+ * Reference, enqueue etc. assets in this plugin by relative path
+ */
+class Asset {
+    function __construct ($relpath) {
+        $this->relpath = $relpath;
+    }
+
+    function url () {
+        return plugins_url($this->relpath, entry_point());
+    }
+
+    function abspath () {
+        return topdir() . "/" . $this->relpath;
+    }
+
+    function enqueue_script ($deps = ['jquery']) {
+        return wp_enqueue_script(
+            basename($this->relpath, ".js"),
+            $this->url(),
+            $deps,
+            filemtime($this->abspath()));
+    }
+
+    function enqueue_style () {
+        return wp_enqueue_style(
+            basename($this->relpath, ".css"),
+            $this->url(),
+            [],
+            filemtime($this->abspath()));
+    }
+}
+
+function on_activate ($callable) {
+    register_activation_hook(entry_point(), $callable);
+}
+
+function on_deactivate ($callable) {
+    register_deactivation_hook(entry_point(), $callable);
+}

--- a/data/wp/wp-content/plugins/epfl/lib/wp-admin-api.php
+++ b/data/wp/wp-content/plugins/epfl/lib/wp-admin-api.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Homemade HTML forms and AJAX in the wp-admin area, with XSRF protection.
+ */
+
+namespace EPFL\AdminAPI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    die( 'Access denied.' );
+}
+
+/**
+ * An endpoint for AJAX or Web 1.0-style ("custom POST handler") forms
+ * in the wp-admin pages, with XSRF protection
+ *
+ * An instance of this class represents a number of PHP methods on the
+ * server side (registered with @link register_handlers), and all the
+ * information that the client-side HTML or JS needs in order to
+ * successfully invoke them (that includes an "action" demultiplexer
+ * and an XSRF nonce, both emitted as
+ * application/x-www-form-urlencoded POST fields; see @link
+ * output_bindings).
+ */
+class Endpoint
+{
+    function __construct ($slug) {
+        // $slug must be a valid JS identifier:
+        assert(preg_match('/^[A-Za-z_][A-Za-z0-9_]+$/', $slug));
+        $this->slug = $slug;
+    }
+
+    private function get_action_name ($method_stem) {
+        // IMPORTANT: the JS code served by @link output_js_prototype
+        // must perform the exact same computation for the "action"
+        // field.
+        return sprintf('epfl_%s_%s', $this->slug, $method_stem);
+    }
+
+    private function nonce_name () {
+        return 'xsrf_nonce_' . $this->slug;
+    }
+
+    /**
+     * Register $class as having AJAX and/or custom POST handlers
+     *
+     * All methods in $class whose name is like ajax_${method_stem}
+     * are set up as so-called "WP-AJAX" handlers, available at URL
+     * /admin-ajax.php?action=epfl_${slug}_${method_stem}, where $slug
+     * is the constructor parameter. Likewise, all methods in $class
+     * whose name matches admin_post_${method_stem} are hooked up as
+     * so-called "custom POST handlers", at address
+     * /post.php?action=epfl_${slug}_${method_stem}.
+     *
+     * WP-AJAX handler methods can obtain the details of a GET AJAX
+     * request in $_GET, and/or $_REQUEST; in the case of a proper
+     * JSON POST request (with Content-Type: application/json in the
+     * request), the decoded JSON will be passed as a parameter to the
+     * handler method instead. WP-AJAX handler methods shall return
+     * the data structure that they wish to return to the AJAX caller
+     * (typically a PHP associative array).
+     *
+     * Custom POST handler methods get the parameters using $_REQUEST
+     * / $_POST as usual; they shall return the URL (relative to
+     * /wp-admin) the user's browser shall be 301-redirected to.
+     * (Serving actual HTML pages only out of GET requests is a best
+     * practice to prevent issues with the browser's reload button.)
+     *
+     * Neither WP-AJAX nor custom-post method handlers need to check
+     * the nonce by themselves for XSRF protection; this will have
+     * been done already by code in this class before control enters
+     * the handlers.
+     *
+     * @see https://codex.wordpress.org/AJAX_in_Plugins WP-AJAX API definition
+     * @see https://codex.wordpress.org/Plugin_API/Action_Reference/admin_post_(action) Custom POST handlers API definition
+     *
+     * @param $class The fully qualified class name. Tip: you can
+     *               use the form `MyClass::class` to get a fully
+     *               qualified class name.
+     */
+    function register_handlers ($class)
+    {
+        $self = $this;
+        foreach (get_class_methods($class) as $method_name) {
+            $matched = [];
+            if (preg_match("/^ajax_(.*)$/", $method_name, $matched)) {
+                add_action(
+                    "wp_ajax_" . $this->get_action_name($matched[1]),
+                    function() use ($self, $class, $method_name) {
+                        $self->_handle_ajax($class, $method_name);
+                    });
+            }
+            if (preg_match("/^admin_post_(.*)$/", $method_name, $matched)) {
+                add_action(
+                    "admin_post_" . $this->get_action_name($matched[1]),
+                    function() use ($self, $class, $method_name) {
+                        $self->_handle_admin_post($class, $method_name);
+                    });
+            }
+        }
+    }
+
+    function _handle_ajax ($class, $method_name) {
+        check_ajax_referer($this->nonce_name());
+        if ($_SERVER['REQUEST_METHOD'] === "POST" &&
+            $_SERVER["CONTENT_TYPE"] === "application/json") {
+            $json_response = call_user_func(
+                array($class, $method_name),
+                json_decode(file_get_contents('php://input'), true));
+        } else {
+            $json_response = call_user_func(
+                array($class, $method_name));
+        }
+        echo json_encode($json_response, JSON_PRETTY_PRINT);
+        wp_die();  // That's the way WP AJAX rolls
+    }
+
+    function _handle_admin_post ($class, $method_name) {
+        check_admin_referer($this->nonce_name());
+        $redirect_url = call_user_func(array($class, $method_name));
+        wp_redirect(admin_url($redirect_url));
+        exit();
+    }
+
+
+    static $_endpoint_emitted;
+    /**
+     * Output the Endpoint constructor into the PHP document flow.
+     */
+    static private function output_js_endpoint_once ()
+    {
+        if (self::$_endpoint_emitted) return;
+
+            ?>
+            <script>
+            function Endpoint(slug, nonce) {
+                var web10POSTUrl = "<?php echo admin_url('admin-post.php'); ?>",
+                    ajaxUrl = "<?php echo admin_url('admin-ajax.php'); ?>";
+<?php # IMPORTANT: action_name() below must make the exact same
+      # computation as @link get_action_name ?>
+                function action_name (method_stem) {
+                    return 'epfl_' +  slug + '_' + method_stem;
+                }
+                function ajax (method_stem, opts) {
+                    var $ = window.jQuery;
+                    return $.ajax($.extend({
+                            url: ajaxUrl + '?_ajax_nonce=' + nonce + 
+                                 '&action=' + action_name(method_stem),
+                        }, (opts || {})));
+                }
+                return {
+                    ajax: ajax,
+                    post: function (method_stem, opts) {
+                        if (! opts) {
+                            opts = {};
+                        }
+                        if (! ('data' in opts)) {
+                            opts.data = {};
+                        }
+                        if (typeof(opts.data) !== "string") {
+                            opts.data = JSON.stringify(opts.data);
+                        }
+                        return ajax(method_stem, window.jQuery.extend(
+                            {
+                                type: 'POST',
+                                contentType: "application/json",
+                                dataType: "json"  // Expected in return
+                            }, opts));
+                    },
+                    asWPAdminPostForm: function (method_stem) {
+                        var $ = window.jQuery;
+                        var $form = $('<form></form>').appendTo($('body'));
+                        $form.attr({
+                                method: 'POST',
+                                action: web10POSTUrl
+                             });
+
+                        $form.inputHidden = function(name, value) {
+                            var $input = $('<input type="hidden"></input>')
+                                       .appendTo($form);
+                            $input.attr({
+                                  id: name,<?php # Cargo-culted ?>
+                                  name: name,
+                                  value: value});
+                            return $input;
+                        };
+                        $form.inputHidden('_wpnonce', nonce);
+                        $form.inputHidden('action', action_name(method_stem));
+                        return $form;
+                    }
+                };
+            }
+            </script>
+            <?php
+
+        self::$_endpoint_emitted = true;
+    }
+
+    /**
+     * Echoes some JS code to encapsulate calling the AJAX endpoints
+     *
+     * window[$slug] will be set up as an object with .ajax(), .post()
+     * and .asWPAdminPostForm() methods that encapsulate (hide) the
+     * demultiplexing and XSRF protection concerns from the caller.
+     * window[$slug].ajax() and window[$slug].post() work a lot like
+     * jQuery.ajax and jQuery.post respectively, except the URL
+     * parameter is replaced with a PHP-side method stem (that is, the
+     * part after "ajax_" of methods of the class(es) passed to @link
+     * register_handlers).
+     *
+     * window[$slug].asWPAdminPostForm(actionSlug) creates and returns
+     * a jQuery object containing a newly constructed <form> element;
+     * likewise, the actionSlug parameter corresponds do the part
+     * after "admin_post_" in the name of class(es) passed to @link
+     * register_handlers. Call .inputHidden(name, value) on the
+     * returned jQuery object to add form fields to your liking (in
+     * addition to the ones set up automatically, see below)
+     *
+     * In both cases, the appropriate piping is performed transparently:
+     * the `action` POST field is set up to match the 
+     * @link wp_ajax_(action) or @link admin_post_(action) in the
+     * Wordpress API, and a nonce field (_wpnonce for the
+     * asWPAdminPostForm case; _ajax_nonce for the ajax / post case)
+     * is set up to a suitably generated XSRF protection token.
+     */
+    function output_bindings ()
+    {
+        $this->output_js_endpoint_once();
+        printf(
+            "<script>window.%s = new Endpoint('%s', '%s');</script>\n",
+            $this->slug, $this->slug,
+            wp_create_nonce($this->nonce_name()));
+    }
+
+    /**
+     * Arrange for @link output_bindings() to be called
+     */
+    function admin_enqueue ()
+    {
+        add_action('admin_enqueue_scripts',
+                   array($this, 'output_bindings'));
+    }
+}

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.css
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.css
@@ -1,0 +1,54 @@
+#edit-external-menu {
+        background-color: yellow;
+}
+
+.ajax-pending, .ajax-resolved, .ajax-rejected, .ajax-timeout {
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+    margin-left: 0.3em;
+}
+
+.ajax-pending {
+    background-image: url(../../../../wp-admin/images/loading.gif);
+    background-repeat: no-repeat;
+    background-position: right center;
+}
+
+.ajax-resolved::after {
+    color: green;
+    content: "✓";
+}
+
+.ajax-rejected::after {
+    color: red;
+    content: "⚠";
+}
+
+.ajax-timeout::after {
+    content: "🕒";
+}
+
+button p.tooltip-error {
+    color: red;
+    display: block;
+    visibility: hidden;
+
+    position: absolute;
+    right: -130%;
+    top: 0px;
+
+    border: 1px solid black;
+    border-radius: 6px;
+    padding: 0px 10px;
+    background-color: #f1f1f1;
+}
+
+button p.tooltip-error::before {
+    color: black;
+    content: "💡 ";
+}
+
+button:hover p.tooltip-error {
+    visibility: visible;
+}

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus-admin.js
@@ -1,0 +1,185 @@
+/**
+ * Interactive features for the external menus functionality
+ *
+ * This piece of JS is loaded on both the list view app for the
+ * epfl-external-menu custom post type, and in the Appearance -> Menus
+ * screen (although at the moment it does nothing on the latter).
+ */
+
+/**
+ * Activate the app on the epfl-external-menu list view screen
+ */
+function initExternalMenuList ($) {
+    $('a.page-title-action').remove();
+    $('h1.wp-heading-inline').after('<button class="page-title-action">' + wp.translations.refresh_button + '</button>');
+    var $button = $('h1.wp-heading-inline').next();
+
+    $button.click(function() {
+        onRefreshButton($, $button);
+    });
+}
+
+function onRefreshButton ($, $button) {
+    if ($button.spinner) {
+        if ($button.spinner.isActive()) {
+            return;
+        } else {
+            $button.spinner.$spinner.remove();
+        }
+    }
+    $('p', $button).remove();  // Previous error messages (if any), see below
+    $button.spinner = new Spinner($);
+    $button.append($button.spinner.$spinner);
+
+    window.EPFLMenus.post('enumerate', { data: { retryToken: null} })
+        .then(function(response) {
+          return enumerateRetry(response);
+        }).then(
+            function(response) {
+                var ids = response.external_menu_item_ids;
+                if (ids) {
+                    $button.spinner.progress.resolve();
+                    return updateRowsDeferred($, ids);
+                } else {
+                    console.log('AJAX ERROR:', response);
+                    throw new Error(response.status);
+                }
+            },
+            function(err) {
+                $button.spinner.progress.reject();
+                if (err.status === 504) {
+                    $button.spinner.$spinner.removeClass().addClass('ajax-timeout');
+                    $button.append('<p class="tooltip-error">Timeout in the server</p>');
+                } else {
+                    $button.append('<p class="tooltip-error">Server-side error</p>');
+                }
+
+            });
+
+    function enumerateRetry(response) {
+        if (! response.hasOwnProperty('retryToken')) {
+            return response;
+        }
+        return window.EPFLMenus.post(
+            'enumerate',
+            {data: {retryToken: response.retryToken}})
+            .then(
+                enumerateRetry,
+                function(err) {
+                    if (err.status === 504) {
+                        return enumerateRetry(response);
+                    } else {
+                        throw new Error(response.status);
+                    }
+                });
+    }
+}
+
+/**
+ * @param $ the jQuery framework object
+ * @param ids An array of IDs returned by the 'enumerate' AJAX call,
+ *            which may differ from what is visible on-screen (e.g.
+ *            new child site just popped up, or there are more
+ *            ExternalMenuItem's than the pagination limit)
+ */
+function updateRowsDeferred ($, ids) {
+    var d = $.Deferred();
+    var todoCount = ids.length;
+    var hasInvisibleChanges = false;
+
+    if (! todoCount) {
+        // It is bad practice to resolve a promise before returning it:
+        window.setTimeout(function() {
+            d.resolve();
+        }, 0);
+        return d;
+    }
+
+    // Here, we could update the tr's in tbody#the-list to match ids,
+    // perhaps with some kind of CSS animation for
+    // appearing/disappearing rows.
+
+    for (var i = 0 ; i < ids.length; i++) {
+        var id = ids[i], $tr = $('tr#post-' + id);
+        if (! $tr.length) {
+            hasInvisibleChanges = true;
+        }
+
+        // Start all the updates in parallel at once, and let the
+        // browser's outstanding XMLHTTPRrequest limit do the
+        // throttling
+        updateOneRowDeferred($, id, $tr).always(function() {
+            if (--todoCount) return;
+
+            if (! hasInvisibleChanges) {
+                // Put a check mark in the top-most Refresh button,
+                // and allow user to click it again
+                d.resolve();
+            } else {
+                // Some rows were created/deleted (or pagination is in
+                // play), and the display might currently be
+                // incomplete or misleading. Rather than patching up
+                // the DOM (which we could, see comment above), just
+                // reload the page. This is a rare case; in
+                // steady-state, the reload button doesn't create or
+                // delete any ExternalMenuItem.
+                location.reload();
+            }
+        });
+    }
+    return d;
+}
+
+function updateOneRowDeferred ($, id, $tr) {
+    if ($tr.spinner) { $tr.spinner.$spinner.remove(); }
+    var spinner = $tr.spinner = new Spinner($);
+    $('td.column-date', $tr).empty().append(spinner.$spinner);
+
+    var allRowClasses = 'sync-inprogress sync-success sync-failed';
+    $tr.removeClass(allRowClasses).addClass('sync-inprogress');
+    spinner.progress.then(
+        function() { $tr.removeClass(allRowClasses).addClass('sync-success'); },
+        function() { $tr.removeClass(allRowClasses).addClass('sync-failed'); });
+
+    window.EPFLMenus.post('refresh_and_resubscribe_by_id', {data: {id: id}})
+        .then(
+            function (response) {
+                if (response.status !== 'OK') {
+                    spinner.progress.reject();
+                } else {
+                    spinner.progress.resolve();
+                }
+            },
+            function (error) {
+                console.log('POST refresh_and_resubscribe_by_id for ' + id + ': ', error);
+                spinner.progress.reject();
+            });
+    return spinner.progress;
+}
+
+/**
+ * @constructor
+ */
+function Spinner ($) {
+    var $spinner = this.$spinner = $('<span></span>');
+    var progress = this.progress = $.Deferred();
+
+    function updateSpinner () {
+        $spinner.removeClass().addClass('ajax-' + progress.state());
+    }
+    updateSpinner();
+    progress.always(updateSpinner);
+}
+
+Spinner.prototype.isActive = function() {
+    return this.progress.state() === 'pending';
+}
+
+jQuery(document).ready(function($) {
+    if (window.wp.screen.base === 'edit' && window.wp.screen.post_type === 'epfl-external-menu' ) {
+        initExternalMenuList($);
+    }
+
+    // If you see this, nothing threw or crashed (yet).
+    console.log('epfl-menus-admin.js is on duty.');
+});

--- a/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
+++ b/data/wp/wp-content/plugins/epfl/menus/epfl-menus.php
@@ -1,0 +1,2001 @@
+<?php
+/* Copyright © 2018 École Polytechnique Fédérale de Lausanne, Switzerland */
+/* All Rights Reserved, except as stated in the LICENSE file. */
+/**
+ * Stitch menus across sites
+ *
+ * The EPFL is a pretty big place, and Wordpress' access control is
+ * not up to task to its administrative complexity. The solution we
+ * came up with is to apportion pages and posts of large Web sites
+ * into as many WordPress instances, living under the same Apache
+ * server and URL tree, as there are administrative subdivisions to
+ * cater to. This is made transparent to the visitor through a number
+ * of tricks and extensions, including this one.
+ */
+
+namespace EPFL\Menus;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+require_once(ABSPATH . 'wp-admin/includes/class-walker-nav-menu-edit.php');
+
+require_once(dirname(__DIR__) . '/lib/model.php');
+use \EPFL\Model\TypedPost;
+
+require_once(dirname(__DIR__) . '/lib/results.php');
+use \EPFL\Results\FindFromAllTrait;
+
+require_once(dirname(__DIR__) . '/lib/rest.php');
+use \EPFL\REST\REST_API;
+use \EPFL\REST\RESTClient;
+use \EPFL\REST\RESTClientError;
+use \EPFL\REST\RESTRemoteError;
+use \EPFL\REST\RESTAPIError;
+
+require_once(dirname(__DIR__) . '/lib/admin-controller.php');
+use \EPFL\AdminController\TransientErrors;
+use \EPFL\AdminController\CustomPostTypeController;
+
+require_once(dirname(__DIR__) . '/lib/pubsub.php');
+use \EPFL\Pubsub\PublishController;
+use \EPFL\Pubsub\SubscribeController;
+use \EPFL\Pubsub\TestWebhookFlowException;
+
+require_once(dirname(__DIR__) . '/lib/i18n.php');
+use function EPFL\I18N\___;
+use function EPFL\I18N\__x;
+use function EPFL\I18N\__e;
+use function EPFL\I18N\get_current_language;
+
+require_once(dirname(__DIR__) . '/lib/this-plugin.php');
+use EPFL\ThisPlugin\Asset;
+
+require_once(dirname(__DIR__) . '/lib/pod.php');
+use EPFL\Pod\Site;
+
+class MenuError extends \Exception {}
+
+class TreeError extends \Exception {}
+
+class TreeLoopError extends TreeError {
+    function __construct($ids_array) {
+        $msg = implode(" ", array_keys($ids_array));
+        parent::__construct($msg);
+    }
+}
+
+/**
+ * A Wordpress-style list of menu objects.
+ *
+ * An instance represents a list of objects that are typically
+ * manipulated by Wordpress and its so-called walkers in order to
+ * construct menus. Instances are immutable: all mutating operations
+ * return a fresh object where all $item objects (the ones returned
+ * by @link as_list) are also fresh.
+ */
+class MenuItemBag
+{
+    function __construct ($items, $hide_tree_problems=false) {
+        if (! is_array($items)) {
+            throw new \Error('Bad argument: ' . var_export($items, true));
+        }
+        $this->items = array();
+        foreach ($items as $item) {
+            $this->_MUTATE_add_item($item);
+        }
+        $this->_MUTATE_validate_and_toposort($hide_tree_problems);
+    }
+
+    static function coerce ($what) {
+        $thisclass = get_called_class();
+        if ($what instanceof $thisclass) {
+            return $what;
+        } else {
+            return new $thisclass($what);
+        }
+    }
+
+    function copy () {
+        $thisclass = get_called_class();
+        $copied_items = array();
+        foreach ($this->as_list() as $item) {
+            $copied_items[] = clone $item;
+        }
+        return new $thisclass($copied_items);
+    }
+
+    function mimic_current ($another_menu_tree) {
+        $copy = $this->_copy_attributes($another_menu_tree,
+                                        array('classes', 'current'));
+        $copy->_MUTATE_fixup_current_attributes_and_classes();
+        return $copy;
+    }
+
+    /**
+     * Enforce the same values on attributes 'current',
+     * 'current_item_ancestor' and 'current_item_parent' and 'classes'
+     * as WordPress' @link wp_nav_menu function would:
+     *
+     * - every parent of an item that is 'current' is 'current_item_parent'
+     *
+     * - every parent or ancestor of an item that is 'current' is
+     *   'current_item_ancestor'
+     *
+     * - a node has class 'menu-item-has-children' if and only if
+     *   it has children
+     */
+    private function _MUTATE_fixup_current_attributes_and_classes() {
+        $current_items = array();  // Plural 'coz why not?
+        foreach ($this->items as $item) {
+            $this->_MUTATE_reset_current_ancestry_status($item);
+            if ($this->_is_current($item)) {
+                $current_items[$this->_get_id($item)] = $item;
+            }
+        }
+
+        $current_ancestors = array();
+        foreach ($current_items as $item) {
+            $current_parent_id = $this->_get_parent_id($item);
+            if (! $current_parent_id) continue;
+            if (! ($current_parent = $this->items[$current_parent_id])) continue;
+            $this->_MUTATE_make_parent_of_current($current_parent);
+
+            $current_ancestors[$current_parent_id] = $current_parent;
+        }
+
+        while(count($current_ancestors)) {
+            $current_ancestors_next = array();
+            foreach ($current_ancestors as $current_ancestor) {
+                $current_ancestor_id = $this->_get_parent_id($current_ancestor);
+                if (! ($current_ancestor =
+                       $this->items[$current_ancestor_id])) continue;
+                $current_ancestors_next[$current_ancestor_id] = $current_ancestor;
+                $this->_MUTATE_make_ancestor_of_current($current_ancestor);
+            }
+            $current_ancestors = $current_ancestors_next;
+        }
+
+        $all_parents = array();
+        foreach ($this->items as $item) {
+            if (! ($parent_id = $this->_get_parent_id($item))) continue;
+            $all_parents[$parent_id] = 1;
+        }
+
+        // Fix up 'menu-item-has-children' class or lack thereof
+        foreach ($this->items as $item) {
+            if ($classes = $item->classes) {
+                $item->classes = array_filter(
+                    $classes,
+                    function($class) {
+                        return $class != 'menu-item-has-children';
+                    });
+            }
+        }
+        foreach (array_keys($all_parents) as $parent_id) {
+            $this->items[$parent_id]->classes[] = 'menu-item-has-children';
+            // wp_nav_menu() caller will eliminate any duplicates
+        }
+    }
+
+    private function _copy_attributes ($another_menu, $attributes) {
+        $thisclass = get_called_class();
+        if ($another_menu instanceof $thisclass) {
+            $src_items = $another_menu_tree->items;
+        } else {
+            $src_items = array();
+            foreach ($another_menu as $item) {
+                $src_items[$this->_get_id($item)] = $item;
+            }
+        }
+
+        $copy = $this->copy();
+        foreach ($copy->items as $id => &$item) {
+            foreach ($attributes as $k) {
+                if ($v = @$src_items[$id]->$k) {
+                    $item->$k = $v;
+                }
+            }
+        }
+        return $copy;
+    }
+
+   /**
+    * Sort the tree in-place in topological order (ancestors before
+    * descendants)
+    *
+    * At the same time, validate the tree so that
+    *
+    *  - All ->_get_parent_id's are 0 or within the graph
+    *
+    *  - There are no ancestry loops
+    *
+    * @param boolean $hide_tree_problems Set to true if you want to ignore the
+    *        problematic descendants, without throwing an error
+    */
+    private function _MUTATE_validate_and_toposort (bool $hide_tree_problems) {
+        // Based on https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
+        $children        = array();    // Adjacency list, keyed by parent ID
+        $safe            = array();    // List of nodes with no loops in their ancestry
+                                       // (S in the Wikipedia algorithm)
+        $ids_to_ignore   = array();    // if we have a parent id without the data,
+                                       // ignore the full subtree
+
+        foreach ($this->items as $item) {
+            $id = $this->_get_id($item);
+            $parent_id = $this->_get_parent_id($item);
+            if (! $parent_id) {
+                $safe[] = $id;
+            } elseif (! array_key_exists($parent_id, $this->items)) {
+                // Houston, we have an inconsistency. wp-admin should show it
+                // in menu editor. Until someone manualy fix it,
+                //  keep the item hidden
+                if (!$hide_tree_problems) {
+                    throw new TreeError("Parent of $id ($parent_id) unknown");
+                } else {
+                    $ids_to_ignore[] = $id;
+                    if (defined('WP_DEBUG') && WP_DEBUG) {
+                        // debuggers may want to understand what is currently happening
+                        error_log("Menu tree error : Parent of $id ($parent_id) unknown; ignoring this entry and all the current children");
+                    }
+                }
+            } elseif (in_array($parent_id, $ids_to_ignore)) {
+                // as the parent has an inconsistency, ignore all the children too
+                $ids_to_ignore[] = $id;
+                if (defined('WP_DEBUG') && WP_DEBUG) {
+                    // debuggers may want to understand what is currently happening
+                    error_log("Menu tree error : Ignoring this entry $id as the parent $parent_id is currently ignored");
+                }
+            } elseif (! array_key_exists($parent_id, $children)) {
+                $children[$parent_id] = array($id);
+            } else {
+                $children[$parent_id][] = $id;
+            }
+        }
+
+        $sorted = array();    // L in the Wikipedia algorithm
+        while(count($safe)) {
+            $n = array_shift($safe);  // Proof of termination starts here
+
+            // $n is 1) known not to have loops in its ancestry, 2)
+            // at the right place at the end of the topological sort.
+            $sorted[] = $n;
+
+            if (array_key_exists($n, $children)) {
+                // All children of a safe node are safe
+                $safe = array_merge($safe, $children[$n]);
+                // Discard the corresponding edges from the adjacency list
+                unset($children[$n]);
+            }
+        }
+
+        if (count($children)) {
+            // Some nodes were not visited; they must have cycles.
+            throw new TreeLoopError(array_keys($children));
+        }
+
+        $unsorted_items = $this->items;
+        $this->items = array();
+        foreach ($sorted as $id) {
+            $this->items[$id] = $unsorted_items[$id];
+        }
+    }
+
+    function as_list () {
+        return array_values($this->items);
+    }
+
+    function find ($item_or_id) {
+        $id = is_object($item_or_id) ? $item_or_id->ID : $item_or_id;
+        return $this->items[$id];
+    }
+
+    function annotate_roots ($annotations) {
+        $copy = $this->copy();
+        foreach ($copy->items as $item) {
+            if (! $this->get_parent($item)) {
+                foreach ($annotations as $k => $v) {
+                    // ->copy() is a deep copy so this is safe.
+                    $item->$k = $v;
+                }
+            }
+        }
+        return $copy;
+    }
+
+    function graft ($at_item, $bag) {
+        return static::_MUTATE_graft(
+            $this->_get_id($at_item),
+            $this->copy(), $this->_renumber(static::coerce($bag)));
+    }
+
+    function reverse_graft ($at_item, $into) {
+        $id = $this->_get_id($at_item);
+        $into_renumbered = $this->_renumber($into, /*&*/$id);
+        return static::_MUTATE_graft($id, $into_renumbered, $this->copy());
+    }
+
+    /**
+     * Pluck all items in MenuItemBag that match $callable_predicate,
+     * and return them separately from the pruned tree. Discard
+     * now-dangling descendants of the plucked items.
+     *
+     * @param $callable_predicate A callable that takes a $item as the
+     *        sole parameter, and returns a true value for items to
+     *        remove from the tree, and a false value for those to
+     *        keep. Items that are descendants of an item for which
+     *        $callable_predicate returned true, will be discarded
+     *        (regardless of what $callable_predicate returned for them,
+     *        if indeed $callable_predicate was called at all for them
+     *        which is left unspecified)
+     *
+     * @return A pair of the form array($pruned_tree, $removed) where
+     *         $pruned_tree is a newly created copy of the pruned tree
+     *         (or $this if $callable_predicate never returned true),
+     *         and $removed is the list of items for which
+     *         $callable_predicate returned a true value (*not* the
+     *         descendants thereof).
+     */
+    function pluck ($callable_predicate) {
+        $remaining_candidates = array();
+
+        $pruned = array();
+        foreach ($this->items as $item) {
+            if (call_user_func($callable_predicate, $item)) {
+                $pruned[$this->_get_id($item)] = $item;
+            } else {
+                $remaining_candidates[] = $item;
+            }
+        }
+
+        if (! count($pruned)) {
+            return array($this, []);  // No change
+        }
+
+        // Keep descendants of $pruned out of $remaining
+        $remaining = array();
+        foreach ($remaining_candidates as $rc) {
+            $ancestor_ids = array();
+
+            for ($ancestor = $rc; $ancestor;
+                 $ancestor = $this->get_parent($ancestor))
+            {
+                $ancestor_id = $this->_get_id($ancestor);
+                if (isset($ancestor_ids[$ancestor_id])){
+                    throw new TreeLoopError($ancestor_ids);
+                } else {
+                    $ancestor_ids[$ancestor_id] = 1;
+                }
+                if (array_key_exists($ancestor_id, $pruned)) continue 2;
+            }
+            $remaining[] = $rc;
+        }
+
+        $thisclass = get_called_class();
+        return array(new $thisclass($remaining), $pruned);
+    }
+
+    /**
+     * Apply a function on each item in this MenuItemBag.
+     *
+     * @param $func A callable that takes a $item as the sole
+     *        parameter, and returns either a menu item (with a type
+     *        and structure similar to $item) or NULL
+     *
+     * @return A new MenuItemBag made out of all the non-NULL values
+     *         returned by $func
+     */
+    function map ($func) {
+        $mapped_items = array();
+        foreach ($this->items as $item) {
+            $mapped_item = call_user_func($func, $item);
+            if ($mapped_item !== NULL) {
+                $mapped_items[] = $mapped_item;
+            }
+        }
+        $thisclass = get_called_class();
+        return new $thisclass($mapped_items);
+    }
+
+    /**
+     * @return A copy of $this without the ExternalMenuItem nodes
+     *
+     * Parent nodes of ExternalMenuItem nodes are decorated with
+     * an additional attribute 'epfl_external_menu_children_count'
+     * counting the elements so removed. WordPress attributes and
+     * CSS classes that encode parent-child relationships are also
+     * updated.
+     */
+    function trim_external () {
+        list($retval, $emis) = $this->pluck(function($item) {
+            return ExternalMenuItem::looks_like($item);
+        });
+        foreach ($emis as $emi) {
+          $parent_id = $emi->menu_item_parent;
+          if (! $parent_id) continue;
+          $parent = $retval->find($parent_id);
+          if (! property_exists($parent, "epfl_external_menu_children_count")) {
+            $parent->epfl_external_menu_children_count = 0;
+          }
+          $parent->epfl_external_menu_children_count++;
+        }
+        $retval->_MUTATE_fixup_current_attributes_and_classes();
+        return $retval;
+    }
+
+    /**
+     * @return A copy of $this with ExternalMenuItem entries annotated
+     *         with their ->rest_url, and stripped from other
+     *         irrelevant (internal-only) metadata
+     */
+    function export_external () {
+        $self = $this;
+        return $this->map(function($item) use ($self) {
+            if ($emi = ExternalMenuItem::get($item)) {
+                $self->_MUTATE_censor_local_metadata($item);
+                unset($item->url);  // Makes no sense to API consumers
+
+                $item->rest_url = $emi->get_rest_url();
+                $item->urn = $emi->get_urn();
+            }
+            return $item;
+        });
+    }
+
+    function get_parent ($item) {
+        return @$this->items[$this->_get_parent_id($item)];
+    }
+
+    private function _get_id ($item) {
+        return $item->db_id;
+    }
+
+    private function _get_parent_id ($item) {
+        return $item->menu_item_parent;
+    }
+
+    // Mutators must be called *only* in the constructor or
+    // on (the items of) an instance obtained with @link copy.
+    private function _MUTATE_set_id ($item, $new_id) {
+        $item->db_id = $new_id;
+        // In actual menus, ->ID and ->db_id are always the same.
+        // Strange things happen if they get desynched e.g. visibility
+        // of deeper menu items seems to be regulated by the ->ID,
+        // while parent/child relationship works with the ->db_id.
+        // #gofigure
+        $item->ID = $new_id;
+    }
+
+    private function _MUTATE_set_parent_id ($item, $new_parent_id) {
+        $item->menu_item_parent = $new_parent_id;
+    }
+
+    private function _MUTATE_censor_local_metadata ($item) {
+        unset($item->guid);
+        unset($item->object_id);
+    }
+
+    private function _is_current ($item) {
+        return @$item->current;
+    }
+
+    private function _MUTATE_reset_current_ancestry_status ($item) {
+        unset($item->current_item_parent);
+        unset($item->current_item_ancestor);
+        $item->classes = array_filter(
+            $item->classes,
+            function($c) {
+                return ($c !== 'current-menu-parent' and
+                        $c != 'current-menu-ancestor');
+            });
+    }
+
+    private function _MUTATE_make_parent_of_current ($item) {
+        $item->current_item_parent = true;
+        $item->classes[] = 'current-menu-parent';
+        $this->_MUTATE_make_ancestor_of_current($item);
+    }
+
+    private function _MUTATE_make_ancestor_of_current ($item) {
+        $item->current_item_ancestor = true;
+        $item->classes[] = 'current-menu-ancestor';
+    }
+
+    private function _MUTATE_add_item ($item) {
+        if (array_key_exists($this->_get_id($item), $this->items)) {
+            throw new \Error("Duplicate ID: " . $this->_get_id($item));
+        }
+        $item = clone($item);
+        $this->items[$this->_get_id($item)] = $item;
+    }
+
+    /**
+     * Graft $inner into $outer at $at_id, preserving ordering.
+     *
+     * Splice the node list of $inner into $outer's at the
+     * proper place, also taking care of reparenting the root nodes of
+     * $inner.
+     *
+     * _MUTATE_graft() does *not* tolerate ID clashes between $outer and
+     * $inner; caller should ->_renumber() first as appropriate.
+     * 
+     * _MUTATE_graft() may mutate (the items of) both $outer and
+     * $inner (the former, because it shares them into the return
+     * value). Again, caller should ->copy() as appropriate.
+     *
+     * @return A new instance of the class.
+     */
+
+    private static function _MUTATE_graft ($at_id, $outer, $inner) {
+        $new_parent_id = $outer->_get_parent_id($outer->find($at_id));
+
+        $items = array();
+        foreach ($outer->as_list() as $item) {
+            $items[] = $item;
+            if ($outer->_get_id($item) === $at_id) {
+                foreach ($inner->as_list() as $item) {
+                    if (! $inner->_get_parent_id($item)) {
+                        $inner->_MUTATE_set_parent_id($item, $new_parent_id);
+                    }
+                    $items[] = $item;
+                }
+            }
+        }
+        $thisclass = get_called_class();
+        return new $thisclass($items);
+    }
+
+    /**
+     * Compute and return a copy of $other_bag with all IDs changed
+     * so that they don't clash with those in this instance.
+     *
+     * Renumbering always uses *negative* numbers for IDs; the
+     * positive numbers are reserved for pristine (i.e.,
+     * authoritative) nodes in the menus served over REST, so be sure
+     * to ->_renumber() the things that you are adding to your tree
+     * out of some REST query, and keep the locally-issued IDs as they
+     * are.
+     *
+     * This method does the right thing when this instance already
+     * contains items with negative IDs, thanks to @link
+     * _get_largest_negative_unused_id. Also, it calls @link
+     * _MUTATE_censor_local_metadata on all (copies of) the items
+     * in $other_bag
+     *
+     * @param $other_bag An instance of this class (call @link coerce
+     *        yourself if needed)
+     *
+     * @param &$follow_this_id If passed-in as the ID of an item in
+     *                         the tree being renumbered, will be
+     *                         mutated (and passed-out) as the ID of the
+     *                         same item after renumbering
+     *
+     * @return A new instance of this class, fully unshared from both
+     *         $this and $other_bag
+     */
+    protected function _renumber ($other_bag, &$follow_this_id = NULL) {
+        $next_id = $this->_get_largest_negative_unused_id();
+
+        $translation_table = array();
+        foreach ($other_bag->items as $item) {
+            $orig_id        = $this->_get_id       ($item);
+            $orig_parent_id = $this->_get_parent_id($item);
+            foreach (array($orig_id, $orig_parent_id) as $old_id) {
+                if ($old_id and ! array_key_exists($old_id, $translation_table)) {
+                    $translation_table[$old_id] = $next_id--;
+                }
+            }
+        }
+
+        // Now that we have a complete $translation_table, start over
+        // and renumber
+        $translated = array();
+        foreach ($other_bag->items as $item) {
+            $item = clone $item;
+            $this->_MUTATE_censor_local_metadata($item);
+
+            $orig_id = $this->_get_id($item);
+            $this->_MUTATE_set_id($item, $translation_table[$orig_id]);
+
+            if ($orig_parent_id = $this->_get_parent_id($item)) {
+                $this->_MUTATE_set_parent_id(
+                    $item, $translation_table[$orig_parent_id]);
+            }
+
+            $translated[] = $item;
+        }
+
+        if ($follow_this_id) {  // Not NULL, not zero
+            $follow_this_id = $translation_table[$follow_this_id];
+        }
+
+        $thisclass = get_called_class();
+        return new $thisclass($translated);
+    }
+
+    protected function _get_largest_negative_unused_id () {
+        $myids = array_keys($this->items);
+        $myids[] = 0;  // Ensure return value is -1 or less
+        return min($myids) - 1;
+    }
+}
+
+
+/**
+ * Object model for "normal" WordPress menus, augmented with support
+ * for EPFL-style menu stitching.
+ */
+class Menu
+{
+    static function by_term ($term_or_term_id) {
+        if (is_object($term_or_term_id)) {
+            $term_id = $term_or_term_id->term_id;
+        } else {
+            $term_id = $term_or_term_id;
+        }
+
+        $thisclass = get_called_class();
+        return new $thisclass($term_id);
+    }
+
+    static function by_theme_location ($theme_location) {
+        $mme = MenuMapEntry::find(array('theme_location' => $theme_location))
+            ->first_preferred(array('language' => get_current_language()));
+        if (! $mme) return false;
+
+        return $mme->get_menu();
+    }
+
+    private function __construct ($term_id) {
+        if ($term_id > 0) {
+            $this->term_id = $term_id;
+        } else {
+            throw new \Error("Bogus term ID $term_id");
+        }
+    }
+
+    /**
+     * @return A list of all instances used anywhere in the theme's menus,
+     *         according to @link MenuMapEntry
+     */
+    static function all_mapped () {
+        $all = array();
+        foreach (MenuMapEntry::all() as $entry) {
+            $menu = $entry->get_menu();
+            if (! array_key_exists($menu->get_term_id(), $all)) {
+                $all[$menu->get_term_id()] = $menu;
+            }
+        }
+        return array_values($all);
+    }
+
+    /**
+     * @return A site-wide unique integer ID for this Menu
+     */
+    function get_term_id () {
+        return (int)$this->term_id;
+    }
+
+    function equals ($that) {
+        $thisclass = get_called_class();
+        if ($that and ($that instanceof $thisclass)) {
+            return $this->get_term_id() === $that->get_term_id();
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @return A @link MenuItemBag instance
+     */
+    private function _get_local_tree () {
+        $items = wp_get_nav_menu_items($this->term_id);
+        if ($items === FALSE) {
+            throw new MenuError(
+                "Cannot find term with ID $this->term_id");
+        }
+
+        if (function_exists('pll_get_post_translations') &&
+            ($homepage_id = 0 + get_option('page_on_front'))) {
+            // For whatever reason, URLs of homepages and their
+            // translations are... weird. Reconstruct them
+            $is_homepage_translation = array();
+
+            foreach (pll_get_post_translations($homepage_id)
+                     as $id) {
+                $is_homepage_translation[$id] = 1;
+            }
+
+            foreach ($items as $item) {
+                $post_id = 0 + $item->object_id;
+                if (array_key_exists($post_id, $is_homepage_translation)) {
+                    $item->url = sprintf('%s/%s/%s/',
+                                         site_url(),
+                                         pll_get_post_language($post_id),
+                                         get_post($post_id)->post_name);
+                }
+            }
+        }
+
+        return new MenuItemBag($items, /* $hide_tree_problems = */ true);
+    }
+
+    private const SOA_SLUG = 'epfl_soa';
+
+    /**
+     * Compute "stitched down" menu rooted at this Menu.
+     *
+     * ExternalMenuItem entries present in the menu are decorated with
+     * the contents of the remote menu, as obtained over REST; they
+     * remain in the returned tree as a positional indicator for REST
+     * clients (call @link MenuItemBag::trim_external to remove them,
+     * e.g. prior to passing to a frontend walker).
+     *
+     * Keep our own nodes (the ones we have authority for) with
+     * positive IDs and renumber all grafted nodes with negative IDs.
+     *
+     * @return A @link MenuItemBag instance, in which the
+     *         authoritative menu entries (the ones retrieved from the
+     *         local database) have positive IDs, while the remote
+     *         IDs are negative
+     */
+    function get_stitched_down_tree () {
+        $tree = $this->_get_local_tree();
+        foreach ($tree->as_list() as $item) {
+            if (! ($emi = ExternalMenuItem::get($item))) continue;
+            $soa_url = Site::root()->make_absolute_url(
+                $emi->get_site_url() ?
+                $emi->get_site_url() :
+                $emi->get_rest_url());
+
+            $remote_menu = $emi->get_remote_menu();
+            if ($remote_menu) {
+                $tree = $tree->graft(
+                    $item,
+                    $remote_menu->annotate_roots(array(
+                        self::SOA_SLUG => $soa_url)));
+            } else {
+                error_log("$emi has no remote menu");
+            }
+        }
+
+        return $tree;
+    }
+
+    /**
+     * Compute the fully stitched menu that surrounds this Menu.
+     *
+     * Like @link get_stitched_down_tree, but additionally if we are
+     * rendering the primary menu and this is not the root site, graft
+     * ourselves into the root site's menu at the proper point.
+     *
+     * In both grafting operations ("down" for ExternalMenuItems, "up"
+     * for the root site's menu), keep our own nodes (the ones we have
+     * authority for) with positive IDs and renumber all foreign nodes
+     * with negative IDs.
+     *
+     * @param $mme A @link MenuMapEntry instance representing the menu
+     *             being rendered.
+     *
+     * @return A @link MenuItemBag instance, in which the
+     *         authoritative menu entries (the ones retrieved from the
+     *         local database) have positive IDs, while the remote
+     *         IDs are negative
+     */
+    function get_fully_stitched_tree ($mme) {
+        $tree = $this->get_stitched_down_tree();
+        if (! $mme->is_main()) return $tree;
+
+        if (! $root_menu = $this->_get_root_menu(Site::this_site(), $mme->get_theme_location(), $mme->get_language())) {
+            return $tree;
+        }
+
+        $soa_slug = self::SOA_SLUG;
+        $site_url = site_url();
+        if (! preg_match('#/$#', $site_url)) {
+            $site_url .= '/';
+        }
+        $root_menu = $root_menu->pluck(
+            function($item) use ($soa_slug, $site_url) {
+                return property_exists($item, $soa_slug) && $item->$soa_slug === $site_url;
+            })[0];
+
+        // When stitching up, the graft point(s) are any and all
+        // ExternalMenuItem's that point to ourselves.
+        $grafted_count = 0;
+        $self = $this;
+        foreach (
+            array_filter($root_menu->as_list(),
+                         function($item) use ($self) {
+                             return $self->_corresponds($item);
+                         })
+            as $graft_point)
+        {
+            $tree = $tree->annotate_roots(array($soa_slug => $site_url))->reverse_graft($graft_point, $root_menu);
+            $grafted_count++;
+        }
+
+        if (! $grafted_count) {
+            error_log(sprintf(
+                'Cannot find graft point - Unable to stitch up %s (in %s)\n%s',
+                $self,
+                get_site_url(),
+                var_export($root_menu, true)));
+        }
+
+        return $tree;
+    }
+
+    protected function _get_root_menu ($site, $theme_slug, $language=NULL) {
+        if (! $language) {
+            $language = get_current_language();
+        }
+
+        # if we have configured top menu url, get it
+        $menu_root_provider_url = $site->get_configured_root_menu_url();
+
+        if(empty($menu_root_provider_url)) {
+            if ($site->is_root()) {
+                return;  // No root menu for ya
+            }
+            $menu_root_provider_url = Site::root()->get_path();
+            if (! $menu_root_provider_url) return;
+        }
+        
+        $emi = ExternalMenuItem::find(array(
+            'site_url'       => $menu_root_provider_url,
+            'remote_slug'    => $theme_slug
+        ))
+            ->first_preferred(array(
+                'language' => $language));
+
+        if (! $emi) return;
+
+        return $emi->get_remote_menu();
+    }
+
+    public function has_root_menu ($theme_slug) {
+        return (boolean) $this->_get_root_menu(Site::this_site(), $theme_slug);
+    }
+
+    /**
+     * Only called for the main ("top") menu
+     * @param $item An item out of a @link MenuItemBag
+     *
+     * @return True iff $item designates us - That is, it came from
+     *         the JSON representation of some ExternalMenuItem in
+     *         another WordPress in the same pod, that points to this
+     *         Menu instance.
+     */
+    protected function _corresponds ($item) {
+        if (! ExternalMenuItem::looks_like($item)) return false;
+
+        # is an item with url or an urn ?
+        $urn = $item->urn;
+        $url = Site::this_site()->make_relative_url($item->rest_url);
+
+        $matched = array();
+        if (!empty($url) && preg_match(
+            '#^/wp-json/(.*)/menus/(.*?)(?:\?lang=(.*))?$#',
+            $url, $matched)) {
+            // Works by parsing the ->rest_url, so there is coupling with
+            // MenuRESTController
+        $mme = MenuMapEntry::find(array('theme_location' => $matched[2]))
+              ->first_preferred(array('language' => $matched[3]));
+        if (! $mme) return false;
+
+        return $this->equals($mme->get_menu());
+        } elseif (!empty($urn)) {
+            # Check if this item is the configured place
+            $menu_root_provider_self_urn = Site::this_site()->get_pod_config('menu_root_provider_self_urn');
+
+            if ($menu_root_provider_self_urn === $urn) {
+                return true;
+    }
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Whether our "authoritative" menu subtree depends on $emi
+     *
+     * @param $emi An @link ExternalMenuItem instance
+     *
+     * @return false if no change in $emi could possibly make "us"
+     *         change (in the sense of @link get_stitched_down_tree,
+     *         i.e. the part that we are authoritative for - Not the
+     *         parts "above us" created with @link
+     *         get_fully_stitched_tree). true otherwise.
+     */
+    function depends ($emi) {
+        foreach ($this->_get_local_tree()->as_list() as $item) {
+            if ($emi->equals($item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Take into account a (possible) change in $emi
+     *
+     * @return false if we can conservatively ascertain that the
+     *         change in $emi had no effect on "our" tree (in the
+     *         sense of @link get_stitched_down_tree, i.e. the part
+     *         that we are authoritative for); true otherwise
+     */
+    function update ($emi) {
+        // Always trust the caller and attempt to refresh:
+        try {
+            $emi->refresh();
+        } catch (Throwable $t) {  // Non-goal: PHP5 support
+            return false;  // Our tree hasn't changed for sure
+        }
+
+        // Block propagation in case the menu is not listed, in
+        // particular if it is the root menu - that one is of use to
+        // get_fully_stitched_tree() but not get_stitched_down_tree()
+        if (! $this->depends($emi)) return false;
+
+        // We could encache, compare and block null updates here, but
+        // for now this is conservative and good enough
+        // performance-wise:
+        return true;
+    }
+
+    function __toString () {
+        $thisclass = get_called_class();
+
+        return "<$thisclass(term_id=$this->term_id)>";
+    }
+}
+
+
+/**
+ * Model for menus as belonging to the theme's menu map.
+ *
+ * An instance represents one menu from the Appearance → Menus screen
+ * in wp-admin; it has-a @link Menu, and also a description, a theme
+ * location (e.g. "primary") and a language.
+ */
+class MenuMapEntry
+{
+    private function __construct(
+        $term_or_term_id, $theme_location, $description, $language = NULL)
+    {
+        $this->menu = Menu::by_term($term_or_term_id);
+        $this->theme_location = $theme_location;
+        $this->description = $description;
+        $this->language = $language;
+    }
+
+    function __toString () {
+        $thisclass = get_called_class();
+        return "<$thisclass('$this->theme_location', '$this->language')>";
+    }
+
+    function get_menu () {
+        return $this->menu;
+    }
+
+    function get_menu_term_id () {
+        return (int) $this->menu->get_term_id();
+    }
+
+    /**
+     * Returns the name of the location (as defined by the theme) that
+     * this entry appears under; also used as a portion of the URL
+     * ("slug") by API consumers (see @link ExternalMenuItem).
+     *
+     * @return A string designating the menu position, e.g. "primary"
+     *         or "footer"
+     */
+    function get_theme_location () {
+        return $this->theme_location;
+    }
+
+    function get_description () {
+        return $this->description;
+    }
+
+    function get_language () {
+        return $this->language;
+    }
+
+    function is_main () {
+        $loc = $this->get_theme_location();
+        return ($loc === 'primary' or $loc === 'top');
+    }
+
+    /**
+     * @return A list of instances across all languages
+     */
+    static function all () {
+        if ($all_from_polylang = static::_all_from_polylang()) {
+            return $all_from_polylang;
+        } else {
+            return static::all_in_current_language();
+        }
+    }
+
+    use FindFromAllTrait;
+
+    /**
+     * @return An list of MenuMapEntry instances in the current language.
+     */
+    static function all_in_current_language () {
+        $thisclass = get_called_class();
+
+        $registered = get_registered_nav_menus();
+        $lang = get_current_language();
+
+        $all = array();
+        // Polylang hooks into the 'theme_mod_nav_menu_locations'
+        // filter, therefore get_nav_menu_locations() depends on the
+        // current language.
+        foreach (get_nav_menu_locations() as $theme_location => $term_id) {
+            if (! $term_id) continue;
+            if (! array_key_exists($theme_location, $registered)) continue;
+            $all[] = new $thisclass(
+                $term_id, $theme_location,
+                /* $description = */ $registered[$theme_location],
+                $lang);
+        }
+        return $all;
+    }
+
+    static function _all_from_polylang () {
+        // Polylang may be inactive, but with its options still
+        // available in-database so check this first.
+        if (! function_exists('pll_current_language')) return NULL;
+
+        // Really, frobbing through the Polylang persistent data is
+        // the least fragile way to go about this.
+        $poly_options = get_option('polylang');  // Auto-deserializes
+        if (! $poly_options) return NULL;
+
+        $thisclass = get_called_class();
+        $registered = get_registered_nav_menus();
+
+        $all = array();
+        $poly_nav_menus = $poly_options['nav_menus'][get_stylesheet()];
+        if ($poly_nav_menus) {
+            foreach ($poly_nav_menus as $theme_location => $menus) {
+                if (! array_key_exists($theme_location, $registered)) continue;
+                foreach ($menus as $lang => $term_id) {
+                    if (! $term_id) continue;
+                    $all[] = new $thisclass(
+                        $term_id, $theme_location,
+                        /* $description = */ $registered[$theme_location],
+                        $lang);
+                }
+            }
+        }
+        return $all;
+    }
+
+    /**
+     * @return The menu map entry associated with $theme_location in
+     *         the current language.
+     *
+     * Note that when Polylang is in play, the result depends on the
+     * current language (typically passed by a ?lang=XX query
+     * parameter in REST queries)
+     */
+    static function by_theme_location ($theme_location) {
+        foreach (MenuMapEntry::all_in_current_language() as $entry) {
+            if ($entry->get_theme_location() === $theme_location) {
+                return $entry;
+            }
+        }
+    }
+}
+
+
+/**
+ * An external menu that needs fetching and/or integrating
+ * with the "normal" menus.
+ *
+ * Instances are represented in the Wordpress database as posts
+ * of custom post type "epfl-external-menu".
+ * They can be keyed by either the URL of the REST API that provides their contents or
+ * an URN. The latter case is called an independent item; for such an item, submenus will never be fetched.
+ */
+class ExternalMenuItem extends \EPFL\Model\UniqueKeyTypedPost
+{
+    const SLUG = "epfl-external-menu";
+
+    // For ->meta()->{get_,set_}foo():
+    const META_ACCESSORS = array(
+        // {get_,set_} suffix  => in-database post meta name ("-emi-" stands for "external menu item")
+        'rest_url'             => 'epfl-emi-rest-api-url',  // a url or an urn (if this is an independent item, eg. urn:epfl:labs)
+        'rest_subscribe_url'   => 'epfl-emi-rest-api-subscribe-url',
+        'items_json'           => 'epfl-emi-remote-contents-json',
+        'last_synced'          => 'epfl-emi-last-synced-epoch',
+        'sync_started_failing' => 'epfl-emi-sync-started-failing-epoch',
+
+        // The following two meta fields are *optional* and only exist
+        // for "true" WordPress-generated menus. (This is not always
+        // the case - Think single-purpose footer menu server written
+        // in node.js)
+        'site_url'             => 'epfl-emi-site-url',
+        // Also from this perspective, we call this a slug not a
+        // theme_location (which is what it is from the perspective of
+        // the remote MenuMapEntry, but we don't want to know or care
+        // about that)
+        'remote_slug'          => 'epfl-emi-remote-slug',
+    );
+
+    // For get_or_create():
+    const META_PRIMARY_KEY = array('epfl-emi-rest-api-url');
+
+    static function get_post_type () {
+        return self::SLUG;
+    }
+
+    /**
+     * @return The URL of the local WordPress site that this
+     *         ExternalMenuItem comes from, or NULL if this
+     *         ExternalMenuItem doesn't live in this pod.
+     */
+    function get_site_url () {
+        $url = $this->meta()->get_site_url();
+        $url = preg_replace('#^https://localhost:8443#', '', $url);  # XXX TMPHACK
+        return $url;
+    }
+
+    /**
+     * @return The URL that this ExternalMenuItem obtains the remote
+     *         menu from (in JSON form), or NULL if there is none (eg. labs)
+     */
+    function get_rest_url () {
+        $url = $this->meta()->get_rest_url();
+
+        if ($this->get_urn()) return;
+        $url = preg_replace('#^https://localhost:8443#', '', $url);  # XXX TMPHACK
+        return $url;
+    }
+
+    /**
+     * Get the URN of this independent menu item, or NULL if this item is not independent
+     * 
+     * This shares the same data slot as @link get_rest_url.
+     */
+    function get_urn () {
+        $url = $this->meta()->get_rest_url();
+        if (preg_match('#^urn:#' , $url)) {
+            return $url;
+        }
+    }
+
+    /**
+     * Overridden to also accept a 'nav-menu-item' Post object with
+     * ->object === "epfl-external-menu".
+     */
+    static function get ($what) {
+        if (static::looks_like($what)
+            and ($what->object_id)) {
+            return parent::get($what->object_id);
+        } else {
+            return parent::get($what);
+        }
+    }
+
+    function equals ($what) {
+        $thisclass = get_called_class();
+        $what = $thisclass::get($what);
+        return ($what && $what->ID == $this->ID);
+    }
+
+    /**
+     * Returns true iff $what looks like a menu item (e.g. from
+     * a @link MenuItemBag) that was an ExternalMenuItem at the time
+     * it was inserted into the wp-admin menu.
+     *
+     * Unlike checking @link get for a NULL return value, this check
+     * doesn't hit the database; it will work even for
+     * ExternalMenuItem's that are not local to this Wordpress site.
+     */
+    static function looks_like ($what) {
+        return (is_object($what)
+                and ($what->post_type === 'nav_menu_item')
+                // Don't test for ->object_id here, as
+                // MenuItemBag->export_external() could have scrubbed
+                // it before serving over REST
+                and ($what->object === static::get_post_type()));
+    }
+
+    use FindFromAllTrait;
+
+    static function load_from_filesystem () {
+        $me = Site::this_site();
+        $neighbors = array_merge(array(Site::root()),
+                                 $me->get_subsites());
+
+        $instances = array();
+        foreach ($neighbors as $site) {
+            if ($site->equals($me)) continue;
+            try {
+                $instances = array_merge(
+                    $instances,
+                    static::load_from_wp_site_url(
+                        $site->get_path()));
+            } catch (RESTRemoteError $e) {
+                error_log("[Not our fault, IGNORED] " . $e);
+                continue;
+            }
+        }
+        return $instances;
+    }
+
+    static function load_from_config_file () {
+        $menu_root_provider_url = Site::this_site()->get_configured_root_menu_url();
+
+        if ($menu_root_provider_url) {
+            ExternalMenuItem::load_from_wp_site_url($menu_root_provider_url);
+        }
+    }
+
+    /**
+     * @return An array of instances of this class
+     */
+    static function load_from_wp_site_url ($site_url) {
+        $instances = array();
+
+        $rest = (new RESTClient())->set_base_uri(
+            REST_API::get_entrypoint_url('', $site_url));
+        foreach ($rest->GET_JSON("languages") as $lang) {
+            try {
+                $menu_descrs = $rest->GET_JSON("menus?lang=$lang");
+            } catch (RESTClientError $e) {
+                error_log("[Not our fault, IGNORED] " . $e);
+                continue;
+            }
+
+            foreach ($menu_descrs as $menu_descr) {
+                $menu_slug = $menu_descr->slug;
+                $menu_url = REST_API::get_entrypoint_url(
+                    "menus/$menu_slug?lang=$lang", $site_url);
+                $that = static::get_or_create($menu_url);
+                // Unlike an ExternalMenuItem that would be just
+                // created from its REST URL, for this one we do know
+                // that it comes from a "true" Wordpress. Note down
+                // the additional metadata we know (for the purpose
+                // of @link Menu::_get_root_menu)
+                $that->meta()->set_site_url($site_url);
+                $that->meta()->set_remote_slug($menu_slug);
+                // Keep Polylang language in sync, so that the little flags
+                // show up in the wp-admin list UI.
+                $that->set_language($lang);
+
+                if (! $that->wp_post()->post_title) {
+                    $site_moniker = parse_url($site_url, PHP_URL_PATH);
+                    $menu_moniker = $menu_descr->description;
+                    wp_update_post(array(
+                        'ID' => $that->ID,
+                        'post_title' =>  "$menu_moniker\[$lang\] @ $site_moniker"));
+                }
+
+                $instances[] = $that;
+            }
+        }
+        return $instances;
+    }
+
+    /* A model class that has-a controller is a bad thing, but since
+       that is hidden in a protected function we're good, I guess? */
+    protected function _get_subscribe_controller () {
+        // The subscribe slug will be embedded in webhook
+        // URLs, so it must not change inbetween queries.
+        // Using the post ID is perhaps a bit difficult to
+        // read out of error logs, but certainly the easiest
+        // and most future-proof way of going about it.
+        return SubscribeController::by_namespace_and_slug("menu", $this->ID);
+    }
+
+    function add_observer ($callable) {
+        $this->_get_subscribe_controller()->add_listener($callable);
+    }
+
+    function refresh () {
+        try {
+            if (! ($get_url = $this->get_rest_url())) {
+                return;  // independent hence immutable
+            }
+
+            $menu_contents = @RESTClient::GET_JSON($get_url);
+            $this->set_remote_menu($menu_contents->items);
+
+            $this->meta()->set_last_synced(time());
+            $this->meta()->del_sync_started_failing();
+            if ($subscribe_url = $menu_contents->get_link('subscribe')) {
+                $this->meta()->set_rest_subscribe_url($subscribe_url);
+            }
+
+            return $menu_contents;
+        } catch (RESTClientError $e) {
+            $this->error_log("unable to refresh: $e");
+            if (! $this->meta()->get_sync_started_failing()) {
+                $this->meta()->set_sync_started_failing(time());
+            }
+            throw $e;
+        }
+    }
+
+    function resubscribe () {
+        if ($subscribe_url = $this->meta()->get_rest_subscribe_url()) {
+            $this->_get_subscribe_controller()->subscribe($subscribe_url);
+        }
+    }
+
+    function set_remote_menu ($what) {
+        $what = MenuItemBag::coerce($what);
+        $this->meta()->set_items_json(json_encode($what->as_list()));
+    }
+
+    function get_remote_menu () {
+        $json = $this->meta()->get_items_json();
+        if (! $json) return;
+        return new MenuItemBag(json_decode($json));
+    }
+
+    function get_sync_status () {
+        $status = new \stdClass();
+        $status->failing_since = $this->meta()->get_sync_started_failing();
+        $status->last_success  = $this->meta()->get_last_synced();
+        return $status;
+    }
+
+    function is_failing () {
+        return !! $this->meta()->get_sync_started_failing();
+    }
+
+    function has_succeeded () {
+        return !! $this->meta()->get_last_synced();
+    }
+
+    function __toString () {
+        return sprintf('<ExternalMenuItem(id=%d name="%s")>',
+                       $this->ID,
+                       $this->wp_post()->post_title);
+    }
+}
+
+/**
+ * Enumerate menus over the REST API
+ *
+ * Enumeration is independent of languages (or lack thereof) i.e.
+ * there is at most one result per theme slot (in the sense of
+ * @link get_registered_nav_menus). It is also independent of the
+ * pubsub mechanism, in the sense that the code thereof is not invoked
+ * here (but URLs that point to the pubsub REST endpoints, do get
+ * computed and served)
+ *
+ * Additionally, the MenuRESTController class is in charge of managing
+ * the @link PublishController instances. (See @link MenuItemController
+ * for the subscribe side.)
+ *
+ * @url /epfl/v1/menus
+ */
+class MenuRESTController
+{
+    static function hook () {
+        $thisclass = get_called_class();
+        REST_API::GET_JSON(
+            '/menus',
+            $thisclass, 'get_menus');
+        // There is coupling with Menu::_corresponds as far as
+        // the URI structure is concerned.
+        REST_API::GET_JSON(
+            '/menus/(?P<slug>[a-zA-Z0-9_-]+)',
+            $thisclass, 'get_menu');
+
+        // "The feature is available only in Polylang Pro." #groan
+        REST_API::GET_JSON(
+            '/languages',
+            function() { return pll_languages_list(); });
+
+        add_action('rest_api_init', function() use ($thisclass) {
+            foreach (Menu::all_mapped() as $menu) {
+                $thisclass::_get_publish_controller($menu)->serve_api();
+            }
+        });
+    }
+
+    static function get_menus () {
+        $retval = [];
+        foreach (MenuMapEntry::all_in_current_language() as $entry) {
+            $slug        = $entry->get_theme_location();
+            $description = $entry->get_description();
+            if (substr($slug, 0, 1) !== '_') {
+                array_push($retval, array(
+                    'slug'        => $slug,
+                    'description' => $description
+                ));
+            }
+        }
+        return $retval;
+    }
+
+    static function get_menu ($data) {
+        $slug = $data['slug'];  // Matched from the URL with a named pattern
+
+        if (! ($entry = MenuMapEntry::by_theme_location($slug))) {
+            if (function_exists('pll_current_language')) {
+                $inlang = " in language " . pll_current_language();
+            }
+            throw new RESTAPIError(404, array(
+                'status' => 'NOT_FOUND',
+                'msg' => "No menu with slug $slug$inlang"));
+        }
+        $menu = $entry->get_menu();
+
+        $response = new \WP_REST_Response(array(
+            'status' => 'OK',
+            'items'  => $menu->get_stitched_down_tree()
+                             ->export_external()->as_list()));
+        // Note: this link is for subscribing to changes in any
+        // language, not just the one being served now.
+        $subscribe_link = REST_API::get_entrypoint_url(
+            static::_get_subscribe_uri($menu));
+        $response->add_link('subscribe', $subscribe_link);
+
+        return $response;
+    }
+
+    /**
+     * Returns the URI that provides the webhook subscription service
+     * for $menu
+     *
+     * Note that this URI may *not* be unique per $menu, and in fact
+     * isn't even in the day-one implementation (two translations of
+     * the same menu, share the same pubsub endpoint)
+     */
+    static function _get_subscribe_uri ($menu) {
+        $term_id = $menu->get_term_id();
+        return "menus/$term_id/subscribe";
+    }
+
+    static private $pubs = array();
+    static private function _get_publish_controller ($menu) {
+        $term_id = $menu->get_term_id();
+        if (! array_key_exists($term_id, static::$pubs)) {
+            static::$pubs[$term_id] = new PublishController(
+                static::_get_subscribe_uri($menu));
+        }
+        return static::$pubs[$term_id];
+    }
+
+    /**
+     * Shall be called whenever $menu changes (from the point
+     * of view of @link get_menu)
+     */
+    static function menu_changed ($menu, $causality = NULL) {
+        $publisher = static::_get_publish_controller($menu);
+        if ($causality) {
+            $publisher->forward($causality);
+        } else {
+            $publisher->initiate();
+        }
+    }
+}
+
+MenuRESTController::hook();
+
+
+/**
+ * The controller for external menu items (w/ custom post type)
+ *
+ * An external menu item is a "graft point" in the menu where another
+ * site's menu shall appear. This class is responsible for the
+ * creation and mutation of external menu items per se and their
+ * metadata - not their place, or lack thereof, in any menu; for that
+ * see @link MenuEditorController instead. This class is also not in
+ * play (except for the concern of registering the custom post type)
+ * when rendering front-end pages; see @link MenuFrontendController.
+ *
+ * An external menu item is handled as a Wordpress custom post type,
+ * with in-database persistence and a custom editor page in the admin
+ * menu featuring a custom rendering widget as the main matter,
+ * instead of the customary TinyMCE.
+ *
+ * MenuItemController is a "pure static" class, i.e. no instances are
+ * ever constructed.
+ */
+class MenuItemController extends CustomPostTypeController
+{
+    static function get_model_class () {
+        return ExternalMenuItem::class;
+    }
+
+    static function hook () {
+        parent::hook();
+
+        static::get_model_class()::make_polylang_translatable();
+
+        $thisclass = get_called_class();
+        $thisclass::hook_meta_boxes();
+        add_filter('hidden_meta_boxes', array($thisclass, 'hidden_meta_box'), 10, 2);
+
+        add_action('init', array($thisclass, 'register_post_type'));
+
+        add_action('rest_api_init', function() use ($thisclass) {
+            foreach (static::get_model_class()::all()
+                     as $emi) {
+                $thisclass::hook_pubsub($emi);
+            }
+        });
+
+        static::hook_refresh_button();
+
+        static::hook_admin_list();
+
+        static::_auto_fields_controller()->hook();
+    }
+    /**
+     * Show "External menus" screen options by default
+     */
+    static function hidden_meta_box($hidden, $screen) {
+        //make sure we are dealing with the correct screen
+        if ( ('nav-menus' == $screen->base) && ('nav-menus' == $screen->id) ){
+            $to_remove = array('add-post-type-epfl-external-menu');
+            $hidden = array_diff($hidden, $to_remove);
+        }
+        return $hidden;
+    }
+
+    static function hook_pubsub ($emi) {
+        $thisclass = get_called_class();
+        $emi->add_observer(
+            function($event) use ($thisclass, $emi) {
+                set_time_limit(0);
+                foreach (Menu::all_mapped() as $menu) {
+                    if ($menu->update($emi)) {
+                        MenuRESTController::menu_changed($menu, $event);
+                    }
+                }
+            });
+    }
+
+    static function hook_refresh_button () {
+        $thisclass = get_called_class();
+
+        // Server side:
+        add_action('admin_init', function() use ($thisclass) {
+            $thisclass::_get_api()->register_handlers($thisclass);
+        });
+
+        // JS side:
+        add_action('current_screen', function() use ($thisclass) {
+            if ((get_current_screen()->base === 'edit') &&
+                $_REQUEST['post_type'] === static::get_post_type())
+            {
+                $thisclass::_get_api()->admin_enqueue();
+                _MenusJSApp::load();
+            }
+        });
+    }
+
+    static private function _get_api () {
+        require_once(dirname(__DIR__) . '/lib/wp-admin-api.php');
+        return new \EPFL\AdminAPI\Endpoint('EPFLMenus');
+    }
+
+    /**
+     * Register a custom post type for external menus
+     *
+     * A "post" of this post type has no title, content, tags etc. It only
+     * exists to point to the remote API endpoint that enumerates the menu,
+     * and to itself appear in this site's menu.
+     *
+     * @see https://stackoverflow.com/a/20294968/435004
+     */
+    static function register_post_type () {
+        register_post_type(static::get_post_type(), array(
+            'labels' => array(
+                'name'               => ___('External Menus'),
+                'singular_name'      => ___('External Menu'),
+                'menu_name'          => ___('External Menus'),
+                'name_admin_bar'     => __x('External Menu', 'add new on admin bar'),
+		'add_new'            => ___('Add New External Menu'),
+		'add_new_item'       => ___('Add New External Menu'),
+                'view_item'          => ___('View External Menu'),
+                'edit_item'          => ___('Edit External Menu'),
+                'all_items'          => ___('All External Menus'),
+                'not_found'          => ___('No external menus found.'),
+            ),
+            'supports' => array('title', 'custom-fields'),
+            'public'                => false,
+            'show_ui'               => true,
+            'show_in_nav_menus'     => true,
+            'has_archive'           => false,
+            'menu_icon'             => 'dashicons-list-view',
+            'capabilities'          => static::capabilities_for_edit_but_not_create(),
+            'register_meta_box_cb' => array(get_called_class(),
+                                            'register_meta_boxes')
+        ));
+    }
+
+    /**
+     * Invoked first by the wp-admin refresh button
+     */
+    static function ajax_enumerate ($opts = array()) {
+        if (! array_key_exists("retryToken", $opts)) {
+            throw new \Error("Old client code no longer supported");
+        }
+
+        if (! ($retryToken = $opts["retryToken"])) {
+            $freshRetryToken = substr(md5(microtime()), 0, 5);
+            return array('retryToken' => $freshRetryToken);
+        }
+
+        $transient_name = "epfl-menus-all-external-item-ids-$retryToken";
+
+        if (false !== get_transient($transient_name)) {
+            // Poor man's thread join in PHP
+            $join_deadline_seconds = 15;
+            for($i = 0; $i < $join_deadline_seconds; $i++) {
+                wp_cache_flush();  // Transients are cached in RAM by default
+                $transient = get_transient($transient_name);
+                if ($transient !== "WAITING") {
+                    return $transient;
+                } else {
+                    sleep(1);
+                }
+            }
+            error_log(get_called_class() . "::ajax_enumerate(): " .
+                      "timed out joining computation $retryToken " .
+                      "after $join_deadline_seconds seconds");
+            http_response_code(504);
+            die();
+        }
+
+        set_transient($transient_name, "WAITING", 300);
+        // The Varnish-side limit is 30 seconds, however the
+        // client-side AJAX app is prepared to deal with 504's
+        set_time_limit(120);
+
+        ExternalMenuItem::load_from_filesystem();
+        ExternalMenuItem::load_from_config_file();
+        $value = array(
+            'status' => 'OK',
+            'external_menu_item_ids' => array_map(function($emi) {
+                return (int) $emi->ID;
+            }, ExternalMenuItem::all()));
+        set_transient($transient_name, $value, 300);
+        return $value;
+    }
+
+    /**
+     * Invoked by the wp-admin refresh button once for each
+     * ExternalMenuItemID that @link ajax_refresh_local previously
+     * returned
+     */
+    static function ajax_refresh_and_resubscribe_by_id ($data) {
+        if (! ($emi = ExternalMenuItem::get($data['id']))) {
+            error_log('Unknown ID or malformed ajax_refresh_and_resubscribe_by_id: ' . var_export($data, true));
+            return array(
+                'status' => 'ERROR',
+                'message' => "$data->id not found"
+            );
+        }
+        try {
+            $emi->refresh();
+            $emi->resubscribe();
+            return array(
+                'status' => 'OK'
+            );
+        } catch (RESTClientError $e) {
+            return array(
+                'status' => 'ERROR',
+                'exception' => get_class($e),
+                'message' => sprintf(___('Sync failed: %s'), $e)
+            );
+        }
+    }
+
+    /**
+     * Make the "edit" screen for menu objects show an auto-fields
+     * meta box (see @link \EPFL\AutoFields\AutoFieldsController)
+     */
+    public static function register_meta_boxes () {
+        static::_auto_fields_controller()->add_meta_boxes();
+    }
+
+    private static function capabilities_for_edit_but_not_create () {
+        return array(
+            'create_posts'       => '__NEVER_PERMITTED__',
+            'edit_post'          => 'edit_posts',
+            'read_post'          => 'read_post',
+            'delete_post'        => 'delete_posts',  // #WAT
+            'edit_posts'         => 'edit_posts',
+            'edit_others_posts'  => 'edit_others_posts',
+            'publish_posts'      => 'publish_posts',
+            'read_private_posts' => 'read_private_posts',
+        );
+    }
+
+    private static function _auto_fields_controller () {
+        require_once(dirname(__DIR__) . '/lib/auto-fields.php');
+        return new \EPFL\AutoFields\AutoFieldsController(
+            ExternalMenuItem::class);
+    }
+
+    static function hook_admin_list () {
+        // Rendered by render_date_column method, below
+        static::column('date')->set_title(___('Synced'))->hook();
+
+        add_filter('post_class',
+                   array(get_called_class(), '_filter_post_class'),
+                   10, 4);
+
+        $yellow = 'rgba(248, 247, 202, 0.45)';
+        $stripesize = '20px'; $stripesize2x = '40px';
+        static::add_editor_css("
+.wp-list-table tr.sync-failed, .wp-list-table tr.sync-inprogress {
+  background-image: repeating-linear-gradient(-45deg,$yellow,$yellow $stripesize,transparent $stripesize,transparent $stripesize2x);
+}
+
+.wp-list-table tr.sync-inprogress {
+  animation: wp-epfl-sync-barber .5s linear infinite;
+}
+
+@keyframes wp-epfl-sync-barber {
+  from {
+    background-position-x: 0px;
+  }
+
+  to {
+    background-position-x: 57px;
+  }
+}
+");
+    }
+
+    static function render_date_column ($emi) {
+        $ss = $emi->get_sync_status();
+        $echoed_something = FALSE;
+        if ($ss->failing_since) {
+            printf('<span class="epfl-menus-sync-failing">%s</span>',
+                   sprintf(___('Failing for %s'),
+                           human_time_diff($ss->failing_since)));
+            $echoed_something = TRUE;
+        }
+        if ($ss->last_success) {
+            if ($echoed_something) { echo '<br/>'; }
+            printf('Last sync success: %s ago',
+                   human_time_diff($ss->last_success));
+            $echoed_something = TRUE;
+        }
+        if (! $echoed_something) {
+            echo ___('Never synced yet');
+        }
+    }
+
+    /**
+     * Filter function for the @link post_class filter
+     *
+     * Add CSS classes to the <tr> element to indicate success /
+     * failure state of the last sync.
+     */
+    static function _filter_post_class ($classes_orig, $class, $post_id) {
+        $post = ExternalMenuItem::get($post_id);
+        if (! $post) return $classes_orig;
+
+        $classes = $classes_orig;
+        if ($post->is_failing()) {
+            $classes[] = 'sync-failed';
+        } elseif ($post->has_succeeded()) {
+              $classes[] = 'sync-success';
+        }
+        return $classes;
+    }
+}
+
+MenuItemController::hook();
+
+
+class _MenusJSApp
+{
+    /**
+     * A good hook to call this from is @link admin_enqueue_scripts
+     */
+    static function load () {
+        (new Asset("lib/polyfills.js"))->enqueue_script();
+        (new Asset("menus/epfl-menus-admin.js"))->enqueue_script();
+        (new Asset("menus/epfl-menus-admin.css"))->enqueue_style();
+        add_action('admin_print_footer_scripts', function() {
+            $screen = array('base' => get_current_screen()->base);
+            if (array_key_exists('post_type', $_REQUEST)) {
+                $screen['post_type'] = $_REQUEST['post_type'];
+            }
+            echo "\n<script>\n";
+            // Since the app is loaded from multiple wp-admin scripts,
+            // pass enough info so that the JS side can orient itself:
+?>
+window.wp.screen = <?php echo json_encode($screen); ?>;
+<?php
+            // And I have yet to come up with a better idea than this
+            // to translate UI strings in the JS app:
+?>
+window.wp.translations = {
+  refresh_button: "<?php echo __x('Refresh', 'JS button'); ?>",
+  refresh_failed: "<?php __e('Refresh failed'); ?>"
+};
+<?php
+
+            echo "</script>\n";
+        });
+    }
+}
+
+################## External menus in admin menu editor #################
+
+
+
+/**
+ * The controller to handle external menu entries in the wp-admin menu
+ * editor
+ *
+ * This is a "pure static" class, i.e. no instances are ever
+ * constructed.
+ */
+class MenuEditorController
+{
+    static function hook () {
+        add_action('admin_enqueue_scripts', function() {
+            if (get_current_screen()->base === 'nav-menus') {
+                _MenusJSApp::load();
+            }
+        });
+
+        add_action('wp_update_nav_menu', function($nav_menu_selected_id, $new_menu_data = NULL) {
+            // For whatever reason, this action is called twice per click on
+            // the Save button.
+            if (! $new_menu_data) return;
+
+            if (! ($menu = Menu::by_term($nav_menu_selected_id))) return;
+
+            MenuRESTController::menu_changed($menu);
+        }, 10, 2);
+    }
+}
+
+MenuEditorController::hook();
+
+
+################## External menus on the main site #################
+
+/**
+ * Arrange for the front-end to render complete, stitched menus.
+ *
+ * This class has no impact on any of the wp-admin pages.
+ */
+class MenuFrontendController
+{
+    static function hook () {
+        add_filter('home_url',
+                   array(get_called_class(), 'home_url_is_root_site_url_for_theme'),
+                   100, 4);
+
+        // Note: Polylang also hooks into these two and it isn't quite
+        // as careful as we are about preserving tree invariants
+        // (topological ordering and child-parent referential
+        // integrity). Make sure to register ourselves after it.
+        add_filter('wp_get_nav_menu_items',
+                   array(get_called_class(), 'filter_wp_nav_menu_items_for_theme'),
+                   30, 3);
+
+        add_filter('wp_nav_menu_objects',
+                   array(get_called_class(), 'filter_wp_nav_menu_objects'),
+                   20, 2);
+
+        add_filter('epfl_root_menu_ready',
+                   array(get_called_class(), 'filter_epfl_root_menu_ready'),
+                   20, 2);
+    }
+
+    /**
+     * Hooked to the @link wp_nav_menu_objects filter.
+     *
+     * Before rendering a menu to the front-end, replace its tree with
+     * the fully stitched one. Maintain all Wordpress-y bells and
+     * whistles such as additional CSS classes ('class' attribute),
+     * ancestry decoration ('current', 'current_item_parent' and
+     * 'current_item_ancestor' attributes) etc.
+     *
+     * @param $items_orig The menu as extracted from the database as a
+     *                    flat list of "spare parts", chained by their
+     *                    ->menu_item_parent and ->db_id fields.
+     *                    (Additionally, this module assumes that
+     *                    their ->ID is always the same as their
+     *                    ->db_id.)
+     *
+     * @param $args As passed to Wordpress' @link wp_nav_menu function
+     */
+    static function filter_wp_nav_menu_objects ($items_orig, $args) {
+        return static::stitch_menu($items_orig, $args->menu, TRUE);
+    }
+
+    static function stitch_menu ($items_orig, $menu_term,
+                                 $mimic_current = FALSE) {
+        if ($menu_term &&
+            ($menu = Menu::by_term($menu_term)) &&
+            ($entry = static::_guess_menu_entry_from_menu_term($menu_term)))
+        {
+            $bag = $menu->get_fully_stitched_tree($entry);
+
+            if ($mimic_current) {
+                $bag = $bag->mimic_current($items_orig);
+            }
+
+            return $bag->trim_external()->as_list();
+        } else {
+            return $items_orig;
+        }
+    }
+
+    /**
+     * @return The @link MenuMapEntry instance we are rendering the
+     *         menu for.
+     */
+    static function _guess_menu_entry_from_menu_term ($menu) {
+        $menu_term_id = (int) (is_object($menu) ?
+                               $menu->term_id   : $menu);
+
+        return @MenuMapEntry
+            ::find(array('menu_term_id' => $menu_term_id))
+            ->first_preferred(array('language' => get_current_language()));
+    }
+
+    /**
+     * Change the return value of @link wp_get_nav_menu_items to the
+     * complete (stitched) tree, but only if the theme is calling that
+     * function directly.
+     */
+    static function filter_wp_nav_menu_items_for_theme
+        ($items_orig, $menu, $args)
+    {
+        if (static::_is_being_called_by_theme('wp_get_nav_menu_items')) {
+            return static::stitch_menu($items_orig, $menu);
+        } else {
+            return $items_orig;
+        }
+    }
+
+    /**
+     * @return True iff the root menu is correctly stitched
+     */
+    public static function filter_epfl_root_menu_ready ($ready_orig, $theme_location) {
+        # main root site is always correct, as this is the main ref.
+        if (Site::this_site()->is_main_root()) {
+            return true;
+        }
+        
+        $menu = Menu::by_theme_location($theme_location);
+        return $menu && $menu->has_root_menu($theme_location);
+    }
+
+    private static function _is_being_called_by_theme ($function_name) {
+        $bt = debug_backtrace();
+        for ($i = 0; $i < count($bt); $i++) {
+            $caller = $bt[$i];
+            if ($caller['function'] != $function_name) continue;
+            return preg_match('#/wp-content/themes/#', $caller['file']);
+        }
+    }
+
+    static function home_url_is_root_site_url_for_theme
+        ($url_orig, $unused_path, $unused_orig_scheme, $unused_blog_id)
+    {
+        if (static::_is_being_called_by_theme('get_home_url')) {
+            return Site::root()->get_url();
+        } else {
+            return $url_orig;
+        }
+    }
+}
+
+MenuFrontendController::hook();

--- a/data/wp/wp-content/plugins/epfl/menus/wpcli.php
+++ b/data/wp/wp-content/plugins/epfl/menus/wpcli.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace EPFL\Menus\CLI;
+
+if (! defined( 'ABSPATH' )) {
+    die( 'Access denied.' );
+}
+
+use \WP_CLI;
+use \WP_CLI_Command;
+
+require_once(dirname(__DIR__) . '/lib/i18n.php');
+use function EPFL\I18N\___;
+
+require_once(__DIR__ . '/epfl-menus.php');
+use \EPFL\Menus\ExternalMenuItem;
+
+class EPFLMenusCLICommand extends WP_CLI_Command
+{
+    public static function hook () {
+        WP_CLI::add_command('epfl-menus', get_called_class());
+    }
+
+    public function refresh () {
+        WP_CLI::log(___('Enumerating menus on filesystem...'));
+        $local = ExternalMenuItem::load_from_filesystem();
+        WP_CLI::log(sprintf(___('... Success, found %d local menus'),
+                            count($local)));
+
+        WP_CLI::log(___('Enumerating menus in config file...'));
+        $local = ExternalMenuItem::load_from_config_file();
+        WP_CLI::log(sprintf(___('... Success, found %d site-configured menus'),
+                            count($local)));
+
+        $all = ExternalMenuItem::all();
+        WP_CLI::log(sprintf(___('Refreshing %d instances...'),
+                            count($all)));
+        foreach ($all as $emi) {
+            try {
+                $emi->refresh();
+                WP_CLI::log(sprintf(___('✓ %s'), $emi));
+            } catch (\Throwable $t) {
+                WP_CLI::log(sprintf(___('\u001b[31m✗ %s\u001b[0m'), $emi));
+            }
+        }
+        
+    }
+
+    /**
+     * @example wp epfl-menus add_external_menu_item --menu-location-slug=top urn:epfl:labs "laboratoires"
+     */
+    public function add_external_menu_item ($args, $assoc_args) {
+        list($urn, $title) = $args;
+
+        $menu_location_slug = $assoc_args['menu-location-slug'];
+        if (!empty($menu_location_slug)) $menu_location_slug = "top";
+
+        # todo: check that params is format urn:epfl
+        WP_CLI::log(___('Add a new external menu item...'));
+
+        $external_menu_item = ExternalMenuItem::get_or_create($urn);
+        $external_menu_item->set_title($title);
+        $external_menu_item->meta()->set_remote_slug($menu_location_slug);
+        $external_menu_item->meta()->set_items_json('[]');
+
+        WP_CLI::log(sprintf(___('External menu item ID %d...'),$external_menu_item->ID));
+    }
+}
+
+EPFLMenusCLICommand::hook();


### PR DESCRIPTION
- On remet le code des menus dans le plugin
- On désactive le plugin "epfl-menu" dans Ansible via https://github.com/epfl-idevelop/wp-ops/pull/132
- Plugin plus installé sur nouveau site
