### PR TITLE
Nouveau plugin bloc PDF Viewer

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -25,8 +25,8 @@ plugins:
     config: !include svg-support/config-plugin.yml
   - name: feedzy-rss-feeds
     config: !include feedzy-rss-feeds/config-plugin.yml
-#  - name: enlighter
-#    config: !include enlighter/config-plugin.yml
+  - name: pdf-viewer-block
+    config: !include pdf-viewer-block/config-plugin.yml
   - name: remote-content-shortcode
     config: !include remote-content-shortcode/config-plugin.yml
   - name: shortcode-ui

--- a/data/plugins/generic/pdf-viewer-block/config-plugin.yml
+++ b/data/plugins/generic/pdf-viewer-block/config-plugin.yml
@@ -1,0 +1,2 @@
+src: web
+activate: yes

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.1
+* Version: 1.0.2
 * Author: wwp-admin@epfl.ch
  */
 
@@ -74,6 +74,7 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
         'core/image',
         'core/file',
         'tadv/classic-paragraph',
+        'pdf-viewer-block/standard',
     );
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -257,7 +257,7 @@ class GutenbergBlocks(Shortcodes):
 
         :param attachment_url: URL of attachment for which we want ID
         """
-        att_list = json.loads(self.wp_config.run_wp_cli('post list --post_type=attachment --fields=ID,guid --format=json'))
+        att_list = json.loads(self.wp_config.run_wp_cli('post list --post_type=attachment --fields=ID,guid --format=json --skip-plugins --skip-themes'))
 
         for att in att_list:
 

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -251,6 +251,23 @@ class GutenbergBlocks(Shortcodes):
         return json.dumps(res, separators=(',', ':'))
 
 
+    def _get_attachment_id(self, attachment_url):
+        """
+        Returns attachment id from an attachment URL
+
+        :param attachment_url: URL of attachment for which we want ID
+        """
+        att_list = json.loads(self.wp_config.run_wp_cli('post list --post_type=attachment --fields=ID,guid --format=json'))
+
+        for att in att_list:
+
+            if att['guid'] == attachment_url:
+                return att['ID']
+            
+        # If nothing found
+        return None
+
+
     def _get_news_themes(self, themes, page_id, extra_attr):
         """
         Returns encoded list of dict with infos corresponding to given themes.
@@ -1954,7 +1971,6 @@ class GutenbergBlocks(Shortcodes):
         # Attribute description to recover correct value from each shortcode calls
         attributes_desc = ['url']
 
-
         for call in calls:
 
             # To store new attributes
@@ -1965,6 +1981,49 @@ class GutenbergBlocks(Shortcodes):
 
             # We generate new shortcode from scratch
             new_call = '<!-- wp:{} {} /-->'.format(block, json.dumps(attributes))
+
+            self._log_to_file("Before: {}".format(call))
+            self._log_to_file("After: {}".format(new_call))
+
+            # Replacing in global content
+            content = content.replace(call, new_call)
+
+            self._update_report(shortcode)
+
+        return content
+
+    
+    def _fix_pdfjs_viewer(self, content, page_id):
+        """
+        Transforms PDFJS Viewer shortcode to Gutenberg block
+
+        :param content: content to update
+        :param page_id: Id of page containing content
+        """
+        shortcode = 'pdfjs-viewer'
+        block = 'pdf-viewer-block/standard'
+
+        # Looking for all calls to modify them one by one
+        calls = self._get_all_shortcode_calls(content, shortcode)
+
+        for call in calls:
+
+            url = self._get_attribute(call, 'url')
+            viewer_width = self._get_attribute(call, 'viewer_width')
+            viewer_height = self._get_attribute(call, 'viewer_height')
+            
+            attributes = {}
+
+            id = self._get_attachment_id(url)
+
+            if id is None:
+                self._log_to_file("No attachement ID found for shortcode call: {}".format(call))
+                continue
+            
+            attributes = {'mediaID': id}
+
+            # We generate new shortcode from scratch
+            new_call = '<!-- wp:{0} {1} -->\n<div class="wp-block-pdf-viewer-block-standard" style="text-align:left"><div class="uploaded-pdf"><a href="{2}" data-width="{3}" data-height="{4}"></a></div></div>\n<!-- /wp:{0} -->'.format(block, json.dumps(attributes), url, viewer_width, viewer_height)
 
             self._log_to_file("Before: {}".format(call))
             self._log_to_file("After: {}".format(new_call))

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -2016,7 +2016,7 @@ class GutenbergBlocks(Shortcodes):
 
             id = self._get_attachment_id(url)
 
-            if id is None:
+            if not id:
                 self._log_to_file("Page {}, No attachement ID found for shortcode call: {}".format(page_id, call))
                 continue
             

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -2017,7 +2017,7 @@ class GutenbergBlocks(Shortcodes):
             id = self._get_attachment_id(url)
 
             if id is None:
-                self._log_to_file("No attachement ID found for shortcode call: {}".format(call))
+                self._log_to_file("Page {}, No attachement ID found for shortcode call: {}".format(page_id, call))
                 continue
             
             attributes = {'mediaID': id}

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -300,12 +300,12 @@ class Shortcodes():
         :param attr_name: Attribute name for which we want the value
         :return:
         """
-        matching_reg = re.compile('{}=(".+?"|\S+?)'.format(attr_name),
+        matching_reg = re.compile('{}=(".+?"|.+?\s)'.format(attr_name),
                                   re.VERBOSE | re.DOTALL)
 
         value = matching_reg.findall(shortcode_call)
         # We remove surrounding " if exists.
-        return value[0].strip('"') if value else None
+        return value[0].strip().strip('"') if value else None
 
     def _get_content(self, shortcode_call):
         """


### PR DESCRIPTION
https://epfl-webvolution.atlassian.net/browse/WWP-52

- Ajout du plugin PDF Viewer Gutenberg pour remplacer "pdfjs viewer"
- Mise à jour du mu-plugin avec la white-list de blocs
- Mécanisme de transformation du shortcode "pdfjs-viewer" vers le nouveau bloc
- Correction d'un bug dans la recherche d'une valeur d'attribut de shortcode si celle-ci n'est pas entre double quotes.

Le plugin est ajouté dans l'image via la PR https://github.com/epfl-idevelop/wp-ops/pull/137

