### PR TITLE
Move theme lock to right file

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu_loader.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu_loader.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.5
+* Version: 1.0.6
 * Author: wwp-admin@epfl.ch
  */
 

--- a/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
@@ -3,7 +3,7 @@
  * Plugin Name: EPFL lock plugin and theme install and configuration
  * Plugin URI: 
  * Description: Must-use plugin for the EPFL website.
- * Version: 0.0.4
+ * Version: 0.0.5
  * Author: wwp-admin@epfl.ch
  * */
 
@@ -97,6 +97,19 @@ function EPFL_remove_admin_submenus() {
    remove_submenu_page( 'upload.php', 'ewww-image-optimizer-dynamic-debug' );
    remove_submenu_page( 'upload.php', 'ewww-image-optimizer-queue-debug' );
    remove_submenu_page( 'upload.php', 'ewww-image-optimizer-bulk' );
+
+   remove_submenu_page( 'themes.php', 'themes.php' );
+
+	// Hide customize page (there is no other way to do it)
+	global $submenu;
+	if ( isset( $submenu[ 'themes.php' ] ) ) {
+        foreach ( $submenu[ 'themes.php' ] as $index => $menu_item ) {
+            if ( in_array(strtolower($menu_item[0]),  array( 'customize', 'customizer' )) ) {
+                unset( $submenu[ 'themes.php' ][ $index ] );
+            }
+        }
+    }
+
 }
 
 
@@ -118,6 +131,8 @@ function EPFL_remove_theme_reference_widget() {
     remove_meta_box('dashboard_right_now', 'dashboard', 'normal');
     remove_action('welcome_panel', 'wp_welcome_panel');
 }
+
+
 
 
 ?>

--- a/data/wp/wp-content/mu-plugins/epfl-custom-editor-menu/epfl-custom-editor-menu.php
+++ b/data/wp/wp-content/mu-plugins/epfl-custom-editor-menu/epfl-custom-editor-menu.php
@@ -1,19 +1,5 @@
 <?php
 
-// Allow editors to see Appearance menu
-$role_object = get_role( 'editor' );
-$role_object->add_cap( 'edit_theme_options' );
-function hide_menu() {
-	// Hide theme selection page
-	remove_submenu_page( 'themes.php', 'themes.php' );
-
-	// Hide customize page
-	global $submenu;
-	unset($submenu['themes.php'][6]);
-}
-
-add_action('admin_head', 'hide_menu');
-
 // For Gutenberg only, limit and remove some elements
 function add_gutenberg_custom_editor_menu() {
 	wp_enqueue_script(


### PR DESCRIPTION
- Déplacement du code qui cache l'entrée de menu `themes.php` (sous "Appearance") dans la partie admin pour qu'il soit au même endroit que le code qui verrouille les autres entrées du menu.
- Adaptation du code pour le rendre un peu plus dynamique par rapport à la structure des données WordPress et à la manière dont ils stockent les infos des menus.