### PR TITLE
 [janitor] The IDEVELOP unit is no more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ vars: check-env
 	@echo '  JAHIA_HOST=${JAHIA_HOST}'
 
 build: check-env
-	docker build -t epflidevelop/os-wp-base ../wp-ops/docker/wp-base
+	docker build -t epflsi/os-wp-base ../wp-ops/docker/wp-base
 	docker-compose build
 
 up: build

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@
 </h4>
 
 <p align="center">
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/docs/CHANGELOG.md">
-    <img src="https://img.shields.io/github/release/epfl-idevelop/jahia2wp.svg"
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/docs/CHANGELOG.md">
+    <img src="https://img.shields.io/github/release/epfl-si/jahia2wp.svg"
          alt="Changelog">
   </a>
   <a href="http://jahia2wp.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/jahia2wp.svg"
          alt="RDT">
   </a>
-  <a href="https://travis-ci.org/epfl-idevelop/jahia2wp">
-    <img src="https://travis-ci.org/epfl-idevelop/jahia2wp.svg?branch=master"
+  <a href="https://travis-ci.org/epfl-si/jahia2wp">
+    <img src="https://travis-ci.org/epfl-si/jahia2wp.svg?branch=master"
          alt="Travis">
   </a>
-  <a href="https://codecov.io/gh/epfl-idevelop/jahia2wp">
-    <img src="https://codecov.io/gh/epfl-idevelop/jahia2wp/branch/master/graph/badge.svg"
+  <a href="https://codecov.io/gh/epfl-si/jahia2wp">
+    <img src="https://codecov.io/gh/epfl-si/jahia2wp/branch/master/graph/badge.svg"
          alt="Codecov" />
   </a>
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/LICENSE">
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg"
          alt="License" />
   </a>
