### PR TITLE
New MU-Plugin for blocks white-list

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
@@ -1,0 +1,63 @@
+<?php
+/*
+* Plugin Name: EPFL block white list
+* Plugin URI:
+* Description: Must-use plugin for the EPFL website to define allowed blocks
+* Version: 1.0.0
+* Author: wwp-admin@epfl.ch
+ */
+
+function epfl_allowed_block_types( $allowed_block_types, $post ) {
+    $blocks = array(
+        'epfl/news',
+        'epfl/memento',
+        'epfl/cover',
+        'epfl/cover-dynamic',
+        'epfl/toggle',
+        'epfl/quote',
+        'epfl/people',
+        'epfl/map',
+        'epfl/introduction',
+        'epfl/hero',
+        'epfl/google-forms',
+        'epfl/video',
+        'epfl/scheduler',
+        'epfl/tableau',
+        'epfl/page-teaser',
+        'epfl/custom-teaser',
+        'epfl/custom-highlight',
+        'epfl/page-highlight',
+        'epfl/post-teaser',
+        'epfl/post-highlight',
+        'epfl/infoscience-search',
+        'epfl/social-feed',
+        'epfl/contact',
+        'epfl/caption-cards',
+        'epfl/card',
+        'epfl/definition-list',
+        'epfl/links-group',
+        'core/paragraph',
+        'core/heading',
+        'core/gallery',
+        'core/classic',
+        'core/rss',
+        'core/table',
+        'core/spacer',
+        'core/separator',
+        'core/shortcode',
+        'core/freeform',
+        'core/list',
+        'core/image',
+        'core/file',
+        'tadv/classic-paragraph',
+        'pdf-viewer-block/standard',
+    );
+
+  	return $blocks;
+    // return True; // if you want all natifs blocks.
+}
+
+// Gutenberg is on ?
+if (function_exists( 'register_block_type' ) ) {
+	add_filter( 'allowed_block_types', 'epfl_allowed_block_types', 10, 2 );
+}

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.3
+* Version: 1.0.4
 * Author: wwp-admin@epfl.ch
  */
 

--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu.php
@@ -31,26 +31,9 @@ function add_gutenberg_custom_editor_menu() {
 	);
 }
 
-function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
-
-    /* Recovering white list from option */
-    $generic_blocks = get_option('epfl:gutenberg:generic-blocks', '');
-    $generic_blocks = (trim($generic_blocks) == '')? array() : explode(",", $generic_blocks);
-
-    $specific_blocks = get_option('epfl:gutenberg:specific-blocks', '');
-    $specific_blocks = (trim($specific_blocks) == '')? array() : explode(",", $specific_blocks);
-
-    /* Merging generic and specific and removing duplicates if any */
-    $blocks = array_unique( array_merge($generic_blocks, $specific_blocks));
-
-  	return (sizeof($blocks)==0)? True : $blocks;
-    // return True; // if you want all natifs blocks.
-}
-
 // Gutenberg is on ?
 if (function_exists( 'register_block_type' ) ) {
 	add_action( 'enqueue_block_editor_assets', 'add_gutenberg_custom_editor_menu' );
-	add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );
 }
 
 ?>

--- a/src/wordpress/generator.py
+++ b/src/wordpress/generator.py
@@ -484,6 +484,7 @@ class WPGenerator:
         if self._site_params['category'] != 'Unmanaged':
             WPMuPluginConfig(self.wp_site, "EPFL_disable_comments.php").install(no_symlink=no_symlink)
             WPMuPluginConfig(self.wp_site, "EPFL_jahia_redirect.php").install(no_symlink=no_symlink)
+            WPMuPluginConfig(self.wp_site, "EPFL_block_white_list.php").install(no_symlink=no_symlink)
 
     def enable_updates_automatic_if_allowed(self):
         if self.wp_config.updates_automatic:


### PR DESCRIPTION
- Ajout d'un nouveau MU-Plugin pour gérer la white-list des blocs
- Suppression du code de gestion (via option dans la DB) introduite dans #1113 
- Ajout de l'installation du MU-Plugin lorsque l'on utilise `jahia2wp.py generate` et s'il ne s'agit pas d'un site "unmanaged"

Lié à la PR https://github.com/epfl-idevelop/wp-ops/pull/139 qui s'occupe d'ajouter le mu-plugin dans l'image