### PR TITLE
Update EPFL Quota image URL

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EPFL Quota
  * Description: Allows to set quota for medias
- * Version: 0.4
+ * Version: 0.5
  * Author: Lucien Chaboudez
  * Contributors:
  * License: Copyright (c) 2019 Ecole Polytechnique Federale de Lausanne, Switzerland

--- a/data/wp/wp-content/mu-plugins/epfl-quota/epfl-quota.php
+++ b/data/wp/wp-content/mu-plugins/epfl-quota/epfl-quota.php
@@ -302,7 +302,7 @@ class EPFLQuota
 
     ?>
     <div class="notice notice-info">
-        <img src="<?php echo plugins_url( 'img/gauge.svg', __FILE__ ); ?>" style="height:32px; width:32px; float:left; margin:3px 15px 3px 0px;">
+        <img src="<?php echo WPMU_PLUGIN_URL.'/'.basename(dirname(__FILE__)).'/img/gauge.svg'; ?>" style="height:32px; width:32px; float:left; margin:3px 15px 3px 0px;">
         <p><?php echo $quota_status; ?></p>
     </div>
     <?php


### PR DESCRIPTION
Depuis symlinkage du plugin, l'URL pour afficher la petite image de la jauge était erronnée, correction.