### PR TITLE
card to card-deck again...

### DIFF
--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -351,7 +351,9 @@ class GutenbergFixes(GutenbergBlocks):
 
                     if value is not None:
                         if attr_name == 'imageId':
-                            if value != 'null':
+                            if value == 'null':
+                                value = None
+                            else:
                                 value = int(value)
                         elif attr_name == 'title':
                             value = value.replace('\\\\u', '\\u')

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -348,7 +348,8 @@ class GutenbergFixes(GutenbergBlocks):
 
                     if value is not None:
                         if attr_name == 'imageId':
-                            value = int(value)
+                            if value is not None:
+                                value = int(value)
                         elif attr_name == 'title':
                             value = value.replace('\\\\u', '\\u')
 

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -351,10 +351,13 @@ class GutenbergFixes(GutenbergBlocks):
 
                     if value is not None:
                         if attr_name == 'imageId':
-                            if value == 'null':
-                                value = None
-                            else:
+                            try:
+                                # Value can be equal to "null" or can have others incorrect values so... instead
+                                # of handling all specific errors, we use "try except" statement..
                                 value = int(value)
+                            except ValueError e:
+                                value = None
+
                         elif attr_name == 'title':
                             value = value.replace('\\\\u', '\\u')
 

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -349,7 +349,7 @@ class GutenbergFixes(GutenbergBlocks):
                     if value is not None:
                         if attr_name == 'imageId':
                             value = int(value)
-                        else if attr_name == 'title':
+                        elif attr_name == 'title':
                             value = value.replace('\\\\u', '\\u')
 
                         card_deck_attributes[attr_name] = value

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -355,7 +355,7 @@ class GutenbergFixes(GutenbergBlocks):
                                 # Value can be equal to "null" or can have others incorrect values so... instead
                                 # of handling all specific errors, we use "try except" statement..
                                 value = int(value)
-                            except ValueError e:
+                            except ValueError as e:
                                 value = None
 
                         elif attr_name == 'title':

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -302,6 +302,9 @@ class GutenbergFixes(GutenbergBlocks):
 
             url = self._get_attribute(call, 'url')
 
+            if url is None: 
+                continue
+
             new_url = url.replace('\/', '/')
             new_url = new_url.replace('\\u0026amp;', '\\u0026')
             new_call = call.replace(url, new_url)

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -348,7 +348,7 @@ class GutenbergFixes(GutenbergBlocks):
 
                     if value is not None:
                         if attr_name == 'imageId':
-                            if value is not None:
+                            if value != 'null':
                                 value = int(value)
                         elif attr_name == 'title':
                             value = value.replace('\\\\u', '\\u')

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -316,3 +316,78 @@ class GutenbergFixes(GutenbergBlocks):
         
         return content
     
+
+    def _fix_block_card(self, content, page_id):
+        """
+        Fix EPFL Card by putting an attribute content inside the block
+        :param content: content to update
+        :param page_id: Id of page containing content
+        """
+        
+        block_name = "card"
+
+        # Looking for all calls to modify them one by one
+        calls = self._get_all_block_calls(content, block_name)
+
+        json_separators =  (',', ':')
+
+        for call in calls:
+
+            new_call = call
+            block_contents = []
+
+            # We loop through inside elements
+            for i in range(1,4):
+
+                card_deck_attributes = {}
+                attributes = ['title', 'link', 'imageId', 'imageUrl']
+
+                for attr_name in attributes:
+
+                    value = self._get_attribute(new_call, "{}{}".format(attr_name, i))
+
+                    if value is not None:
+                        if attr_name == 'imageId':
+                            value = int(value)
+                        else if attr_name == 'title':
+                            value = value.replace('\\\\u', '\\u')
+
+                        card_deck_attributes[attr_name] = value
+                
+                block_content = self._get_attribute(new_call, "content{}".format(i))
+
+                if block_content is None:
+                    block_content = ""
+                block_content = self._decode_unicode(block_content)
+      
+                # We remove new line characters in code
+                block_content = block_content.replace('\\n', "").replace('\\r', "").replace("\\t", "")
+                # We unescape double quotes
+                block_content = block_content.replace('\\"', '"')
+                
+                block_content = block_content.strip("\n")
+
+                json_code = "" if len(card_deck_attributes) == 0 else "{} ".format(json.dumps(card_deck_attributes, separators=json_separators))
+
+                # If block is empty, we have to return without wp:freeform otherwise content won't be editable in visual
+                if block_content == "":
+                    block_contents.append('<!-- wp:epfl/card-panel {}/-->'.format(json_code))
+                else:
+                    block_contents.append('<!-- wp:epfl/card-panel {}-->\n<!-- wp:tadv/classic-paragraph -->\n{}\n<!-- /wp:tadv/classic-paragraph -->\n<!-- /wp:epfl/card-panel -->'.format(json_code, block_content))
+
+            # We remove \n at beginning and end
+            new_call = new_call.strip('\n')
+            new_call = new_call.replace('/-->', '-->').replace('wp:epfl/card', 'wp:epfl/card-deck')
+
+            new_call = '{}\n{}\n<!-- /wp:epfl/card-deck -->'.format(new_call, '\n'.join(block_contents))
+
+            
+            if new_call != call:
+                self._log_to_file("Before: {}".format(call))
+                self._log_to_file("After: {}".format(new_call))
+
+                self._update_report(block_name)
+
+                content = content.replace(call, new_call)
+        
+        return content


### PR DESCRIPTION
Certains cas particulier  (données incorrectes) de "transformation" de `epfl/card` en `epfl/card-deck` n'ayant pas été pris en compte, il y a des sites pour lequels la transformation a planté sur une page (Exception) et du coup, le reste des pages du site n'a pas pu être traitée (ou la totalité des pages dans le cas où ça aurait pété sur la première page rencontrée...)

Le code a donc été repris depuis une ancienne branche (vu qu'effacé par la suite car on pensait ne plus en avoir besoin...) et il a été adapté pour gérer plus d'erreurs (notamment la gestion de `imageId` et l'appel à la fonction `int(...)`

Pour le moment, on corrige les sites au cas par cas quand il y a un incident mais une correction "globale" va être réappliquée lors du wagon de change du 17 janvier.