### PR TITLE
[janitor] The IDEVELOP unit is no more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ vars: check-env
 	@echo '  JAHIA_HOST=${JAHIA_HOST}'
 
 build: check-env
-	docker build -t epflidevelop/os-wp-base ../wp-ops/docker/wp-base
+	docker build -t epflsi/os-wp-base ../wp-ops/docker/wp-base
 	docker-compose build
 
 up: build

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@
 </h4>
 
 <p align="center">
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/docs/CHANGELOG.md">
-    <img src="https://img.shields.io/github/release/epfl-idevelop/jahia2wp.svg"
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/docs/CHANGELOG.md">
+    <img src="https://img.shields.io/github/release/epfl-si/jahia2wp.svg"
          alt="Changelog">
   </a>
   <a href="http://jahia2wp.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/jahia2wp.svg"
          alt="RDT">
   </a>
-  <a href="https://travis-ci.org/epfl-idevelop/jahia2wp">
-    <img src="https://travis-ci.org/epfl-idevelop/jahia2wp.svg?branch=master"
+  <a href="https://travis-ci.org/epfl-si/jahia2wp">
+    <img src="https://travis-ci.org/epfl-si/jahia2wp.svg?branch=master"
          alt="Travis">
   </a>
-  <a href="https://codecov.io/gh/epfl-idevelop/jahia2wp">
-    <img src="https://codecov.io/gh/epfl-idevelop/jahia2wp/branch/master/graph/badge.svg"
+  <a href="https://codecov.io/gh/epfl-si/jahia2wp">
+    <img src="https://codecov.io/gh/epfl-si/jahia2wp/branch/master/graph/badge.svg"
          alt="Codecov" />
   </a>
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/LICENSE">
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg"
          alt="License" />
   </a>
