### PR TITLE
Transform to InnerBlocks - Remove new line special characters

### DIFF
--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -154,6 +154,7 @@ class GutenbergFixes(GutenbergBlocks):
         block_content = block_content.replace('\\n', "").replace('\\r', "")
         # We remove \n at beginning and end
         call = call.strip("\n")
+        block_content = block_content.strip("\n")
 
         return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:freeform -->\n{2}\n<!-- /wp:freeform --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)
 

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -150,8 +150,9 @@ class GutenbergFixes(GutenbergBlocks):
 
         call = call.replace("/-->", "-->")
 
+        # We remove new line characters in code
+        block_content = block_content.replace('\\n', "").replace('\\r', "")
         # We remove \n at beginning and end
-        block_content = block_content.strip("\n")
         call = call.strip("\n")
 
         return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:freeform -->\n{2}\n<!-- /wp:freeform --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)


### PR DESCRIPTION
Parfois, quand on a du vieuuuux contenu qui vient de Jahia, il peut y avoir des `\n` ou `\r` dans le code... et ceux-ci, une fois traduits en InnerBlocks (dans un block "Classic Editor" donc) sont affichés tel quel... et ce n'est pas le résultat attendu.