### PR TITLE
Change full backup retention

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -28,7 +28,7 @@ FULL_BACKUP_RETENTION_THEME = {
     'hourly': 0,
     'daily': 0,
     'weekly': 8,
-    'monthly': 24,
+    'monthly': 12,
     'yearly': 'always',
 }
 


### PR DESCRIPTION
Diminution de la rétention des backup full pour passer de 24 à 12 mois. La raison d'une rétention si élevée était pour le SAC afin qu'ils puissent prouver que des informations étaient bien affichées sur le site à une date donnée en cas de contestation d'un étudiant. Mais on a les "previous versions" pour savoir ceci et c'est encore plus simple et rapide pour récupérer l'information que de devoir restaurer le site web à un autre endroit et changer plein de choses (search replace, etc..) pour qu'il soit accessible.

Ceci permettra de gagner de la place sur le volume NAS de backup