### PR TITLE
Fix inner blocks again

### DIFF
--- a/data/plugins/generic/tinymce-advanced/config-plugin.yml
+++ b/data/plugins/generic/tinymce-advanced/config-plugin.yml
@@ -1,5 +1,2 @@
 src: web
 activate: yes
-install_if:
-  csv_value: !from_csv wp_version
-  match_reg: '^4\.'

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -73,6 +73,7 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'core/list',
         'core/image',
         'core/file',
+        'tadv/classic-paragraph',
     );
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -183,7 +183,7 @@ class GutenbergFixes(GutenbergBlocks):
         if block_content == "":
             return '{0}\n<div class="wp-block-epfl-{1}"></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name)
 
-        return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:freeform -->\n{2}\n<!-- /wp:freeform --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)
+        return '{0}\n<div class="wp-block-epfl-{1}"><!-- wp:tadv/classic-paragraph -->\n{2}\n<!-- /wp:tadv/classic-paragraph --></div>\n<!-- /wp:epfl/{1} -->'.format(call, block_name, block_content)
 
 
     def _decode_unicode(self, encoded_html):


### PR DESCRIPTION
A nouveau besoin de corriger le contenu des InnerBlocks... finalement, utiliser Classic Editor n'est pas une bonne idée..
Si on:
1. Modifier via script pour mettre le contenu du innerblock dans classic editor
1. Aller sur la page pour l'éditer, c'est correct
1. Cliquer sur "Save", c'est toujours correct
1. Revenir sur la page, c'est pété... 

Solution de contournement, utiliser à nouveau TinyMCE Advanced qui a évolué en block...


**PROCÉDURE**
1. Activer TinyMCE partout
`wp plugin activate tinymce-advanced`
1. Update les contenus avec `jahia2wp.py block-fix-inventory ...`