### PR TITLE
EPFL Blocks White Filter - Remove 'array_unique' call

### DIFF
--- a/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
+++ b/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL block white list
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website to define allowed blocks coming from Gutenberg or installed plugins.
-* Version: 1.0.4
+* Version: 1.0.5
 * Author: wwp-admin@epfl.ch
  */
 
@@ -42,8 +42,10 @@ function epfl_allowed_block_types( $allowed_block_types, $post ) {
         $allowed_block_types = array_merge($allowed_block_types, $rest_of_allowed_blocks);
     }
 
-    // We ensure there's no duplicate
-  	return array_unique($allowed_block_types);
+    /* NOTE: Don't do an "array_unique()" to avoid duplicates. For an unknown reason, even if the array content seems to be correctly
+        filtered, the result will be that all blocks will be allowed, but ONLY on pages... not on posts... it's like the return of
+        "array_unique" function is "different" when the number of elements in the array is more than X ... */
+    return $allowed_block_types;
     // return True; // if you want all natifs blocks.
 }
 


### PR DESCRIPTION
Pour une raison plus qu'inconnue (mais y'a forcément une logique derrière), c'était l'appel à la fonction `array_unique()` pour s'assurer qu'il n'y avait pas de doublons qui faisait que tous les blocs étaient autorisés sur les pages.
Après test, cette fonction fait correctement son boulot et filtre bien le tableau en ne laissant qu'un exemplair de chaque élément. Mais après, c'est comme si on retournait `true` pour autoriser tous les blocs... ⁉️ ... et encore plus bizarre, ça ne fait ça que pour les pages et pas les posts... la seule différence étant le nombre d'élément dans le tableau passé à `array_unique` qui est plus élevé avec les pages...

Donc, ben suppression de l'appel à `array_unique()` pour résoudre le problème.