### PR TITLE
[wait] Put block white list in DB

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -34,23 +34,16 @@ function add_gutenberg_custom_editor_menu() {
 function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
 
     /* Recovering white list from option */
-    $white_list = get_option('epfl:gutenberg:allowed-blocks', '');
+    $generic_blocks = get_option('epfl:gutenberg:generic-blocks', '');
+    $generic_blocks = (trim($generic_blocks) == '')? array() : explode(",", $generic_blocks);
 
-    /* If no limitation */
-    if(trim($white_list) == '')
-    {
-        return True;
-    }
+    $specific_blocks = get_option('epfl:gutenberg:specific-blocks', '');
+    $specific_blocks = (trim($specific_blocks) == '')? array() : explode(",", $specific_blocks);
 
-    /* Creating array from string */
-    $blocks = explode(",", $white_list);
+    /* Merging generic and specific and removing duplicates if any */
+    $blocks = array_unique( array_merge($generic_blocks, $specific_blocks));
 
-    // Add epfl/scienceqa block for WP instance https://www.epfl.ch only
-    if (get_option('blogname') == 'EPFL') {
-        array_push($blocks, 'epfl/scienceqa');
-    }
-
-  	return $blocks;
+  	return (sizeof($blocks)==0)? True : $blocks;
     // return True; // if you want all natifs blocks.
 }
 

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.2
+* Version: 1.0.3
 * Author: wwp-admin@epfl.ch
  */
 
@@ -32,50 +32,18 @@ function add_gutenberg_custom_editor_menu() {
 }
 
 function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
-    $blocks = array(
-        'epfl/news',
-        'epfl/memento',
-        'epfl/cover',
-        'epfl/cover-dynamic',
-        'epfl/toggle',
-        'epfl/quote',
-        'epfl/people',
-        'epfl/map',
-        'epfl/introduction',
-        'epfl/hero',
-        'epfl/google-forms',
-        'epfl/video',
-        'epfl/scheduler',
-        'epfl/tableau',
-        'epfl/page-teaser',
-        'epfl/custom-teaser',
-        'epfl/custom-highlight',
-        'epfl/page-highlight',
-        'epfl/post-teaser',
-        'epfl/post-highlight',
-        'epfl/infoscience-search',
-        'epfl/social-feed',
-        'epfl/contact',
-        'epfl/caption-cards',
-        'epfl/card',
-        'epfl/definition-list',
-        'epfl/links-group',
-        'core/paragraph',
-        'core/heading',
-        'core/gallery',
-        'core/classic',
-        'core/rss',
-        'core/table',
-        'core/spacer',
-        'core/separator',
-        'core/shortcode',
-        'core/freeform',
-        'core/list',
-        'core/image',
-        'core/file',
-        'tadv/classic-paragraph',
-        'pdf-viewer-block/standard',
-    );
+
+    /* Recovering white list from option */
+    $white_list = get_option('epfl:gutenberg:allowed-blocks', '');
+
+    /* If no limitation */
+    if(trim($white_list) == '')
+    {
+        return True;
+    }
+
+    /* Creating array from string */
+    $blocks = explode(",", $white_list);
 
     // Add epfl/scienceqa block for WP instance https://www.epfl.ch only
     if (get_option('blogname') == 'EPFL') {


### PR DESCRIPTION
- Déplacement de la "white list" des blocs dans la DB sous la forme d'une chaîne de caractères dans laquelle les blocs sont séparés par des virgules. Nom de l'option (peut-être un peu longue donc possibilité de changer si ça dérange) `epfl:gutenberg:generic-blocks`
- Ajout d'une autre option `epfl:gutenberg:specific-blocks` pour enregistrer une potentielle liste de blocs spécifiques au site (comme `epfl/scienceqa` pour www.epfl.ch). Le fait d'avoir une autre option pour les spécificités permettra de ne pas se marcher sur le sachet lorsque l'on voudra mettre à jour la liste des blocs autorisés pour tous les sites, ça évitera de virer une spécificité pour un site.
- Transformation du mu-plugin contenant la white list pour qu'il aille maintenant chercher dans la DB.
- On merge le contenu de chaque option et si le tableau final (contenant la liste des blocs) est de taille nulle, on admet que tous les blocs sont autorisés.



**MISE EN PRODUCTION**
1. Ajouter l'option dans la DB de tous les sites:
> wp option add epfl:gutenberg:generic-blocks "epfl/news,epfl/memento,epfl/cover,epfl/cover-dynamic,epfl/toggle,epfl/quote,epfl/people,epfl/map,epfl/introduction,epfl/hero,epfl/google-forms,epfl/video,epfl/scheduler,epfl/tableau,epfl/page-teaser,epfl/custom-teaser,epfl/custom-highlight,epfl/page-highlight,epfl/post-teaser,epfl/post-highlight,epfl/infoscience-search,epfl/social-feed,epfl/contact,epfl/caption-cards,epfl/card-deck,epfl/definition-list,epfl/links-group,core/paragraph,core/heading,core/gallery,core/classic,core/rss,core/table,core/spacer,core/separator,core/shortcode,core/freeform,core/list,core/image,core/file,tadv/classic-paragraph,pdf-viewer-block/standard"
1. Sur le site www.epfl.ch, ajouter le plugin spécifique
`wp option add epfl:gutenberg:specific-blocks "epfl/scienceqa"`
1. Merger la PR
1. Rebuild l'image
1. Redéployer l'image