@@ -44,7 +44,7 @@ Head to the [documentation](http://jahia2wp.readthedocs.io/en/master/) for next 
 
 ### 30/11/2017, Naked WordPress : Went Live :airplane:
 
-We spent [6 sprints](https://github.com/epfl-idevelop/jahia2wp/projects/1?) to focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
+We spent [6 sprints](https://github.com/epfl-si/jahia2wp/projects/1?) to focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
 
 1. :balloon: installing a functional WordPress to any given URL
 

--- a/data/plugins/generic/wp-gutenberg-epfl/config-plugin.yml
+++ b/data/plugins/generic/wp-gutenberg-epfl/config-plugin.yml
@@ -1,4 +1,4 @@
-src: https://github.com/epfl-idevelop/wp-gutenberg-epfl/archive/master.zip
+src: https://github.com/epfl-si/wp-gutenberg-epfl/archive/master.zip
 activate: yes
 install_if:
   csv_value: !from_csv wp_version

--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -369,7 +369,7 @@ add_filter('tiny_mce_before_init', 'allow_svg_in_tinymce');
 
 
 /*
-    Add tags present in HTML styleguide (https://epfl-idevelop.github.io/elements/#/) to allow users to use them directly
+    Add tags present in HTML styleguide (https://epfl-si.github.io/elements/#/) to allow users to use them directly
     in "Text Editor"
 */
 function epfl_2018_add_allowed_tags($tags)

--- a/data/wp/wp-content/mu-plugins/package/epfl-wpcli/composer.json
+++ b/data/wp/wp-content/mu-plugins/package/epfl-wpcli/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "epflidevelop/wpcli",
+    "name": "epflsi/wpcli",
     "description": "An extension to existing WPCLI commands to fit EPFL's needs",
     "type": "wp-cli-package",
-    "homepage": "https://github.com/epflidevelop/wpcli",
+    "homepage": "https://github.com/epflsi/wpcli",
     "support": {
-        "issues": "https://github.com/epflidevelop/wpcli/issues"
+        "issues": "https://github.com/epflsi/wpcli/issues"
     },
     "require": {
        "wp-cli/wp-cli": "~1.5.0",

--- a/data/wp/wp-content/mu-plugins/package/epfl-wpcli/epfl-wpcli.php
+++ b/data/wp/wp-content/mu-plugins/package/epfl-wpcli/epfl-wpcli.php
@@ -3,7 +3,7 @@
  * EPFL WPCLI extended commands
  *
  * @author  Lucien Chaboudez <lucien.chaboudez@epfl.ch>
- * @package epflidevelop/wpcli
+ * @package epflsi/wpcli
  * @version 1.0.0
  */
 

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-cover/shortcake-config.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-cover/shortcake-config.php
@@ -16,7 +16,7 @@ Class ShortCakeCoverConfig
                         'label'       => '<h3>' . esc_html__('Cover description', 'epfl') . '</h3>',
                         'attr'        => 'description',
                         'type'        => 'textarea',
-                        'description' => '<a target="_blank" href="https://epfl-idevelop.github.io/elements/#/molecules/cover">Documentation</a>'
+                        'description' => '<a target="_blank" href="https://epfl-si.github.io/elements/#/molecules/cover">Documentation</a>'
                     ),
                     array(
                         'label'       => '<h3>' . esc_html__('Cover image', 'epfl') . '</h3>',

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: EPFL Infoscience search shortcode
- * Plugin URI: https://github.com/epfl-idevelop/jahia2wp
+ * Plugin URI: https://github.com/epfl-si/jahia2wp
  * Description: provides a shortcode to search and dispay results from Infoscience
  * Version: 1.10
  * Author: Julien Delasoie

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-links-group/shortcake-config.php
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-links-group/shortcake-config.php
@@ -24,7 +24,7 @@ Class ShortCakeLinksGroupConfig
             'label'       => '<h3>' . esc_html__('Title', 'epfl') . '</h3>',
             'attr'        => 'title',
             'type'        => 'text',
-            'description' => '<a target="_blank" href="https://epfl-idevelop.github.io/elements/#/molecules/links-group">Documentation</a>'
+            'description' => '<a target="_blank" href="https://epfl-si.github.io/elements/#/molecules/links-group">Documentation</a>'
         ]);
 
         array_push($fields, [

--- a/data/wp/wp-content/plugins/epfl/shortcodes/epfl-polylex-search/README.md
+++ b/data/wp/wp-content/plugins/epfl/shortcodes/epfl-polylex-search/README.md
@@ -1,6 +1,6 @@
 # Shortcode Polylex
 
-Ce shortcode permet un interfaçage avec l'application [wp-polylex](https://github.com/epfl-idevelop/wp-polylex).
+Ce shortcode permet un interfaçage avec l'application [wp-polylex](https://github.com/epfl-si/wp-polylex).
 
 Fonctionnalités :
 - UI permettant

--- a/data/wp/wp-content/themes/epfl-master/README.md
+++ b/data/wp/wp-content/themes/epfl-master/README.md
@@ -2,11 +2,11 @@
 Epfl theme (Wordpress)
 ===
  * Based on [*_s* theme (underscores)](https://underscores.me/)
- * Implements the [elements](https://github.com/epfl-idevelop/elements) styleguide
+ * Implements the [elements](https://github.com/epfl-si/elements) styleguide
  * Uses shortcodes to display special content served by EPFL APIs.
 
 ## Requirements
-  * production build of [elements](https://github.com/epfl-idevelop/elements) located in `/assets`
+  * production build of [elements](https://github.com/epfl-si/elements) located in `/assets`
   * composer
 
 ## Setup
@@ -14,7 +14,7 @@ Epfl theme (Wordpress)
   2. Nothing more, you're ready to go! 🚀
 
 ## Recovering the last version of the styleguide
-  1. head towards [https://github.com/epfl-idevelop/elements](https://github.com/epfl-idevelop/elements)
+  1. head towards [https://github.com/epfl-si/elements](https://github.com/epfl-si/elements)
   2. clone the repo locally
   3. install the project locally (see elements documentation)
   4. launch `$ yarn && yarn build` or `$ docker-compose up builder`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,12 @@ services:
 
   httpd:
     container_name: jahia2wp-httpd
-    # We use build info available in another cloned repository : https://github.com/epfl-idevelop/wp-ops/
-    # TODO: Read domq's comment on PR https://github.com/epfl-idevelop/jahia2wp/pull/800 and determine what can be done
+    # We use build info available in another cloned repository : https://github.com/epfl-si/wp-ops/
+    # TODO: Read domq's comment on PR https://github.com/epfl-si/jahia2wp/pull/800 and determine what can be done
     build: ../wp-ops/docker/httpd
     labels:
       ch.epfl.jahia2wp.httpd.env: ${WP_ENV}
-    image: epflidevelop/wp-ops-httpd
+    image: epflsi/wp-ops-httpd
     volumes:
       - ./volumes/srv:/srv
     links:
@@ -39,9 +39,9 @@ services:
   mgmt:
     labels:
       ch.epfl.jahia2wp.mgmt.env: ${WP_ENV}
-    image: epflidevelop/wp-ops-mgmt
-    # We use build info available in another cloned repository : https://github.com/epfl-idevelop/wp-ops/
-    # TODO: Read domq's comment on PR https://github.com/epfl-idevelop/jahia2wp/pull/800 and determine what can be done
+    image: epflsi/wp-ops-mgmt
+    # We use build info available in another cloned repository : https://github.com/epfl-si/wp-ops/
+    # TODO: Read domq's comment on PR https://github.com/epfl-si/jahia2wp/pull/800 and determine what can be done
     build: ../wp-ops/docker/mgmt
     env_file:
       - .env

--- a/docs/HOWTOs/UPDATE_THEME.md
+++ b/docs/HOWTOs/UPDATE_THEME.md
@@ -2,8 +2,8 @@
 
 The theme and our supported plugins are located in tow places:
 
-1. historically, in [container-wp-volumes](https://github.com/epfl-idevelop/container-wp-volumes). This repository is used by [jahiap](https://github.com/epfl-idevelop/jahiap), the historical repository of the project. That is the place where Aline pushes her updates
-2. in this repository/[data](https://github.com/epfl-idevelop/jahia2wp/tree/master/data). This is  the source of the code for the current phase of the project
+1. historically, in [container-wp-volumes](https://github.com/epfl-si/container-wp-volumes). This repository is used by [jahiap](https://github.com/epfl-si/jahiap), the historical repository of the project. That is the place where Aline pushes her updates
+2. in this repository/[data](https://github.com/epfl-si/jahia2wp/tree/master/data). This is  the source of the code for the current phase of the project
 
 As for now, the current repository must be manually updated.
 
@@ -40,4 +40,4 @@ We will make the assumptions that you have your repos in the following paths, in
         jahia2wp (fix-...-wp-volumes) $ git commit -am "updated wp-content with content of last sprint"
         jahia2wp (fix-...-wp-volumes) $ git push
 
-5. Create PR on [github](https://github.com/epfl-idevelop/jahia2wp/branches). You probably can use your CHANGELOG description as the description of your PR
+5. Create PR on [github](https://github.com/epfl-si/jahia2wp/branches). You probably can use your CHANGELOG description as the description of your PR

--- a/docs/INSTALL_DETAILED.md
+++ b/docs/INSTALL_DETAILED.md
@@ -19,7 +19,7 @@ Table of contents
 
 Github is currently the only way to leverage this project (and its awesome features).
 
-    you@host:~$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    you@host:~$ git clone git@github.com:epfl-si/jahia2wp.git
     you@host:~$ cd jahia2wp
 
 ## Initial setup (details of `make bootstrap-local`)
@@ -132,7 +132,7 @@ Login to the management container (within VPN) and go to your environment:
 
 Clone the project:
 
-    www-data@mgmt-x-xxx:/srv/your-env$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    www-data@mgmt-x-xxx:/srv/your-env$ git clone git@github.com:epfl-si/jahia2wp.git
     www-data@mgmt-x-xxx:/srv/your-env$ cd jahia2wp
     www-data@mgmt-x-xxx:/srv/your-env/jahia2wp$ cp /srv/.config/.env .env
 

--- a/docs/KNOWN_ERRORS.md
+++ b/docs/KNOWN_ERRORS.md
@@ -1,1 +1,1 @@
-Please head for the open [issues on GitHub](https://github.com/epfl-idevelop/jahia2wp/issues), and feel free to submit a new one if necessary
+Please head for the open [issues on GitHub](https://github.com/epfl-si/jahia2wp/issues), and feel free to submit a new one if necessary

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable -->
 <h1 align="center" style="margin:1em">
-  <a href="https://github.com/epfl-idevelop/jahia2wp">
+  <a href="https://github.com/epfl-si/jahia2wp">
     <img src="./static/jahia2wp.png"
          alt="jahia2wp"
          width="200"></a>
@@ -13,23 +13,23 @@
 </h4>
 
 <p align="center">
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/docs/CHANGELOG.md">
-    <img src="https://img.shields.io/github/release/epfl-idevelop/jahia2wp.svg"
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/docs/CHANGELOG.md">
+    <img src="https://img.shields.io/github/release/epfl-si/jahia2wp.svg"
          alt="Changelog">
   </a>
   <a href="http://jahia2wp.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/jahia2wp.svg"
          alt="RDT">
   </a>
-  <a href="https://travis-ci.org/epfl-idevelop/jahia2wp">
-    <img src="https://travis-ci.org/epfl-idevelop/jahia2wp.svg?branch=master"
+  <a href="https://travis-ci.org/epfl-si/jahia2wp">
+    <img src="https://travis-ci.org/epfl-si/jahia2wp.svg?branch=master"
          alt="Travis">
   </a>
-  <a href="https://codecov.io/gh/epfl-idevelop/jahia2wp">
-    <img src="https://codecov.io/gh/epfl-idevelop/jahia2wp/branch/master/graph/badge.svg"
+  <a href="https://codecov.io/gh/epfl-si/jahia2wp">
+    <img src="https://codecov.io/gh/epfl-si/jahia2wp/branch/master/graph/badge.svg"
          alt="Codecov" />
   </a>
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/LICENSE">
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg"
          alt="License" />
   </a>
@@ -86,7 +86,7 @@ In the process, not only shall you **not** loose your data, but you shall also b
 
 We will first focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
 
-This phase ended on the 30th of November, with the [release 0.3.0](https://github.com/epfl-idevelop/jahia2wp/releases/tag/0.3.0)
+This phase ended on the 30th of November, with the [release 0.3.0](https://github.com/epfl-si/jahia2wp/releases/tag/0.3.0)
 
 We will secondly add support for migration of a simple site:
 
@@ -131,11 +131,11 @@ Note that python is not in the requirements. You do not necessarily need it on y
 
 As some commands require `sudo`, you will be asked for your system password. The process will add a line in your `.bashrc` (again: head to [INSTALL_TOOLS.md](./INSTALL_TOOLS.md) to get more details):
 
-    you@host:~$ git clone git@github.com:epfl-idevelop/jahia2wp.git
-    you@host:~$ git clone git@github.com:epfl-idevelop/wp-ops.git
+    you@host:~$ git clone git@github.com:epfl-si/jahia2wp.git
+    you@host:~$ git clone git@github.com:epfl-si/wp-ops.git
     # or, would you rather use https instead of SSH
-    # you@host:~$ git clone https://github.com/epfl-idevelop/jahia2wp.git 
-    # you@host:~$ git clone https://github.com/epfl-idevelop/wp-ops.git 
+    # you@host:~$ git clone https://github.com/epfl-si/jahia2wp.git 
+    # you@host:~$ git clone https://github.com/epfl-si/wp-ops.git 
     you@host:~$ cd jahia2wp
     you@host:jahia2wp$ make bootstrap-local (add ENV=your-env if you use a C2C environment name here if you have one)
     ...
@@ -158,7 +158,7 @@ You will also need to know what environment (pod) you wish to connect into (and 
 
     you@host:~$ WP_ENV=c2c-env && ssh -A -o SendEnv=WP_ENV www-data@ssh-wwp.epfl.ch -p 32222
     
-    www-data@mgmt-x-xxx:/srv/c2c-env$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    www-data@mgmt-x-xxx:/srv/c2c-env$ git clone git@github.com:epfl-si/jahia2wp.git
     www-data@mgmt-x-xxx:/srv/c2c-env$ cd jahia2wp
     www-data@mgmt-x-xxx:/srv/c2c-env/jahia2wp$ cp /srv/.config/.env . (<- that will set the correct DB credentials for you)
     www-data@mgmt-x-xxx:/srv/c2c-env/jahia2wp$ make -f Makefile.c2c
@@ -294,7 +294,7 @@ A phpMyAdmin is available locally at [localhost:8080](http://localhost:8080), wi
 
 There are a few ways where you can help out:
 
-1. Submit [GitHub issues](https://github.com/epfl-idevelop/jahia2wp/issues) for any feature enhancements, bugs or documentation problems.
+1. Submit [GitHub issues](https://github.com/epfl-si/jahia2wp/issues) for any feature enhancements, bugs or documentation problems.
 1. Fix open issues by sending PRs (please make sure you respect [flake8](http://flake8.pycqa.org/en/latest/) conventions and that all tests pass (see below)
 1. Add documentation (written in [markdown](https://daringfireball.net/projects/markdown/))
 

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -5,7 +5,7 @@ django==1.11.5
 clint==0.5.1
 PyYAML==3.12
 PyMySQL==0.7.11
-git+https://github.com/epfl-idevelop/python-rotate-backups.git
+git+https://github.com/epfl-si/python-rotate-backups.git
 simplejson==3.11.1
-git+https://github.com/epfl-idevelop/python-wordpress-json.git
+git+https://github.com/epfl-si/python-wordpress-json.git
 html5lib==1.0.1

--- a/src/jahia2wp-utils/README.md
+++ b/src/jahia2wp-utils/README.md
@@ -24,7 +24,7 @@ There's a possibility to give an extra argument (ex: `--debug`) and it will be a
 
 ## export.sh
 To export only one site using `jahia2wp.py export` command.
-This will be done by default for "idevelop" unit and with `--installs-locked=yes`. 
+This will be done by default for "idev" unit and with `--installs-locked=yes`. 
 There's a possibility to give an extra argument (ex: `--debug`) and it will be added to `jahia2wp.py export` command.
 > ./export.sh \<siteName> [\<extraArg>]
 

--- a/src/jahia2wp-utils/export.sh
+++ b/src/jahia2wp-utils/export.sh
@@ -23,5 +23,5 @@ fi
 loc=`pwd`
 
 cd ${SRC_DIR}
-python jahia2wp.py export $1 ${SITE_ROOT}${1} idevelop --to-wordpress --installs-locked=yes ${2}
+python jahia2wp.py export $1 ${SITE_ROOT}${1} idev --to-wordpress --installs-locked=yes ${2}
 cd ${loc}

--- a/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
@@ -48,13 +48,13 @@ then
 	#Mettre le nouveau theme 2018
 	mkdir /tmp/theme_2018
 	
-	curl -o /tmp/theme_2018/theme_2018.py https://raw.githubusercontent.com/epfl-idevelop/wp-ops/master/docker/wp-base/install-plugins-and-themes.py
+	curl -o /tmp/theme_2018/theme_2018.py https://raw.githubusercontent.com/epfl-si/wp-ops/master/docker/wp-base/install-plugins-and-themes.py
 	
 	(cd /tmp/theme_2018/
 	chmod +x theme_2018.py)
 
 	(cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-content/themes
-	python /tmp/theme_2018/theme_2018.py wp-theme-2018 https://github.com/epfl-idevelop/wp-theme-2018/tree/dev/wp-theme-2018)
+	python /tmp/theme_2018/theme_2018.py wp-theme-2018 https://github.com/epfl-si/wp-theme-2018/tree/dev/wp-theme-2018)
 
 	#Activer le theme 2018
 	execCmd "wp theme activate wp-theme-2018 --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site"

--- a/src/migration2018/gutenbergblocks.py
+++ b/src/migration2018/gutenbergblocks.py
@@ -662,7 +662,7 @@ class GutenbergBlocks(Shortcodes):
     def _fix_epfl_infoscience_search(self, content, page_id):
         """
         Transforms EPFL Infoscience Search shortcode to Gutenberg block
-        https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
+        https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/plugins/epfl/shortcodes/epfl-infoscience-search/epfl-infoscience-search.php
 
         :param content: content to update
         :param page_id: Id of page containing content
@@ -763,8 +763,8 @@ class GutenbergBlocks(Shortcodes):
     def _fix_epfl_card(self, content, page_id):
         """
         Transforms EPFL card shortcode to Gutenberg block
-        https://github.com/epfl-idevelop/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/epfl_card/view.php
-        https://github.com/epfl-idevelop/wp-gutenberg-epfl/blob/master/src/epfl-card/index.js
+        https://github.com/epfl-si/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/epfl_card/view.php
+        https://github.com/epfl-si/wp-gutenberg-epfl/blob/master/src/epfl-card/index.js
 
         :param content: content to update
         :param page_id: Id of page containing content
@@ -831,7 +831,7 @@ class GutenbergBlocks(Shortcodes):
     def _fix_epfl_faculties(self, content, page_id):
         """
         Transforms EPFL faculties (Schools) shortcode to Gutenberg block
-        https://github.com/epfl-idevelop/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/schools/view.php
+        https://github.com/epfl-si/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/schools/view.php
 
         :param content: content to update
         :param page_id: Id of page containing content
@@ -890,7 +890,7 @@ class GutenbergBlocks(Shortcodes):
     def _fix_epfl_contact(self, content, page_id):
         """
         Transforms EPFL people 2018 shortcode to Gutenberg block
-        https://github.com/epfl-idevelop/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/epfl_contact/view.php
+        https://github.com/epfl-si/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/epfl_contact/view.php
 
         :param content: content to update
         :param page_id: Id of page containing content
@@ -946,7 +946,7 @@ class GutenbergBlocks(Shortcodes):
     def _fix_epfl_definition_list(self, content, page_id):
         """
         Transforms EPFL definition list shortcode to Gutenberg block
-        https://github.com/epfl-idevelop/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/definition_list/view.php
+        https://github.com/epfl-si/wp-theme-2018/blob/dev/wp-theme-2018/shortcodes/definition_list/view.php
 
         :param content: content to update
         :param page_id: Id of page containing content

--- a/src/migration2018/shortcodes.py
+++ b/src/migration2018/shortcodes.py
@@ -674,7 +674,7 @@ class Shortcodes():
     def __fix_to_atom_button(self, content, old_shortcode):
         """
         Return HTML code to display button according 2018 styleguide:
-        https://epfl-idevelop.github.io/elements/#/atoms/button
+        https://epfl-si.github.io/elements/#/atoms/button
         :param content: String in which to fix
         :return:
         """
@@ -727,7 +727,7 @@ class Shortcodes():
     def _fix_su_divider(self, content, page_id):
         """
         Fix "su_divider" from Shortcode Ultimate. We replace it with HTML code, not with another shortcode.
-        https://epfl-idevelop.github.io/elements/#/atoms/separator
+        https://epfl-si.github.io/elements/#/atoms/separator
         :param content: content to update
         :param page_id: Id of page containing content
         :return:
@@ -865,7 +865,7 @@ class Shortcodes():
         """
         Return HTML code to display quote according 2018 styleguide (but without an image and using "col-md-12" instead
         of "col-md-10" for the width):
-        https://epfl-idevelop.github.io/elements/#/molecules/quote
+        https://epfl-si.github.io/elements/#/molecules/quote
         :param content: content to update
         :param page_id: Id of page containing content
         :return:
@@ -944,7 +944,7 @@ class Shortcodes():
     def _fix_su_highlight(self, content, page_id):
         """
         Fix "su_highlight" shortcode from shortcode ultimate. Just transform it into <mark> element as defined
-        in the styleguide: https://epfl-idevelop.github.io/elements/#/doc/design--typography.html
+        in the styleguide: https://epfl-si.github.io/elements/#/doc/design--typography.html
         :param content: content to update
         :param page_id: Id of page containing content
         :return:
@@ -969,7 +969,7 @@ class Shortcodes():
     def _fix_su_note(self, content, page_id):
         """
         Fix "su_note" de Shortcode Ultimate afin de mettre le code HTML d'un trapèze:
-        https://epfl-idevelop.github.io/elements/#/atoms/trapeze
+        https://epfl-si.github.io/elements/#/atoms/trapeze
         :param content: content to update
         :param page_id: Id of page containing content
         :return:

--- a/src/wordpress/plugins/config.py
+++ b/src/wordpress/plugins/config.py
@@ -134,7 +134,7 @@ class WPMuPluginConfig(WPConfig):
 
         # Generating MU-plugin install command.
         # This command is not standard in WP-CLI, following package as to be installed :
-        # https://github.com/epfl-idevelop/wp-cli
+        # https://github.com/epfl-si/wp-cli
         self.run_wp_cli("mu-plugin install {} {} {}".format(src_path, folder_param, no_symlink_option))
 
         logging.debug("%s - MU-Plugins - %s: Installed", repr(self.wp_site), self.name)

--- a/src/wordpress/tests/test_plugins.py
+++ b/src/wordpress/tests/test_plugins.py
@@ -8,7 +8,7 @@ from wordpress import WPPluginList
 TEST_SITE = 'unittest'
 SITE_URL_GENERIC = "http://localhost/"
 SITE_URL_SPECIFIC = "http://localhost/{}".format(TEST_SITE)
-UNIT_NAME = 'idevelop'
+UNIT_NAME = 'idev'
 os.environ["PLUGINS_CONFIG_BASE_PATH"] = "wordpress/tests/plugins"
 reload(settings)
 

--- a/src/wordpress/tests/test_wordpress.py
+++ b/src/wordpress/tests/test_wordpress.py
@@ -77,7 +77,7 @@ class TestWPGenerator:
              'wp_site_url': "http://localhost/folder",
              'wp_site_title': 'DM',
              'wp_tagline': self.TAGLINE_WITH_ACCENT,
-             'unit_name': 'idevelop',
+             'unit_name': 'idev',
              'langs': 'en',
              'updates_automatic': False})
         generator.clean()

--- a/src/wordpress/themes.py
+++ b/src/wordpress/themes.py
@@ -85,7 +85,7 @@ class WPThemeConfig(WPConfig):
         symlink if needed so we need to use WP-CLI command to install themes to make this work.
         But this code will still work, even if we don't have a modified WP-CLI version.
         """
-        zip_url = "https://github.com/epfl-idevelop/wp-theme-2018/archive/master.zip"
+        zip_url = "https://github.com/epfl-si/wp-theme-2018/archive/master.zip"
         zip_base_name = 'wp-theme-2018-master/'
 
         logging.debug("Downloading themes package...")


### PR DESCRIPTION
- github.com/epfl-idevelop → github.com/epfl-si
- epflidevelop → epflsi in (fake) Docker org names
- Use idev instead of idevelop in unit (pun not intended) tests

**From issue**: #xx

**High level changes:**

1. list here the changes in usage, from a user point of view
1. ...

**Low level changes:**

1. list here the modification made in the code structure, from a developer point of view
1. ...

**Targetted version**: x.x.x
