### PR TITLE
Fix Social Feed encoded URLs, Fix incorrect regex

### DIFF
--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -38,7 +38,7 @@ class GutenbergFixes(GutenbergBlocks):
         :param attr_name: Attribute name for which we want the value
         :return:
         """
-        matching_reg = re.compile('"{}":(".+?"|\S+?),?'.format(attr_name),
+        matching_reg = re.compile('"{}":\s?(".+?"|\S+?),?'.format(attr_name),
                                   re.VERBOSE | re.DOTALL)
 
         value = matching_reg.findall(block_call)
@@ -65,7 +65,7 @@ class GutenbergFixes(GutenbergBlocks):
         # <!-- wp:block_name {"attr_name":"a","two":"b"} /-->  >>> <!-- wp:block_name {"attr_name":"b","two":"b"} /-->
         # <!-- wp:block_name {"attr_name":a,"two":"b"} /-->  >>> <!-- wp:block_name {"attr_name":b,"two":"b"} /-->
         
-        matching_reg = re.compile('(?P<before>\<!--\swp:epfl/{}.+\{{.*?\"{}\":)(\".+?\"|\S+?)(?P<after>,|\}})'.format(block_name, attr_name),
+        matching_reg = re.compile('(?P<before>\<!--\swp:epfl/{}.+\{{.*?\"{}\":\s?)(\".+?\"|\S+?)(?P<after>,|\}})'.format(block_name, attr_name),
                                   re.VERBOSE)
 
         double_quotes = '"' if between_double_quotes else ''

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -288,3 +288,45 @@ class GutenbergFixes(GutenbergBlocks):
                 content = content.replace(call, new_call)
         
         return content
+    
+
+    def _fix_block_social_feed(self, content, page_id):
+        """
+        Fix EPFL Social Feed
+        :param content: content to update
+        :param page_id: Id of page containing content
+        """
+        
+        block_name = "social-feed"
+
+        func_list = [ '_decode_html' ]
+        attributes_desc = [{
+                            'attr_name': 'twitterUrl',
+                            'func_list': func_list
+                           },
+                           {
+                            'attr_name': 'instagramUrl',
+                            'func_list': func_list
+                           },
+                           {
+                            'attr_name': 'facebookUrl',
+                            'func_list': func_list
+                           }]
+
+        
+        # Looking for all calls to modify them one by one
+        calls = self._get_all_block_calls(content, block_name)
+
+        for call in calls:
+
+            new_call = self.__fix_attributes(call, block_name, attributes_desc, page_id)
+            
+            if new_call != call:
+                self._log_to_file("Before: {}".format(call))
+                self._log_to_file("After: {}".format(new_call))
+
+                self._update_report(block_name)
+
+                content = content.replace(call, new_call)
+        
+        return content


### PR DESCRIPTION
- Suite au passage de shortcodes en blocs, il a été oublié de décoder les URLs de "social feed". Ceci n'est pas très grave car ça fonctionne quand même. C'est juste dans la partie édition visuelle que l'URL est affichée encodée. Et sur "www", il n'y a qu'un seul site où il y a un petit encodage. Sinon, la majorité des URLs n'est pas encodée.
- Correction d'une regex incorrecte qui faisait que certains blocs n'étaient pas mis à jour... 