### PR TITLE
Avoid to backup files twice

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -344,18 +344,16 @@ class Utils(object):
 
         # To list all files/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
-        # NOTE: We explicitly list FOLDERS and SYMLINKS only because if we list everything, some things will be duplicated
+        # NOTE: We explicitly list FOLDERS only because if we list everything, some things will be duplicated
         # in the backup. In fact, if we give a folder to 'tar' command, it will backup folder and all its content. So if we
-        # list everything (files and folder), files will be backuped a second time because explicitly given...
+        # list everything (files, folder and symlinks), files and symlinks will be backuped a second time because explicitly given...
         cmd_all_folders = 'find {0} -type d -print | egrep "^{0}/wp"'.format(source_path)
-        cmd_all_symlinks = 'find {0} -type l -print | egrep "^{0}/wp"'.format(source_path)
-
+        
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
         # We also remove debug.log to spare some place
-        command = "{{ {} ; {}; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
+        command = "{{ {} ; {};  }} | tar --auto-compress --create --no-check-device --file={} " \
                   "--listed-incremental={} --exclude=debug.log -T -".format(cmd_first_level_files,
                                                         cmd_all_folders,
-                                                        cmd_all_symlinks,
                                                         tar_file_path,
                                                         tar_listed_inc_file_path)
         return Utils.run_command(command)

--- a/src/utils.py
+++ b/src/utils.py
@@ -342,15 +342,20 @@ class Utils(object):
         # To list root FILES and not starting with "wp"
         cmd_first_level_files = 'find {0} -maxdepth 1 -type f -print | egrep -v "^{0}/wp"'.format(source_path)
 
-        # To list all files/dirs/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
+        # To list all files/symlinks starting with "<tar_file_path>/wp" (this will exclude non-WordPress subfolder,
         # which will be very useful when backuping multiple WordPress in a subfolder hierarchy
-        cmd_all_others = 'find {0} -print | egrep "^{0}/wp"'.format(source_path)
+        # NOTE: We explicitly list FOLDERS and SYMLINKS only because if we list everything, some things will be duplicated
+        # in the backup. In fact, if we give a folder to 'tar' command, it will backup folder and all its content. So if we
+        # list everything (files and folder), files will be backuped a second time because explicitly given...
+        cmd_all_folders = 'find {0} -type d -print | egrep "^{0}/wp"'.format(source_path)
+        cmd_all_symlinks = 'find {0} -type l -print | egrep "^{0}/wp"'.format(source_path)
 
         # --auto-compress is used to automatically detect wished file compression depending on given file extension
         # We also remove debug.log to spare some place
-        command = "{{ {} ; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
+        command = "{{ {} ; {}; {}; }} | tar --auto-compress --create --no-check-device --file={} " \
                   "--listed-incremental={} --exclude=debug.log -T -".format(cmd_first_level_files,
-                                                        cmd_all_others,
+                                                        cmd_all_folders,
+                                                        cmd_all_symlinks,
                                                         tar_file_path,
                                                         tar_listed_inc_file_path)
         return Utils.run_command(command)


### PR DESCRIPTION
Subtilité avec la commande `tar`... quand on lui donne une liste de fichiers/dossiers à backuper, certaines choses peuvent être prises à double...
Si on donne un chemin jusqu'à un dossier contenant des fichiers et qu'en plus on donne la liste de chaque fichier du dossier, ces derniers seront pris à double. Pourquoi? simplement parce que quand on donne un dossier à `tar` il le prend avec tout son contenu. Donc si on donne en plus explicitement le contenu, il va le prendre une nouvelle fois, sans se dire que ça a déjà été pris... 

Modification pour maintenant ne lister que les dossiers afin de supprimer les doublons.
Et ça diminue quand même le volume d'un full de moitié... 😅 