### PR TITLE
Trip to innerblocks

### DIFF
--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -41,6 +41,6 @@ $content = str_replace("\\\\u003e", "\\u003e", $content);
 
 
 // Save the new content inside temporary file
-file_put_contents($filename, $content);
+file_put_contents($filename, trim($content));
 
 ?>

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -142,7 +142,7 @@ class GutenbergFixes(GutenbergBlocks):
         block_content = block_content.strip("\n")
         call = call.strip("\n")
 
-        return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:html -->\n{2}\n<!-- /wp:html --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)
+        return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:freeform -->\n{2}\n<!-- /wp:freeform --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)
 
 
     def _decode_unicode(self, encoded_html):

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -220,42 +220,6 @@ class GutenbergFixes(GutenbergBlocks):
         
         return new_call
 
-
-    def _fix_block_google_forms(self, content, page_id):
-        """
-        Fix EPFL Goole Forms URL
-
-        :param content: content to update
-        :param page_id: Id of page containing content
-        """
-        
-        block_name = "google-forms"
-
-        attributes_desc = [{
-                            'attr_name': 'data',
-                            'func_list': [ 
-                                            '_decode_html', 
-                                            '_handle_html' 
-                                         ]
-                            }]
-
-        # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name)
-
-        for call in calls:
-
-            new_call = self.__fix_attributes(call, block_name, attributes_desc, page_id)
-            
-            if new_call != call:
-                self._log_to_file("Before: {}".format(call))
-                self._log_to_file("After: {}".format(new_call))
-
-                self._update_report(block_name)
-
-                content = content.replace(call, new_call)
-        
-        return content
-
        
     def _fix_block_contact(self, content, page_id):
         """
@@ -328,87 +292,6 @@ class GutenbergFixes(GutenbergBlocks):
         for call in calls:
 
             new_call = self._transform_to_block_with_content(call, block_name, "content")
-            
-            if new_call != call:
-                self._log_to_file("Before: {}".format(call))
-                self._log_to_file("After: {}".format(new_call))
-
-                self._update_report(block_name)
-
-                content = content.replace(call, new_call)
-        
-        return content
-
-
-    def _fix_block_card(self, content, page_id):
-        """
-        Fix EPFL Card
-        :param content: content to update
-        :param page_id: Id of page containing content
-        """
-        
-        block_name = "card"
-
-        attributes_desc = []
-
-        func_list = ['_decode_html', 
-                    '_add_paragraph',
-                    '_handle_html',
-                    '_remove_new_lines'
-                    ]
-    
-        for i in range(1, 4):
-            attributes_desc.append({'attr_name': 'content{}'.format(i),
-                                    'func_list': func_list})
-        
-        # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name)
-
-        for call in calls:
-
-            new_call = self.__fix_attributes(call, block_name, attributes_desc, page_id)
-            
-            if new_call != call:
-                self._log_to_file("Before: {}".format(call))
-                self._log_to_file("After: {}".format(new_call))
-
-                self._update_report(block_name)
-
-                content = content.replace(call, new_call)
-        
-        return content
-    
-
-    def _fix_block_social_feed(self, content, page_id):
-        """
-        Fix EPFL Social Feed
-        :param content: content to update
-        :param page_id: Id of page containing content
-        """
-        
-        block_name = "social-feed"
-
-        func_list = [ '_decode_html' ]
-        attributes_desc = [{
-                            'attr_name': 'twitterUrl',
-                            'func_list': func_list
-                           },
-                           {
-                            'attr_name': 'instagramUrl',
-                            'func_list': func_list
-                           },
-                           {
-                            'attr_name': 'facebookUrl',
-                            'func_list': func_list
-                           }]
-
-        
-        # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name)
-
-        for call in calls:
-
-            new_call = self.__fix_attributes(call, block_name, attributes_desc, page_id)
             
             if new_call != call:
                 self._log_to_file("Before: {}".format(call))

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -310,6 +310,34 @@ class GutenbergFixes(GutenbergBlocks):
                 content = content.replace(call, new_call)
         
         return content
+    
+
+    def _fix_block_toggle(self, content, page_id):
+        """
+        Fix EPFL Toggle by putting an attribute content inside the block
+
+        :param content: content to update
+        :param page_id: Id of page containing content
+        """
+        
+        block_name = "toggle"
+
+        # Looking for all calls to modify them one by one
+        calls = self._get_all_block_calls(content, block_name)
+
+        for call in calls:
+
+            new_call = self._transform_to_block_with_content(call, block_name, "content")
+            
+            if new_call != call:
+                self._log_to_file("Before: {}".format(call))
+                self._log_to_file("After: {}".format(new_call))
+
+                self._update_report(block_name)
+
+                content = content.replace(call, new_call)
+        
+        return content
 
 
     def _fix_block_card(self, content, page_id):


### PR DESCRIPTION
- Ajout du nécessaire pour transformer des blocs et faire en sorte qu'un de leurs attributs passe en "contenu" (au sein d'un bloc "Classic Editor")
  - Toggle
  - Scheduler
  - Contact
- Correction d'un petit "bug" dans `call-autop.php` qui ajoutait un retour à la ligne à la fin du fichier, aucune idée pourquoi, mais ça pouvait embêter Gutenberg.
- Suppression des anciennes fonctions de correction des attributs de blocs car passées partout.

**NOTES**
- Liée à la PR https://github.com/epfl-idevelop/wp-gutenberg-epfl/pull/114
- Une fois les 2 mergées et l'image reconstruite, il faudra exécuter la commande `jahia2wp.py block-fix-inventory` sur
  - www
  - www/labs
  - inside