### PR TITLE
Move from epfl/card to epfl/card-deck

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.1
+* Version: 1.0.2
 * Author: wwp-admin@epfl.ch
  */
 
@@ -57,7 +57,7 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'epfl/social-feed',
         'epfl/contact',
         'epfl/caption-cards',
-        'epfl/card',
+        'epfl/card-deck',
         'epfl/definition-list',
         'epfl/links-group',
         'core/paragraph',

--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -1,5 +1,5 @@
 <?php
-
+return;
 $filename = $args[0];
 
 // Get the content of the temporary file
@@ -20,7 +20,7 @@ if ($index_start !== FALSE) {
 }
 
 // Add auto <p>
-$content = wpautop( $content );
+$content = wpautop( $content, false );
 
 if ($index_start !== FALSE) {
     // Search pattern $substitute

--- a/src/migration2018/call-autop.php
+++ b/src/migration2018/call-autop.php
@@ -1,5 +1,4 @@
 <?php
-return;
 $filename = $args[0];
 
 // Get the content of the temporary file

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -321,7 +321,7 @@ class GutenbergFixes(GutenbergBlocks):
             new_call = new_call.strip('\n')
             new_call = new_call.replace('/-->', '-->').replace('wp:epfl/card', 'wp:epfl/card-deck')
 
-            new_call = '{}\n{}\n<!-- /wp:epfl/card-deck -->'.format(new_call, '\n\n'.join(block_contents))
+            new_call = '{}\n{}\n<!-- /wp:epfl/card-deck -->'.format(new_call, '\n'.join(block_contents))
 
             
             if new_call != call:

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -259,24 +259,70 @@ class GutenbergFixes(GutenbergBlocks):
         
         return new_call
 
-       
-    def _fix_block_contact(self, content, page_id):
+
+    def _fix_block_card(self, content, page_id):
         """
-        Fix EPFL Contact by putting an attribute content inside the block
+        Fix EPFL Card by putting an attribute content inside the block
+
         :param content: content to update
         :param page_id: Id of page containing content
         """
         
-        block_name = "contact"
+        block_name = "card"
 
         # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name, with_content=True)
+        calls = self._get_all_block_calls(content, block_name)
+
+        json_separators =  (',', ':')
 
         for call in calls:
 
-            new_call = self._remove_block_call_content(call, block_name)
+            new_call = call
+            block_contents = []
 
-            new_call = self._transform_to_block_with_content(new_call, block_name, "introduction")
+            # We loop through inside elements
+            for i in range(1,4):
+
+                card_deck_attributes = {}
+                attributes = ['title', 'link', 'imageId', 'imageUrl']
+
+                for attr_name in attributes:
+
+                    value = self._get_attribute(new_call, "{}{}".format(attr_name, i))
+
+                    if value is not None:
+                        if attr_name == 'imageId':
+                            value = int(value)
+                        card_deck_attributes[attr_name] = value
+                
+
+                block_content = self._get_attribute(new_call, "content{}".format(i))
+
+                if block_content is None:
+                    block_content = ""
+                block_content = self._decode_unicode(block_content)
+      
+                # We remove new line characters in code
+                block_content = block_content.replace('\\n', "").replace('\\r', "").replace("\\t", "")
+                # We unescape double quotes
+                block_content = block_content.replace('\\"', '"')
+                
+                block_content = block_content.strip("\n")
+
+                json_code = "" if len(card_deck_attributes) == 0 else "{} ".format(json.dumps(card_deck_attributes, separators=json_separators))
+
+                # If block is empty, we have to return without wp:freeform otherwise content won't be editable in visual
+                if block_content == "":
+                    block_contents.append('<!-- wp:epfl/card-panel {}/-->'.format(json_code))
+                else:
+                    block_contents.append('<!-- wp:epfl/card-panel {}-->\n<!-- wp:tadv/classic-paragraph -->\n{}\n<!-- /wp:tadv/classic-paragraph -->\n<!-- /wp:epfl/card-panel -->'.format(json_code, block_content))
+
+            # We remove \n at beginning and end
+            new_call = new_call.strip('\n')
+            new_call = new_call.replace('/-->', '-->').replace('wp:epfl/card', 'wp:epfl/card-deck')
+
+            new_call = '{}\n{}\n<!-- /wp:epfl/card-deck -->'.format(new_call, '\n\n'.join(block_contents))
+
             
             if new_call != call:
                 self._log_to_file("Before: {}".format(call))
@@ -289,61 +335,4 @@ class GutenbergFixes(GutenbergBlocks):
         return content
 
 
-    def _fix_block_scheduler(self, content, page_id):
-        """
-        Fix EPFL Scheduler by putting an attribute content inside the block
-
-        :param content: content to update
-        :param page_id: Id of page containing content
-        """
-        
-        block_name = "scheduler"
-
-        # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name, with_content=True)
-
-        for call in calls:
-
-            new_call = self._remove_block_call_content(call, block_name)
-
-            new_call = self._transform_to_block_with_content(new_call, block_name, "content")
-            
-            if new_call != call:
-                self._log_to_file("Before: {}".format(call))
-                self._log_to_file("After: {}".format(new_call))
-
-                self._update_report(block_name)
-
-                content = content.replace(call, new_call)
-        
-        return content
     
-
-    def _fix_block_toggle(self, content, page_id):
-        """
-        Fix EPFL Toggle by putting an attribute content inside the block
-
-        :param content: content to update
-        :param page_id: Id of page containing content
-        """
-        
-        block_name = "toggle"
-
-        # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name, with_content=True)
-
-        for call in calls:
-
-            new_call = self._remove_block_call_content(call, block_name)
-
-            new_call = self._transform_to_block_with_content(new_call, block_name, "content")
-            
-            if new_call != call:
-                self._log_to_file("Before: {}".format(call))
-                self._log_to_file("After: {}".format(new_call))
-
-                self._update_report(block_name)
-
-                content = content.replace(call, new_call)
-        
-        return content


### PR DESCRIPTION
https://epfl-webvolution.atlassian.net/browse/WWP-57

**IMPORTANT**
En lien avec la PR https://github.com/epfl-idevelop/wp-gutenberg-epfl/pull/130 
Elles devront être mergées en même temps, juste avant le build de l'image et le passage en production.

- Ajout de code pour migrer de `epfl/card` vers `epfl/card-deck`
- Suppression de `epfl/card` dans la white list des blocs autorisés
- Ajout de `epfl/card-deck` dans la white list des blocs autorisés
- Modification de `callautop.php` pour ne pas créer des `<br>` inutiles, ça pourris le code... 