### PR TITLE
Add --posts param to transform shortcodes to blocks

### DIFF
--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -2037,7 +2037,7 @@ class GutenbergBlocks(Shortcodes):
         return content
 
 
-    def fix_site(self, openshift_env, wp_site_url, shortcode_name=None, simulation=False):
+    def fix_site(self, openshift_env, wp_site_url, shortcode_name=None, simulation=False, elem_type="page"):
         """
         Fix shortocdes in WP site
         :param openshift_env: openshift environment name
@@ -2060,7 +2060,8 @@ class GutenbergBlocks(Shortcodes):
                                   wp_site_url,
                                   shortcode_name=shortcode_name,
                                   clean_textbox_div=False,
-                                  simulation=simulation)
+                                  simulation=simulation,
+                                  elem_type=elem_type)
 
         self._log_to_file("Pages incorrect images: \n{}\n".format((json.dumps(self.incorrect_images))))
 

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -1142,7 +1142,7 @@ class Shortcodes():
 
         return content
 
-    def fix_site(self, openshift_env, wp_site_url, shortcode_name=None, clean_textbox_div=True, simulation=False):
+    def fix_site(self, openshift_env, wp_site_url, shortcode_name=None, clean_textbox_div=True, simulation=False, elem_type="page"):
         """
         Fix shortocdes in WP site
         :param openshift_env: openshift environment name
@@ -1165,8 +1165,8 @@ class Shortcodes():
         logging.info("Fixing %s...", self.wp_site.path)
 
         # Getting site posts
-        post_ids = self.wp_config.run_wp_cli("post list --post_type=page --skip-plugins --skip-themes "
-                                        "--format=csv --fields=ID")
+        post_ids = self.wp_config.run_wp_cli("post list --post_type={} --skip-plugins --skip-themes "
+                                        "--format=csv --fields=ID".format(elem_type))
 
         # Nothing to fix
         if not post_ids:


### PR DESCRIPTION
Ajout d'un paramètre `--posts` aux commandes `shortcodes-to-block*` de `jahia2wp.py` histoire de pouvoir aussi traiter les posts à la place des pages.
Afin de traiter les posts ET les pages d'un site, il faudra exécuter 2x la commande `shortcodes-to-blocks`, une fois sans  `--posts` et une fois avec.

**NOTE:**
Aucune modification n'a été ajoutée au code de fix des blocs. A voir si ça devient utile par la suite.