### PR TITLE
Remove old PDF viewer plugin

### DIFF
--- a/data/plugins/generic/config-lot1.yml
+++ b/data/plugins/generic/config-lot1.yml
@@ -37,8 +37,6 @@ plugins:
     config: !include epfl/config-plugin.yml
   - name: wp-media-folder
     config: !include wp-media-folder/config-plugin.yml
-  - name: pdfjs-viewer-shortcode
-    config: !include pdfjs-viewer-shortcode/config-plugin.yml
   - name: very-simple-meta-description
     config: !include very-simple-meta-description/config-plugin.yml
   - name: epfl-404

--- a/data/plugins/generic/pdfjs-viewer-shortcode/config-plugin.yml
+++ b/data/plugins/generic/pdfjs-viewer-shortcode/config-plugin.yml
@@ -1,2 +1,0 @@
-src: web
-activate: yes


### PR DESCRIPTION
Après l'installation du plugin "bloc" pour afficher un PDF (#1111 ) et la transformation des pages pour utiliser celui-ci, on peut supprimer l'ancien, celui sous forme de shortcode