### PR TITLE
Transform old PDF viewer to new

### DIFF
--- a/src/migration2018/gutenbergfixes.py
+++ b/src/migration2018/gutenbergfixes.py
@@ -382,21 +382,27 @@ class GutenbergFixes(GutenbergBlocks):
         return new_call
     
 
-    def _fix_block_gallery(self, content, page_id):
+    def _fix_block_standard(self, content, page_id):
         """
+        
         Fix core gallery block (native WP block)
         :param content: content to update
         :param page_id: Id of page containing content
         """
         
-        block_name = "gallery"
+        block_name = "standard"
 
         # Looking for all calls to modify them one by one
-        calls = self._get_all_block_calls(content, block_name, with_content=True, block_category=None, ignore_if_in_blocks=['epfl/gallery'])
+        calls = self._get_all_block_calls(content, block_name, with_content=True, block_category='pdf-viewer-block')
 
         for call in calls:
 
+            pdfId = self._get_attribute(call, 'mediaID')
+            pdfUrl = self._get_image_url(pdfId, page_id, None)
+
+
             new_call = '<!-- wp:epfl/gallery {{"largeDisplay":false,"navigationThumbnails":true}} -->\n{}\n<!-- /wp:epfl/gallery -->'.format(call)
+            new_call = '<!-- wp:epfl/pdf-flipbook {{"pdfId":{},"pdfUrl":"{}"}} /-->'.format(pdfId, pdfUrl)
 
             if new_call != call:
                 self._log_to_file("Before: {}".format(call))


### PR DESCRIPTION
Permet de transformer "l'ancien" block pour voir un fichier PDF en un nouveau, un qui est présent dans le plugin EPFL.

Ce code va dans un premier temps être utilisé uniquement pour simuler l'exécution et voir ce qui va changer.

# Pré-exéctution du code:
il faudra faire un `wp plugin install flowpaper-lite-pdf-flipbook; wp plugin activate flowpaper-lite-pdf-flipbook` sur tous les sites

# Post exécution
- Faire un `wp plugin deactivate pdf-viewer-block; wp plugin uninstall pdf-viewer-block` sur tous les sites
- Faire approuver la PR https://github.com/epfl-si/wp-ops/pull/316 et ensuite la merger
- Faire approuver la PR https://github.com/epfl-si/wp-mu-plugins/pull/19 et ensuite la merger