### PR TITLE
Transform block 'core/table' to 'epfl/table'

### DIFF
--- a/src/jahia2wp.py
+++ b/src/jahia2wp.py
@@ -93,7 +93,7 @@ import subprocess
 from collections import OrderedDict
 from datetime import datetime, date
 from pprint import pprint
-
+import re
 import os
 import shutil
 
@@ -1059,7 +1059,20 @@ def block_fix(wp_env, wp_url, block_name=None, simulation=False, csv_time_log=No
         time_log_file = open(csv_time_log, mode='a')
         start_time = time.time()
 
-    blocks = GutenbergFixes()
+    block_category = 'epfl'
+
+    # If a block name was given,
+    if block_name:
+        # we look for a full block name (with category, ie: epfl/google-forms)
+        values = re.findall(r'(.+)\/(.+)', block_name)
+
+        # If block name have a category
+        if values:
+            # We extract infos, category and 'short' block name
+            block_category = values[0][0]
+            block_name = values[0][1]
+
+    blocks = GutenbergFixes(block_category=block_category)
     report = blocks.fix_site(wp_env, wp_url, shortcode_name=block_name, simulation=simulation)
     if simulation:
         logging.info("This was a simulation, nothing was changed in database")

--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -153,7 +153,8 @@ class GutenbergFixes(GutenbergBlocks):
         :param content: String in which to look for shortcode calls
         :param block_name: Code name to look for
         :param with_content: To tell if we have to return content as well. If given and shortcode doesn't have content,
-        
+        :param block_category: Block category. Pass None if block is core block
+
         :return:
         """
         block_prefix = '{}/'.format(block_category) if block_category else ''


### PR DESCRIPTION
Pour répondre à la demande https://epfl-webvolution.atlassian.net/browse/WEBEVOL-73 

Se charge de transformer les blocs `core/table` en `epfl/table` en ajoutant au passage, si nécessaire, un attribut pour s'assurer que l'affichage se fasse correctement.

Maintenant, lorsque l'on lance la commande pour "fixer" les blocs, on peut donner, en tant que nom de bloc, un bloc avec sa "catégorie", comme par exemple `core/table`. Si on ne donne rien, on partira du postulat que c'est `epfl` la catégorie.

PR en lien avec les suivantes:
- https://github.com/epfl-si/wp-mu-plugins/pull/5
- https://github.com/epfl-si/wp-gutenberg-epfl/pull/192
