### PR TITLE
Fix infoscience URL format

### DIFF
--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -302,7 +302,9 @@ class GutenbergFixes(GutenbergBlocks):
 
             url = self._get_attribute(call, 'url')
 
-            new_call = call.replace(url, url.replace('\/', '/'))
+            new_url = url.replace('\/', '/')
+            new_url = new_url.replace('&amp;', '&')
+            new_call = call.replace(url, new_url)
             
             if new_call != call:
                 self._log_to_file("Before: {}".format(call))

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -303,7 +303,7 @@ class GutenbergFixes(GutenbergBlocks):
             url = self._get_attribute(call, 'url')
 
             new_url = url.replace('\/', '/')
-            new_url = new_url.replace('&amp;', '&')
+            new_url = new_url.replace('\\u0026amp;', '\\u0026')
             new_call = call.replace(url, new_url)
             
             if new_call != call:

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -286,70 +286,23 @@ class GutenbergFixes(GutenbergBlocks):
         return new_call
     
 
-    def _fix_block_card(self, content, page_id):
+    def _fix_block_infoscience_search(self, content, page_id):
         """
-        Fix EPFL Card by putting an attribute content inside the block
+        Fix EPFL Infoscience URL
         :param content: content to update
         :param page_id: Id of page containing content
         """
         
-        block_name = "card"
+        block_name = "infoscience-search"
 
         # Looking for all calls to modify them one by one
         calls = self._get_all_block_calls(content, block_name)
 
-        json_separators =  (',', ':')
-
         for call in calls:
 
-            new_call = call
-            block_contents = []
+            url = self._get_attribute(call, 'url')
 
-            # We loop through inside elements
-            for i in range(1,4):
-
-                card_deck_attributes = {}
-                attributes = ['title', 'link', 'imageId', 'imageUrl']
-
-                for attr_name in attributes:
-
-                    value = self._get_attribute(new_call, "{}{}".format(attr_name, i))
-
-                    if value is not None:
-                        if attr_name == 'imageId':
-                            value = int(value)
-                        elif attr_name == 'title':
-                            value = value.replace('\\\\u', '\\u')
-
-                        card_deck_attributes[attr_name] = value
-                
-                block_content = self._get_attribute(new_call, "content{}".format(i))
-
-                if block_content is None:
-                    block_content = ""
-                block_content = self._decode_unicode(block_content)
-      
-                # We remove new line characters in code
-                block_content = block_content.replace('\\n', "").replace('\\r', "").replace("\\t", "")
-                # We unescape double quotes
-                block_content = block_content.replace('\\"', '"')
-                
-                block_content = block_content.strip("\n")
-
-                json_code = "" if len(card_deck_attributes) == 0 else "{} ".format(json.dumps(card_deck_attributes, separators=json_separators))
-
-                # If block is empty, we have to return without wp:freeform otherwise content won't be editable in visual
-                if block_content == "":
-                    block_contents.append('<!-- wp:epfl/card-panel {}/-->'.format(json_code))
-                else:
-                    block_contents.append('<!-- wp:epfl/card-panel {}-->\n<!-- wp:tadv/classic-paragraph -->\n{}\n<!-- /wp:tadv/classic-paragraph -->\n<!-- /wp:epfl/card-panel -->'.format(json_code, block_content))
-
-            # We remove \n at beginning and end
-            new_call = new_call.strip('\n')
-            new_call = new_call.replace('/-->', '-->').replace('wp:epfl/card', 'wp:epfl/card-deck')
-
-            new_call = '{}\n{}\n<!-- /wp:epfl/card-deck -->'.format(new_call, '\n'.join(block_contents))
-
+            new_call = call.replace(url, url.replace('\/', '/'))
             
             if new_call != call:
                 self._log_to_file("Before: {}".format(call))


### PR DESCRIPTION
Correction d'un problème d'encodage d'URL pour le bloc `infoscience-search`. Il semblerait (sans avoir réussi à reproduire le problème à coup sûr) que le passage en WP 5.2.5 ait fait que les URL sont maintenant encodées différemment lorsque ce sont des attributs de blocs.
Avant, ceci fonctionnait sans problème:
> https:\/\/infoscience.epfl.ch\/search?ln=en\u0026amp;cc=Infoscience%2FResearch%2FENAC%2FIA%2FLAST\u0026amp;p=\u0026amp;f=\u0026amp;rm=\u0026amp;ln=en\u0026amp;sf=\u0026amp;so=d\u0026amp;rg=10\u0026amp;c=Infoscience%2FResearch%2FENAC%2FIA%2FLAST\u0026amp;c=\u0026amp;of=hb

Maintenant, les `\/`ne sont plus gérés correctement et les `\u0026amp;` (qui représentent `&amp;`) posent problème. Il faut en effet que ceux-ci ressemblent à `\u0026` tout simplement (on ne fait qu'encoder le `&` et c'est tout)
