### PR TITLE
Remove debug.log from backup

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -345,7 +345,7 @@ class Utils(object):
         # To list all files/dirs/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
         # We also remove debug.log to spare some place
-        cmd_all_others = 'find {0} -print | egrep "^{0}/wp" | egrep -v debug.log'.format(source_path)
+        cmd_all_others = 'find {0} -print | egrep "^{0}/wp" | grep -v "debug.log"'.format(source_path)
 
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
         command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \

--- a/src/utils.py
+++ b/src/utils.py
@@ -344,10 +344,10 @@ class Utils(object):
 
         # To list all files/dirs/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
-        # We also remove debug.log to spare some place
         cmd_all_others = 'find {0} -print | egrep "^{0}/wp"'.format(source_path)
 
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
+        # We also remove debug.log to spare some place
         command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
                   "--listed-incremental={} --exclude=debug.log -T -".format(cmd_first_level_files,
                                                         cmd_all_others,

--- a/src/utils.py
+++ b/src/utils.py
@@ -345,11 +345,11 @@ class Utils(object):
         # To list all files/dirs/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
         # We also remove debug.log to spare some place
-        cmd_all_others = 'find {0} -print | egrep "^{0}/wp" | grep -v "debug.log"'.format(source_path)
+        cmd_all_others = 'find {0} -print | egrep "^{0}/wp"'.format(source_path)
 
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
         command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
-                  "--listed-incremental={} -T -".format(cmd_first_level_files,
+                  "--listed-incremental={} --exclude=debug.log -T -".format(cmd_first_level_files,
                                                         cmd_all_others,
                                                         tar_file_path,
                                                         tar_listed_inc_file_path)

--- a/src/utils.py
+++ b/src/utils.py
@@ -344,7 +344,8 @@ class Utils(object):
 
         # To list all files/dirs/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
-        cmd_all_others = 'find {0} -print | egrep "^{0}/wp"'.format(source_path)
+        # We also remove debug.log to spare some place
+        cmd_all_others = 'find {0} -print | egrep "^{0}/wp" | egrep -v debug.log'.format(source_path)
 
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
         command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \


### PR DESCRIPTION
On fait en sorte de ne plus backuper le fichier `debug.log` car il peut vite prendre beauuuucoup d'espace !
