### PR TITLE
[feature] configure wp_mail_from

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_mail.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_mail.php
@@ -1,0 +1,4 @@
+<?php
+add_filter( 'wp_mail_from', function ( $email ) {
+  return 'noreply@epfl.ch';
+} );


### PR DESCRIPTION
This add a filter to configures the default mail from. This is transparent as-it, but helps when using the `wp_mail()` command with a configured `sendmail` in the httpd image.

Please note that it needs [wp-ops/pull/135](https://github.com/epfl-idevelop/wp-ops/pull/135).