@@ -44,7 +44,7 @@ Head to the [documentation](http://jahia2wp.readthedocs.io/en/master/) for next 
 
 ### 30/11/2017, Naked WordPress : Went Live :airplane:
 
-We spent [6 sprints](https://github.com/epfl-idevelop/jahia2wp/projects/1?) to focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
+We spent [6 sprints](https://github.com/epfl-si/jahia2wp/projects/1?) to focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
 
 1. :balloon: installing a functional WordPress to any given URL
 

--- a/ansible/roles/wordpress/tasks/restore-over-ssh.yml
+++ b/ansible/roles/wordpress/tasks/restore-over-ssh.yml
@@ -42,7 +42,7 @@
       {{ backup_prod_shell_untar }} --wildcards --wildcards-match-slash */wp-content/uploads
 
 # Temporary kludge for incremental backups that span across directory
-# rename operations such as https://github.com/epfl-idevelop/jahia2wp/pull/452
+# rename operations such as https://github.com/epfl-si/jahia2wp/pull/452
 - name: Remove duplicate plugins (temporary kludge)
   shell:
     cmd: |

--- a/data/wp/wp-content/mu-plugins/epfl-functions.php
+++ b/data/wp/wp-content/mu-plugins/epfl-functions.php
@@ -370,7 +370,7 @@ add_filter('tiny_mce_before_init', 'allow_svg_in_tinymce');
 
 
 /*
-    Add tags present in HTML styleguide (https://epfl-idevelop.github.io/elements/#/) to allow users to use them directly
+    Add tags present in HTML styleguide (https://epfl-si.github.io/elements/#/) to allow users to use them directly
     in "Text Editor"
 */
 function epfl_2018_add_allowed_tags($tags)

--- a/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
+++ b/data/wp/wp-content/plugins/epfl-infoscience-search/epfl-infoscience-search.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: EPFL Infoscience search shortcode
- * Plugin URI: https://github.com/epfl-idevelop/jahia2wp
+ * Plugin URI: https://github.com/epfl-si/jahia2wp
  * Description: provides a shortcode to search and dispay results from Infoscience
  * Version: 1.8
  * Author: Julien Delasoie

--- a/data/wp/wp-content/plugins/epfl-people/epfl-people.php
+++ b/data/wp/wp-content/plugins/epfl-people/epfl-people.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: EPFL People shortcode
- * Plugin URI: https://github.com/epfl-idevelop/EPFL-WP-SC-People
+ * Plugin URI: https://github.com/epfl-si/EPFL-WP-SC-People
  * Description: provides a shortcode to display results from People
  * Version: 1.5
  * Author: Emmanuel JAEP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,12 @@ services:
 
   httpd:
     container_name: jahia2wp-httpd
-    # We use build info available in another cloned repository : https://github.com/epfl-idevelop/wp-ops/
+    # We use build info available in another cloned repository : https://github.com/epfl-si/wp-ops/
+    # TODO: Read domq's comment on PR https://github.com/epfl-si/jahia2wp/pull/800 and determine what can be done
     build: ../wp-ops/docker/httpd
     labels:
       ch.epfl.jahia2wp.httpd.env: ${WP_ENV}
-    image: epflidevelop/wp-ops-httpd
+    image: epflsi/wp-ops-httpd
     volumes:
       - ./volumes/srv:/srv
     links:
@@ -34,13 +35,13 @@ services:
     ports:
       - "${WP_PORT_HTTP}:8080"
       - "${WP_PORT_HTTPS}:8443"
-      - "8443:8443"
 
   mgmt:
     labels:
       ch.epfl.jahia2wp.mgmt.env: ${WP_ENV}
-    image: epflidevelop/wp-ops-mgmt
-    # We use build info available in another cloned repository : https://github.com/epfl-idevelop/wp-ops/
+    image: epflsi/wp-ops-mgmt
+    # We use build info available in another cloned repository : https://github.com/epfl-si/wp-ops/
+    # TODO: Read domq's comment on PR https://github.com/epfl-si/jahia2wp/pull/800 and determine what can be done
     build: ../wp-ops/docker/mgmt
     env_file:
       - .env

--- a/docs/HOWTOs/UPDATE_THEME.md
+++ b/docs/HOWTOs/UPDATE_THEME.md
@@ -2,8 +2,8 @@
 
 The theme and our supported plugins are located in tow places:
 
-1. historically, in [container-wp-volumes](https://github.com/epfl-idevelop/container-wp-volumes). This repository is used by [jahiap](https://github.com/epfl-idevelop/jahiap), the historical repository of the project. That is the place where Aline pushes her updates
-2. in this repository/[data](https://github.com/epfl-idevelop/jahia2wp/tree/master/data). This is  the source of the code for the current phase of the project
+1. historically, in [container-wp-volumes](https://github.com/epfl-si/container-wp-volumes). This repository is used by [jahiap](https://github.com/epfl-si/jahiap), the historical repository of the project. That is the place where Aline pushes her updates
+2. in this repository/[data](https://github.com/epfl-si/jahia2wp/tree/master/data). This is  the source of the code for the current phase of the project
 
 As for now, the current repository must be manually updated.
 
@@ -40,4 +40,4 @@ We will make the assumptions that you have your repos in the following paths, in
         jahia2wp (fix-...-wp-volumes) $ git commit -am "updated wp-content with content of last sprint"
         jahia2wp (fix-...-wp-volumes) $ git push
 
-5. Create PR on [github](https://github.com/epfl-idevelop/jahia2wp/branches). You probably can use your CHANGELOG description as the description of your PR
+5. Create PR on [github](https://github.com/epfl-si/jahia2wp/branches). You probably can use your CHANGELOG description as the description of your PR

--- a/docs/INSTALL_DETAILED.md
+++ b/docs/INSTALL_DETAILED.md
@@ -19,7 +19,7 @@ Table of contents
 
 Github is currently the only way to leverage this project (and its awesome features).
 
-    you@host:~$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    you@host:~$ git clone git@github.com:epfl-si/jahia2wp.git
     you@host:~$ cd jahia2wp
 
 ## Initial setup (details of `make bootstrap-local`)
@@ -132,7 +132,7 @@ Login to the management container (within VPN) and go to your environment:
 
 Clone the project:
 
-    www-data@mgmt-x-xxx:/srv/your-env$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    www-data@mgmt-x-xxx:/srv/your-env$ git clone git@github.com:epfl-si/jahia2wp.git
     www-data@mgmt-x-xxx:/srv/your-env$ cd jahia2wp
     www-data@mgmt-x-xxx:/srv/your-env/jahia2wp$ cp /srv/.config/.env .env
 

--- a/docs/KNOWN_ERRORS.md
+++ b/docs/KNOWN_ERRORS.md
@@ -1,1 +1,1 @@
-Please head for the open [issues on GitHub](https://github.com/epfl-idevelop/jahia2wp/issues), and feel free to submit a new one if necessary
+Please head for the open [issues on GitHub](https://github.com/epfl-si/jahia2wp/issues), and feel free to submit a new one if necessary

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable -->
 <h1 align="center" style="margin:1em">
-  <a href="https://github.com/epfl-idevelop/jahia2wp">
+  <a href="https://github.com/epfl-si/jahia2wp">
     <img src="./static/jahia2wp.png"
          alt="jahia2wp"
          width="200"></a>
@@ -13,23 +13,23 @@
 </h4>
 
 <p align="center">
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/docs/CHANGELOG.md">
-    <img src="https://img.shields.io/github/release/epfl-idevelop/jahia2wp.svg"
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/docs/CHANGELOG.md">
+    <img src="https://img.shields.io/github/release/epfl-si/jahia2wp.svg"
          alt="Changelog">
   </a>
   <a href="http://jahia2wp.readthedocs.io">
     <img src="https://img.shields.io/readthedocs/jahia2wp.svg"
          alt="RDT">
   </a>
-  <a href="https://travis-ci.org/epfl-idevelop/jahia2wp">
-    <img src="https://travis-ci.org/epfl-idevelop/jahia2wp.svg?branch=master"
+  <a href="https://travis-ci.org/epfl-si/jahia2wp">
+    <img src="https://travis-ci.org/epfl-si/jahia2wp.svg?branch=master"
          alt="Travis">
   </a>
-  <a href="https://codecov.io/gh/epfl-idevelop/jahia2wp">
-    <img src="https://codecov.io/gh/epfl-idevelop/jahia2wp/branch/master/graph/badge.svg"
+  <a href="https://codecov.io/gh/epfl-si/jahia2wp">
+    <img src="https://codecov.io/gh/epfl-si/jahia2wp/branch/master/graph/badge.svg"
          alt="Codecov" />
   </a>
-  <a href="https://github.com/epfl-idevelop/jahia2wp/blob/master/LICENSE">
+  <a href="https://github.com/epfl-si/jahia2wp/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg"
          alt="License" />
   </a>
@@ -86,7 +86,7 @@ In the process, not only shall you **not** loose your data, but you shall also b
 
 We will first focus on automation and maintenance, with the objective of driving all the creation process from one shared spreadsheet (aka configuration source).
 
-This phase ended on the 30th of November, with the [release 0.3.0](https://github.com/epfl-idevelop/jahia2wp/releases/tag/0.3.0)
+This phase ended on the 30th of November, with the [release 0.3.0](https://github.com/epfl-si/jahia2wp/releases/tag/0.3.0)
 
 We will secondly add support for migration of a simple site:
 
@@ -131,11 +131,11 @@ Note that python is not in the requirements. You do not necessarily need it on y
 
 As some commands require `sudo`, you will be asked for your system password. The process will add a line in your `.bashrc` (again: head to [INSTALL_TOOLS.md](./INSTALL_TOOLS.md) to get more details):
 
-    you@host:~$ git clone git@github.com:epfl-idevelop/jahia2wp.git
-    you@host:~$ git clone git@github.com:epfl-idevelop/wp-ops.git
+    you@host:~$ git clone git@github.com:epfl-si/jahia2wp.git
+    you@host:~$ git clone git@github.com:epfl-si/wp-ops.git
     # or, would you rather use https instead of SSH
-    # you@host:~$ git clone https://github.com/epfl-idevelop/jahia2wp.git
-    # you@host:~$ git clone https://github.com/epfl-idevelop/wp-ops.git 
+    # you@host:~$ git clone https://github.com/epfl-si/jahia2wp.git 
+    # you@host:~$ git clone https://github.com/epfl-si/wp-ops.git 
     you@host:~$ cd jahia2wp
     you@host:jahia2wp$ make bootstrap-local (add ENV=your-env if you use a C2C environment name here if you have one)
     ...
@@ -158,7 +158,7 @@ You will also need to know what environment (pod) you wish to connect into (and 
 
     you@host:~$ WP_ENV=c2c-env ssh -A -o SendEnv=WP_ENV www-data@ssh-wwp.epfl.ch -p 32222
     
-    www-data@mgmt-x-xxx:/srv/c2c-env$ git clone git@github.com:epfl-idevelop/jahia2wp.git
+    www-data@mgmt-x-xxx:/srv/c2c-env$ git clone git@github.com:epfl-si/jahia2wp.git
     www-data@mgmt-x-xxx:/srv/c2c-env$ cd jahia2wp
     www-data@mgmt-x-xxx:/srv/c2c-env/jahia2wp$ cp /srv/.config/.env . (<- that will set the correct DB credentials for you)
     www-data@mgmt-x-xxx:/srv/c2c-env/jahia2wp$ make -f Makefile.c2c
@@ -266,8 +266,8 @@ To look into the tree structure and list all valid/unvalid WordPress sites, with
     .../src$ python jahia2wp.py inventory $WP_ENV /srv/your-env/localhost
     INFO - your-env - inventory - Building inventory...
     path;valid;url;version;db_name;db_user;admins
-    /srv/your-env/localhost/htdocs/;OK;http://localhost/;4.8.2;wp_dvyrgdywryrcmnkjnmonfzjv9ts4d;ce8clbbqyzeqta31;admin
-    /srv/your-env/localhost/htdocs/folder;OK;http://localhost/folder;4.8;wp_snqi7wekjznhkfe1ggisr9jmqaqeo;o0ajktkeaygim7w9;admin
+    /srv/your-env/localhost/htdocs/;ok;http://localhost/;4.8.2;wp_dvyrgdywryrcmnkjnmonfzjv9ts4d;ce8clbbqyzeqta31;admin
+    /srv/your-env/localhost/htdocs/folder;ok;http://localhost/folder;4.8;wp_snqi7wekjznhkfe1ggisr9jmqaqeo;o0ajktkeaygim7w9;admin
     /srv/your-env/localhost/htdocs/unittest;KO;;;;;
     INFO - your-env - inventory - Inventory made for /srv/your-env/localhost
 
@@ -294,7 +294,7 @@ A phpMyAdmin is available locally at [localhost:8080](http://localhost:8080), wi
 
 There are a few ways where you can help out:
 
-1. Submit [GitHub issues](https://github.com/epfl-idevelop/jahia2wp/issues) for any feature enhancements, bugs or documentation problems.
+1. Submit [GitHub issues](https://github.com/epfl-si/jahia2wp/issues) for any feature enhancements, bugs or documentation problems.
 1. Fix open issues by sending PRs (please make sure you respect [flake8](http://flake8.pycqa.org/en/latest/) conventions and that all tests pass (see below)
 1. Add documentation (written in [markdown](https://daringfireball.net/projects/markdown/))
 

--- a/functional_tests/test_plugins.py
+++ b/functional_tests/test_plugins.py
@@ -8,7 +8,7 @@ from wordpress.generator import MockedWPGenerator
 TEST_SITE = 'unittest'
 SITE_URL_GENERIC = "http://localhost/"
 SITE_URL_SPECIFIC = "http://localhost/{}".format(TEST_SITE)
-UNIT_NAME = 'idevelop'
+UNIT_NAME = 'idev'
 
 """
 Load fake environment variables for every test

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -5,9 +5,9 @@ django==1.11.5
 clint==0.5.1
 PyYAML==3.12
 PyMySQL==0.7.11
-git+https://github.com/epfl-idevelop/python-rotate-backups.git
+git+https://github.com/epfl-si/python-rotate-backups.git
 simplejson==3.11.1
-git+https://github.com/epfl-idevelop/python-wordpress-json.git
+git+https://github.com/epfl-si/python-wordpress-json.git
 html5lib==1.0.1
 more_itertools==4.2.0
 beautifulsoup4==4.6.0

--- a/src/jahia2wp-utils/README.md
+++ b/src/jahia2wp-utils/README.md
@@ -19,7 +19,7 @@ Used to download a ZIP file from Jahia. A prompt to enter Jahia admin password w
 
 ## export.sh
 To export only one site using `jahia2wp.py export` command.
-This will be done by default for "idevelop" unit and with `--installs-locked=yes`. 
+This will be done by default for "idev" unit and with `--installs-locked=yes`. 
 There's a possibility to give an extra argument (ex: `--debug`) and it will be added to `jahia2wp.py export` command.
 > ./export.sh \<siteName> [\<extraArg>]
 

--- a/src/jahia2wp-utils/export.sh
+++ b/src/jahia2wp-utils/export.sh
@@ -23,5 +23,5 @@ fi
 loc=`pwd`
 
 cd ${SRC_DIR}
-python jahia2wp.py export $1 ${SITE_ROOT}${1} idevelop --to-wordpress --installs-locked=yes ${2}
+python jahia2wp.py export $1 ${SITE_ROOT}${1} idev --to-wordpress --installs-locked=yes ${2}
 cd ${loc}

--- a/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
+++ b/src/jahia2wp-utils/subdomains_to_intlab_restore.sh
@@ -1,4 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+
+
+# Recherche du chemin jusqu'au dossier courant
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+ # Inclusion des fonctions génériques
+source ${CURRENT_DIR}/functions.sh
+
 
 echo "Quel est le nom du site ?"
 read -r site
@@ -7,93 +15,110 @@ if [ ${#site} != 0 ]
 
 then
 	#Restauration des fichiers dans le repertoire du site
-	cd /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/
+	cd /tmp/_srv_subdomains_$site.epfl.ch_htdocs/
 
-	tar xzvf /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/*_full.tar.gz -C /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs
+	tar xzvf /tmp/_srv_subdomains_$site.epfl.ch_htdocs/*_full.tar.gz -C /tmp/_srv_subdomains_$site.epfl.ch_htdocs
 
 	#Deplacer les fichiers dans le bon repertoire
-	mv /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/srv/subdomains/$site.epfl.ch/htdocs /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	execCmd "mv /tmp/_srv_subdomains_$site.epfl.ch_htdocs/srv/subdomains/$site.epfl.ch/htdocs /srv/int/migration-wp.epfl.ch/htdocs/labs/$site"
 
-	#Modifier la valeur dans le fichier wp-config.php du site sur INT par db-wwp.epfl.ch par test-db-wwp.epfl.ch
+	#Modifier le fichier wp-config.php
 	cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site
 
-	sed -i 's/db-wwp.epfl.ch/test-db-wwp.epfl.ch/g' /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php
+	execCmd "sed -i 's/db-wwp.epfl.ch/test-db-wwp.epfl.ch/g' /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php"
+	
+	execCmd "sed -i \"s/subdomains\/${site}.epfl.ch\/htdocs\//int\/migration-wp.epfl.ch\/htdocs\/labs\/${site}/g\" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php"
 
 	#Creation de la base vide
-	DB_USER=`grep DB_USER /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_PASSWORD=`grep DB_PASSWORD /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_NAME=`grep DB_NAME /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && mysql -h test-db-wwp.epfl.ch -u oswproot --password=Pei8vao6Teiv -e "CREATE USER '$DB_USER' IDENTIFIED BY '$DB_PASSWORD';CREATE DATABASE $DB_NAME;GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER';"
-	
-	wp db import /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs/*.sql --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	DB_USER=`grep DB_USER /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_PASSWORD=`grep DB_PASSWORD /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && DB_NAME=`grep DB_NAME /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-config.php |awk '{print $3}' |sed "s/'//g"` && mysql -h test-db-wwp.epfl.ch -u oswproot --password=${MYSQL_SUPER_PASSWORD} -e "CREATE USER '$DB_USER' IDENTIFIED BY '$DB_PASSWORD';CREATE DATABASE $DB_NAME;GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER';"
+
+	execCmd "wp db import /tmp/_srv_subdomains_$site.epfl.ch_htdocs/*.sql --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site"
 
 	#Suppression de l'importation des backups
-	rm -rf /tmp/lab-import/_srv_subdomains_$site.epfl.ch_htdocs
+	rm -rf /tmp/_srv_subdomains_$site.epfl.ch_htdocs
 
 	#Changement de .htaccess
-	sed -i "s|RewriteBase /|RewriteBase /labs/$site|g" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/.htaccess
+	execCmd "sed -i \"s|RewriteBase /|RewriteBase /labs/$site|g\" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/.htaccess"
 
-	sed -i "s|RewriteRule . /index.php|RewriteRule . /labs/$site/index.php|g" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/.htaccess
+	execCmd "sed -i \"s|RewriteRule . /index.php|RewriteRule . /labs/$site/index.php|g\" /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/.htaccess"
 
 	#Mettre a jour les URL du site
-	wp --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site/ search-replace $site.epfl.ch migration-wp.epfl.ch/labs/$site --skip-columns=guid
+	execCmd "wp --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site/ search-replace $site.epfl.ch migration-wp.epfl.ch/labs/$site --skip-columns=guid"
 
 	#Mettre le nouveau theme 2018
 	mkdir /tmp/theme_2018
 	
-	curl -o /tmp/theme_2018/theme_2018.py https://raw.githubusercontent.com/epfl-idevelop/wp-ops/master/docker/wp-base/install-plugins-and-themes.py
+	curl -o /tmp/theme_2018/theme_2018.py https://raw.githubusercontent.com/epfl-si/wp-ops/master/docker/wp-base/install-plugins-and-themes.py
 	
 	(cd /tmp/theme_2018/
 	chmod +x theme_2018.py)
 
 	(cd /srv/int/migration-wp.epfl.ch/htdocs/labs/$site/wp-content/themes
-	python /tmp/theme_2018/theme_2018.py theme_2018 https://github.com/epfl-idevelop/wp-theme-2018/tree/dev/wp-theme-2018)
+	python /tmp/theme_2018/theme_2018.py wp-theme-2018 https://github.com/epfl-si/wp-theme-2018/tree/dev/wp-theme-2018)
 
 	#Activer le theme 2018
-	wp theme activate wp-theme-2018 --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site
+	execCmd "wp theme activate wp-theme-2018 --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site"
 
 	#Suppression de theme_2018.py
 	rm -r /tmp/theme_2018
 	
 	#Desintallations des plugins 2010
 	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site enlighter
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-FAQ
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-faq
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-google-forms
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-grid
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience-search
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-map
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-memento
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-news
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-people
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-scheduler
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Snippet
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-snippet
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-tableau
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-toggle
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-twitter
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-video
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-xml
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Share
-	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-buttons
 	wp plugin uninstall --deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site shortcodes-ultimate
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-FAQ
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-faq
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-google-forms
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-grid
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-infoscience-search
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-map
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-memento
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-news
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-people
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-scheduler
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Snippet
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-snippet
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-tableau
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-toggle
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-twitter
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-video
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-xml
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site EPFL-Share
+	wp plugin deactivate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl-buttons
 
 	#Installer plugins 2018
-	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=epfl --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-plugin
+	execCmd	"wp plugin activate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site epfl"
+	execCmd "wp plugin activate --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/$site wp-media-folder"
 
-	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=wp-media-folder --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-plugin
+	#Activer automatiquement le coming soon
+	execCmd "cp /srv/int/jahia2wp/src/jahia2wp-utils/activation_coming-soon_copie_qa_18.json /tmp/activation_coming-soon_copie_qa_18_${site}"
+	
+	execCmd "sed -i \"s|sitename|${site}|g\" /tmp/activation_coming-soon_copie_qa_18_${site}"
 
+	execCmd "wp option update seed_csp4_settings_content --format=json --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} < /tmp/activation_coming-soon_copie_qa_18_${site}"
+
+	rm /tmp/activation_coming-soon_copie_qa_18_${site}
+	
+	#Mettre les parametres du plugin wp-media-folder
+	execCmd "/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py update-plugins int https://migration-wp.epfl.ch/labs/$site/ --plugin=wp-media-folder --extra-config=/srv/int/jahia2wp/functional_tests/extra.yaml --force-options"
+	
 	#Fix plugins 2010 -> 2018
-	/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py shortcode-fix int https://migration-wp.epfl.ch/labs/$site/ 
+	execCmd "/srv/int/venv/bin/python /srv/int/jahia2wp/src/jahia2wp.py shortcode-fix int https://migration-wp.epfl.ch/labs/$site/ "
 
+	#Optimiser les images
+        execCmd "wp ewwwio optimize all --noprompt --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}"
+        execCmd "wp media regenerate --only-missing --yes --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site}"
+	
 	#Mettre le resultat de la requete SQL dans un fichier .txt
         wp db query 'SELECT ID, post_date, post_content, post_title, post_name, post_status FROM wp_posts WHERE post_content like "%[epfl_infoscience %" and post_type="page" and post_status = "publish"' --path=/srv/int/migration-wp.epfl.ch/htdocs/labs/${site} > /tmp/contenu_des_pages_${site}.txt
-        
-	#Savoir quelles sont les pages qui contiennent infoscience
+
+	#Savoir quelles sont les pages qui contiennent l'ancien plugin infoscience
         myfile="/tmp/contenu_des_pages_${site}.txt"
         while IFS=$'\t' read -r -a myArray
         do
-               	html=${myArray[2]}
-		pos=`echo $html | grep -bo "epfl_infoscience"| sed 's/:.*$//'`
-
+        	html=${myArray[2]}
+		pos=`echo $html | grep -bo "epfl_infoscience"| sed 's/:.*$//'`		
+		
 		if [ -z "$pos" ]
                 then
                         echo ""
@@ -107,8 +132,8 @@ then
                 	done
                 fi
         done < "$myfile"
-
-        #Supprimer le fichier .txt
-	rm -r /tmp/contenu_des_pages_${site}.txt
+	
+	#Supprimer le fichier .txt
+	rm -r /tmp/contenu_des_pages_${site}.txt	
 fi
 

--- a/src/wordpress/tests/test_plugins.py
+++ b/src/wordpress/tests/test_plugins.py
@@ -8,7 +8,7 @@ from wordpress import WPPluginList
 TEST_SITE = 'unittest'
 SITE_URL_GENERIC = "http://localhost/"
 SITE_URL_SPECIFIC = "http://localhost/{}".format(TEST_SITE)
-UNIT_NAME = 'idevelop'
+UNIT_NAME = 'idev'
 os.environ["PLUGINS_CONFIG_BASE_PATH"] = "wordpress/tests/plugins"
 reload(settings)
 

--- a/src/wordpress/tests/test_wordpress.py
+++ b/src/wordpress/tests/test_wordpress.py
@@ -77,7 +77,7 @@ class TestWPGenerator:
              'wp_site_url': "http://localhost/folder",
              'wp_site_title': 'DM',
              'wp_tagline': self.TAGLINE_WITH_ACCENT,
-             'unit_name': 'idevelop',
+             'unit_name': 'idev',
              'langs': 'en',
              'updates_automatic': False})
         generator.clean()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/epfl-si/jahia2wp/pull/1152
for the "2010" release branch, with another bout of `grep` to smoke
out the last idevelop's.

- github.com/epfl-idevelop → github.com/epfl-si
- epflidevelop → epflsi in (fake) Docker org names
- Use idev instead of idevelop in unit (pun not intended) tests
